### PR TITLE
feat(codeql): Use go build ./... for codeql to make sure all sources are compiled for analysis

### DIFF
--- a/.github/workflows/reusable-go-ci.yaml
+++ b/.github/workflows/reusable-go-ci.yaml
@@ -40,7 +40,7 @@ on:
         description: "Set to true to run CodeQL analysis"
         required: false
         type: boolean
-        default: ${{ github.event_name == 'pull_request' || github.ref_name == 'main' || github.ref_name == 'feat/codeql' }}
+        default: ${{ github.event_name == 'pull_request' || github.ref_name == 'main' }}
       run_lint:
         description: "Set to true to run golangci-lint"
         required: false


### PR DESCRIPTION
`Build module for CodeQL` now uses `go build ./...` to make sure all sources are compiled. This is needed for the codeql analysis, so that all files are scanned.