### PR TITLE
Feat/visibility

### DIFF
--- a/admin/api/v1/zone_types.go
+++ b/admin/api/v1/zone_types.go
@@ -10,6 +10,13 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+type ZoneVisibility string
+
+const (
+	ZoneVisibilityWorld      ZoneVisibility = "World"
+	ZoneVisibilityEnterprise ZoneVisibility = "Enterprise"
+)
+
 type RedisConfig struct {
 	Host     string `json:"host"`
 	Port     int    `json:"port"`
@@ -54,6 +61,7 @@ type ZoneSpec struct {
 	Gateway          GatewayConfig          `json:"gateway"`
 	Redis            RedisConfig            `json:"redis"`
 	TeamApis         *TeamApiConfig         `json:"teamApis,omitempty"`
+	Visibility       ZoneVisibility         `json:"visibility"`
 }
 
 type Links struct {

--- a/admin/config/crd/bases/admin.cp.ei.telekom.de_zones.yaml
+++ b/admin/config/crd/bases/admin.cp.ei.telekom.de_zones.yaml
@@ -117,10 +117,13 @@ spec:
                 required:
                 - apis
                 type: object
+              visibility:
+                type: string
             required:
             - gateway
             - identityProvider
             - redis
+            - visibility
             type: object
           status:
             description: ZoneStatus defines the observed state of Zone

--- a/api/Makefile
+++ b/api/Makefile
@@ -44,7 +44,7 @@ help: ## Display this help.
 
 .PHONY: manifests
 manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
-	$(CONTROLLER_GEN) rbac:roleName=manager-role,headerFile="../hack/boilerplate.yaml.txt" crd:headerFile="../hack/boilerplate.yaml.txt" paths="./..." output:crd:artifacts:config=config/crd/bases
+	$(CONTROLLER_GEN) rbac:roleName=manager-role,headerFile="../hack/boilerplate.yaml.txt" crd:headerFile="../hack/boilerplate.yaml.txt" webhook:headerFile="../hack/boilerplate.yaml.txt" paths="./..." output:crd:artifacts:config=config/crd/bases
 
 .PHONY: generate
 generate: controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.

--- a/api/PROJECT
+++ b/api/PROJECT
@@ -35,6 +35,10 @@ resources:
   kind: ApiSubscription
   path: github.com/telekom/controlplane/api/api/v1
   version: v1
+  webhooks:
+    defaulting: true
+    validation: true
+    webhookVersion: v1
 - api:
     crdVersion: v1
     namespaced: true

--- a/api/cmd/main.go
+++ b/api/cmd/main.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/telekom/controlplane/api/internal/controller"
 	"github.com/telekom/controlplane/api/internal/handler/remoteapisubscription/syncer"
+	webhookv1 "github.com/telekom/controlplane/api/internal/webhook/v1"
 	// +kubebuilder:scaffold:imports
 )
 
@@ -169,6 +170,13 @@ func main() {
 	}).SetupWithManager(mgr, syncer.NewSyncerFactory()); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "RemoteApiSubscription")
 		os.Exit(1)
+	}
+	// nolint:goconst
+	if os.Getenv("ENABLE_WEBHOOKS") != "false" {
+		if err := webhookv1.SetupApiSubscriptionWebhookWithManager(mgr); err != nil {
+			setupLog.Error(err, "unable to create webhook", "webhook", "ApiSubscription")
+			os.Exit(1)
+		}
 	}
 	// +kubebuilder:scaffold:builder
 

--- a/api/config/certmanager/certificate-metrics.yaml
+++ b/api/config/certmanager/certificate-metrics.yaml
@@ -1,0 +1,20 @@
+# The following manifests contain a self-signed issuer CR and a metrics certificate CR.
+# More document can be found at https://docs.cert-manager.io
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  labels:
+    app.kubernetes.io/name: api
+    app.kubernetes.io/managed-by: kustomize
+  name: metrics-certs  # this name should match the one appeared in kustomizeconfig.yaml
+  namespace: system
+spec:
+  dnsNames:
+  # SERVICE_NAME and SERVICE_NAMESPACE will be substituted by kustomize
+  # replacements in the config/default/kustomization.yaml file.
+  - SERVICE_NAME.SERVICE_NAMESPACE.svc
+  - SERVICE_NAME.SERVICE_NAMESPACE.svc.cluster.local
+  issuerRef:
+    kind: Issuer
+    name: selfsigned-issuer
+  secretName: metrics-server-cert

--- a/api/config/certmanager/certificate-webhook.yaml
+++ b/api/config/certmanager/certificate-webhook.yaml
@@ -1,0 +1,20 @@
+# The following manifests contain a self-signed issuer CR and a certificate CR.
+# More document can be found at https://docs.cert-manager.io
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  labels:
+    app.kubernetes.io/name: api
+    app.kubernetes.io/managed-by: kustomize
+  name: serving-cert  # this name should match the one appeared in kustomizeconfig.yaml
+  namespace: system
+spec:
+  # SERVICE_NAME and SERVICE_NAMESPACE will be substituted by kustomize
+  # replacements in the config/default/kustomization.yaml file.
+  dnsNames:
+  - SERVICE_NAME.SERVICE_NAMESPACE.svc
+  - SERVICE_NAME.SERVICE_NAMESPACE.svc.cluster.local
+  issuerRef:
+    kind: Issuer
+    name: selfsigned-issuer
+  secretName: webhook-server-cert

--- a/api/config/certmanager/issuer.yaml
+++ b/api/config/certmanager/issuer.yaml
@@ -1,0 +1,13 @@
+# The following manifest contains a self-signed issuer CR.
+# More information can be found at https://docs.cert-manager.io
+# WARNING: Targets CertManager v1.0. Check https://cert-manager.io/docs/installation/upgrading/ for breaking changes.
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  labels:
+    app.kubernetes.io/name: api
+    app.kubernetes.io/managed-by: kustomize
+  name: selfsigned-issuer
+  namespace: system
+spec:
+  selfSigned: {}

--- a/api/config/certmanager/kustomization.yaml
+++ b/api/config/certmanager/kustomization.yaml
@@ -1,0 +1,7 @@
+resources:
+- issuer.yaml
+- certificate-webhook.yaml
+- certificate-metrics.yaml
+
+configurations:
+- kustomizeconfig.yaml

--- a/api/config/certmanager/kustomizeconfig.yaml
+++ b/api/config/certmanager/kustomizeconfig.yaml
@@ -1,0 +1,8 @@
+# This configuration is for teaching kustomize how to update name ref substitution
+nameReference:
+- kind: Issuer
+  group: cert-manager.io
+  fieldSpecs:
+  - kind: Certificate
+    group: cert-manager.io
+    path: spec/issuerRef/name

--- a/api/config/default/kustomization.yaml
+++ b/api/config/default/kustomization.yaml
@@ -24,7 +24,7 @@ resources:
 - ../manager
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
 # crd/kustomization.yaml
-#- ../webhook
+- ../webhook
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'. 'WEBHOOK' components are required.
 #- ../certmanager
 # [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'.
@@ -47,7 +47,7 @@ patches:
 
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
 # crd/kustomization.yaml
-#- path: manager_webhook_patch.yaml
+- path: manager_webhook_patch.yaml
 
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'.
 # Uncomment 'CERTMANAGER' sections in crd/kustomization.yaml to enable the CA injection in the admission webhooks.

--- a/api/config/default/manager_webhook_patch.yaml
+++ b/api/config/default/manager_webhook_patch.yaml
@@ -1,0 +1,29 @@
+# This patch ensures the webhook certificates are properly mounted in the manager container.
+# It configures the necessary arguments, volumes, volume mounts, and container ports.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller-manager
+  namespace: system
+  labels:
+    app.kubernetes.io/name: api-operator
+    app.kubernetes.io/managed-by: kustomize
+spec:
+  template:
+    spec:
+      containers:
+        - name: manager
+          ports:
+            - containerPort: 9443
+              name: webhook-server
+              protocol: TCP
+          volumeMounts:
+            - mountPath: /tmp/k8s-webhook-server/serving-certs
+              name: cert
+              readOnly: true
+      volumes:
+        - name: cert
+          secret:
+            defaultMode: 420
+            secretName: webhook-server-cert

--- a/api/config/network-policy/allow-webhook-traffic.yaml
+++ b/api/config/network-policy/allow-webhook-traffic.yaml
@@ -1,0 +1,27 @@
+# This NetworkPolicy allows ingress traffic to your webhook server running
+# as part of the controller-manager from specific namespaces and pods. CR(s) which uses webhooks
+# will only work when applied in namespaces labeled with 'webhook: enabled'
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  labels:
+    app.kubernetes.io/name: api
+    app.kubernetes.io/managed-by: kustomize
+  name: allow-webhook-traffic
+  namespace: system
+spec:
+  podSelector:
+    matchLabels:
+      control-plane: controller-manager
+      app.kubernetes.io/name: api
+  policyTypes:
+    - Ingress
+  ingress:
+    # This allows ingress traffic from any namespace with the label webhook: enabled
+    - from:
+      - namespaceSelector:
+          matchLabels:
+            webhook: enabled # Only from namespaces with this label
+      ports:
+        - port: 443
+          protocol: TCP

--- a/api/config/network-policy/kustomization.yaml
+++ b/api/config/network-policy/kustomization.yaml
@@ -3,4 +3,5 @@
 # SPDX-License-Identifier: Apache-2.0
 
 resources:
+- allow-webhook-traffic.yaml
 - allow-metrics-traffic.yaml

--- a/api/config/webhook/kustomization.yaml
+++ b/api/config/webhook/kustomization.yaml
@@ -1,0 +1,6 @@
+resources:
+- manifests.yaml
+- service.yaml
+
+configurations:
+- kustomizeconfig.yaml

--- a/api/config/webhook/kustomizeconfig.yaml
+++ b/api/config/webhook/kustomizeconfig.yaml
@@ -1,0 +1,22 @@
+# the following config is for teaching kustomize where to look at when substituting nameReference.
+# It requires kustomize v2.1.0 or newer to work properly.
+nameReference:
+- kind: Service
+  version: v1
+  fieldSpecs:
+  - kind: MutatingWebhookConfiguration
+    group: admissionregistration.k8s.io
+    path: webhooks/clientConfig/service/name
+  - kind: ValidatingWebhookConfiguration
+    group: admissionregistration.k8s.io
+    path: webhooks/clientConfig/service/name
+
+namespace:
+- kind: MutatingWebhookConfiguration
+  group: admissionregistration.k8s.io
+  path: webhooks/clientConfig/service/namespace
+  create: true
+- kind: ValidatingWebhookConfiguration
+  group: admissionregistration.k8s.io
+  path: webhooks/clientConfig/service/namespace
+  create: true

--- a/api/config/webhook/manifests.yaml
+++ b/api/config/webhook/manifests.yaml
@@ -1,0 +1,55 @@
+# SPDX-FileCopyrightText: 2025 Deutsche Telekom IT GmbH
+#
+# SPDX-License-Identifier: Apache-2.0
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: mutating-webhook-configuration
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /mutate-api-cp-ei-telekom-de-v1-apisubscription
+  failurePolicy: Fail
+  name: mapisubscription-v1.kb.io
+  rules:
+  - apiGroups:
+    - api.cp.ei.telekom.de
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - apisubscriptions
+  sideEffects: None
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: validating-webhook-configuration
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /validate-api-cp-ei-telekom-de-v1-apisubscription
+  failurePolicy: Fail
+  name: vapisubscription-v1.kb.io
+  rules:
+  - apiGroups:
+    - api.cp.ei.telekom.de
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - apisubscriptions
+  sideEffects: None

--- a/api/config/webhook/service.yaml
+++ b/api/config/webhook/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/name: api
+    app.kubernetes.io/managed-by: kustomize
+  name: webhook-service
+  namespace: system
+spec:
+  ports:
+    - port: 443
+      protocol: TCP
+      targetPort: 9443
+  selector:
+    control-plane: controller-manager

--- a/api/internal/webhook/v1/apisubscription_webhook.go
+++ b/api/internal/webhook/v1/apisubscription_webhook.go
@@ -1,0 +1,180 @@
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom IT GmbH
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package v1
+
+import (
+	"context"
+	"fmt"
+	adminv1 "github.com/telekom/controlplane/admin/api/v1"
+	cclient "github.com/telekom/controlplane/common/pkg/client"
+	"github.com/telekom/controlplane/common/pkg/config"
+	"github.com/telekom/controlplane/common/pkg/util/labelutil"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	apiv1 "github.com/telekom/controlplane/api/api/v1"
+)
+
+// nolint:unused
+// log is for logging in this package.
+var apisubscriptionlog = logf.Log.WithName("apisubscription-resource")
+
+// SetupApiSubscriptionWebhookWithManager registers the webhook for ApiSubscription in the manager.
+func SetupApiSubscriptionWebhookWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewWebhookManagedBy(mgr).For(&apiv1.ApiSubscription{}).
+		WithValidator(&ApiSubscriptionCustomValidator{mgr.GetClient()}).
+		WithDefaulter(&ApiSubscriptionCustomDefaulter{}).
+		Complete()
+}
+
+// +kubebuilder:webhook:path=/mutate-api-cp-ei-telekom-de-v1-apisubscription,mutating=true,failurePolicy=fail,sideEffects=None,groups=api.cp.ei.telekom.de,resources=apisubscriptions,verbs=create;update,versions=v1,name=mapisubscription-v1.kb.io,admissionReviewVersions=v1
+
+// ApiSubscriptionCustomDefaulter struct is responsible for setting default values on the custom resource of the
+// Kind ApiSubscription when those are created or updated.
+//
+// NOTE: The +kubebuilder:object:generate=false marker prevents controller-gen from generating DeepCopy methods,
+// as it is used only for temporary operations and does not need to be deeply copied.
+type ApiSubscriptionCustomDefaulter struct {
+	// TODO(user): Add more fields as needed for defaulting
+}
+
+var _ webhook.CustomDefaulter = &ApiSubscriptionCustomDefaulter{}
+
+// Default implements webhook.CustomDefaulter so a webhook will be registered for the Kind ApiSubscription.
+func (d *ApiSubscriptionCustomDefaulter) Default(_ context.Context, obj runtime.Object) error {
+	apisubscription, ok := obj.(*apiv1.ApiSubscription)
+
+	if !ok {
+		return fmt.Errorf("expected an ApiSubscription object but got %T", obj)
+	}
+	apisubscriptionlog.Info("Defaulting for ApiSubscription", "name", apisubscription.GetName())
+
+	// TODO(user): fill in your defaulting logic.
+
+	return nil
+}
+
+// +kubebuilder:webhook:path=/validate-api-cp-ei-telekom-de-v1-apisubscription,mutating=false,failurePolicy=fail,sideEffects=None,groups=api.cp.ei.telekom.de,resources=apisubscriptions,verbs=create;update,versions=v1,name=vapisubscription-v1.kb.io,admissionReviewVersions=v1
+
+// ApiSubscriptionCustomValidator struct is responsible for validating the ApiSubscription resource
+// when it is created, updated, or deleted.
+//
+// NOTE: The +kubebuilder:object:generate=false marker prevents controller-gen from generating DeepCopy methods,
+// as this struct is used only for temporary operations and does not need to be deeply copied.
+type ApiSubscriptionCustomValidator struct {
+	client client.Client
+}
+
+var _ webhook.CustomValidator = &ApiSubscriptionCustomValidator{}
+
+// ValidateCreate implements webhook.CustomValidator so a webhook will be registered for the type ApiSubscription.
+func (v *ApiSubscriptionCustomValidator) ValidateCreate(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
+	apisubscription, ok := obj.(*apiv1.ApiSubscription)
+	if !ok {
+		return nil, fmt.Errorf("expected a ApiSubscription object but got %T", obj)
+	}
+	apisubscriptionlog.Info("Validation for ApiSubscription upon creation", "name", apisubscription.GetName())
+
+	return validateCreateOrUpdate(ctx, v.client, *apisubscription)
+}
+
+// ValidateUpdate implements webhook.CustomValidator so a webhook will be registered for the type ApiSubscription.
+func (v *ApiSubscriptionCustomValidator) ValidateUpdate(ctx context.Context, oldObj, newObj runtime.Object) (admission.Warnings, error) {
+	apisubscription, ok := newObj.(*apiv1.ApiSubscription)
+	if !ok {
+		return nil, fmt.Errorf("expected a ApiSubscription object for the newObj but got %T", newObj)
+	}
+	apisubscriptionlog.Info("Validation for ApiSubscription upon update", "name", apisubscription.GetName())
+
+	return validateCreateOrUpdate(ctx, v.client, *apisubscription)
+}
+
+// ValidateDelete implements webhook.CustomValidator so a webhook will be registered for the type ApiSubscription.
+func (v *ApiSubscriptionCustomValidator) ValidateDelete(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
+	apisubscription, ok := obj.(*apiv1.ApiSubscription)
+	if !ok {
+		return nil, fmt.Errorf("expected a ApiSubscription object but got %T", obj)
+	}
+	apisubscriptionlog.Info("Validation for ApiSubscription upon deletion", "name", apisubscription.GetName())
+
+	// todo handle deletion
+
+	return nil, nil
+}
+
+func getEnvironment(object client.Object) (string, bool) {
+	labels := object.GetLabels()
+	if labels == nil {
+		return "", false
+	}
+	e, ok := labels[config.EnvironmentLabelKey]
+	return e, ok
+}
+
+func validateCreateOrUpdate(ctx context.Context, c client.Client, sub apiv1.ApiSubscription) (admission.Warnings, error) {
+	apisubscriptionlog.Info("Validate for ApiSubscription upon creation", "name", sub.GetName())
+	apisubscriptionlog.Info("Client is ", "client", c)
+
+	env, found := getEnvironment(&sub)
+	if !found {
+		return nil, apierrors.NewBadRequest("Environment validation failed - label is not present on subscription")
+	}
+
+	apisubscriptionlog.Info("Environment is ", "env", env)
+	scopedClient := cclient.NewScopedClient(c, env)
+	apisubscriptionlog.Info("Scoped client is ", "scoped client", scopedClient)
+
+	apiExposureList := &apiv1.ApiExposureList{}
+	err := scopedClient.List(ctx, apiExposureList,
+		client.MatchingLabels{apiv1.BasePathLabelKey: labelutil.NormalizeValue(sub.Spec.ApiBasePath)},
+		client.MatchingFields{"status.active": "true"})
+
+	if err != nil {
+		apisubscriptionlog.Error(err, "unable to list ApiExposure", "name", sub.Spec.ApiBasePath)
+		return nil, apierrors.NewBadRequest("Active Api Exposure for this subscription not found")
+	}
+
+	if len(apiExposureList.Items) == 0 {
+		apisubscriptionlog.Error(err, "unable to list ApiExposure", "name", sub.Spec.ApiBasePath)
+		return nil, apierrors.NewBadRequest("Active Api Exposure for this subscription not found")
+	}
+
+	exposure := &apiExposureList.Items[0]
+	exposureVisibility := exposure.Spec.Visibility
+
+	// any subscription is valid for a WORLD exposure
+	if exposureVisibility == apiv1.VisibilityWorld {
+		return nil, nil
+	}
+
+	// get the subscription zone
+	subZone := &adminv1.Zone{}
+	err = scopedClient.Get(ctx, sub.Spec.Zone.K8s(), subZone)
+	if err != nil {
+		apisubscriptionlog.Error(err, "unable to get zone", "name", sub.Spec.Zone.K8s())
+		return nil, apierrors.NewBadRequest("Zone '" + sub.Spec.Zone.GetName() + "' not found")
+	}
+
+	// only same zone
+	if exposureVisibility == apiv1.VisibilityZone {
+		if exposure.Spec.Zone.GetName() != subZone.GetName() {
+			return nil, apierrors.NewBadRequest("Exposure visibility is ZONE and it doesnt match the subscription zone '" + subZone.GetName() + "'")
+		}
+	}
+
+	// only enterprise zones
+	if exposureVisibility == apiv1.VisibilityEnterprise {
+		if subZone.Spec.Visibility != adminv1.ZoneVisibilityEnterprise {
+			return nil, apierrors.NewBadRequest(fmt.Sprintf("Api is exposed with visibility '%s', but subscriptions is from zone with visibility '%s'", apiv1.VisibilityEnterprise, subZone.Spec.Visibility))
+		}
+	}
+	return nil, nil
+}

--- a/api/internal/webhook/v1/apisubscription_webhook.go
+++ b/api/internal/webhook/v1/apisubscription_webhook.go
@@ -57,8 +57,6 @@ func (d *ApiSubscriptionCustomDefaulter) Default(_ context.Context, obj runtime.
 	}
 	apisubscriptionlog.Info("Defaulting for ApiSubscription", "name", apisubscription.GetName())
 
-	// TODO(user): fill in your defaulting logic.
-
 	return nil
 }
 
@@ -118,19 +116,15 @@ func getEnvironment(object client.Object) (string, bool) {
 	e, ok := labels[config.EnvironmentLabelKey]
 	return e, ok
 }
-
 func validateCreateOrUpdate(ctx context.Context, c client.Client, sub apiv1.ApiSubscription) (admission.Warnings, error) {
 	apisubscriptionlog.Info("Validate for ApiSubscription upon creation", "name", sub.GetName())
-	apisubscriptionlog.Info("Client is ", "client", c)
 
 	env, found := getEnvironment(&sub)
 	if !found {
 		return nil, apierrors.NewBadRequest("Environment validation failed - label is not present on subscription")
 	}
 
-	apisubscriptionlog.Info("Environment is ", "env", env)
 	scopedClient := cclient.NewScopedClient(c, env)
-	apisubscriptionlog.Info("Scoped client is ", "scoped client", scopedClient)
 
 	apiExposureList := &apiv1.ApiExposureList{}
 	err := scopedClient.List(ctx, apiExposureList,

--- a/api/internal/webhook/v1/apisubscription_webhook_test.go
+++ b/api/internal/webhook/v1/apisubscription_webhook_test.go
@@ -1,0 +1,75 @@
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom IT GmbH
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package v1
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	apiv1 "github.com/telekom/controlplane/api/api/v1"
+	// TODO (user): Add any additional imports if needed
+)
+
+var _ = Describe("ApiSubscription Webhook", func() {
+	var (
+		obj       *apiv1.ApiSubscription
+		oldObj    *apiv1.ApiSubscription
+		validator ApiSubscriptionCustomValidator
+		defaulter ApiSubscriptionCustomDefaulter
+	)
+
+	BeforeEach(func() {
+		obj = &apiv1.ApiSubscription{}
+		oldObj = &apiv1.ApiSubscription{}
+		validator = ApiSubscriptionCustomValidator{}
+		Expect(validator).NotTo(BeNil(), "Expected validator to be initialized")
+		defaulter = ApiSubscriptionCustomDefaulter{}
+		Expect(defaulter).NotTo(BeNil(), "Expected defaulter to be initialized")
+		Expect(oldObj).NotTo(BeNil(), "Expected oldObj to be initialized")
+		Expect(obj).NotTo(BeNil(), "Expected obj to be initialized")
+		// TODO (user): Add any setup logic common to all tests
+	})
+
+	AfterEach(func() {
+		// TODO (user): Add any teardown logic common to all tests
+	})
+
+	Context("When creating ApiSubscription under Defaulting Webhook", func() {
+		// TODO (user): Add logic for defaulting webhooks
+		// Example:
+		// It("Should apply defaults when a required field is empty", func() {
+		//     By("simulating a scenario where defaults should be applied")
+		//     obj.SomeFieldWithDefault = ""
+		//     By("calling the Default method to apply defaults")
+		//     defaulter.Default(ctx, obj)
+		//     By("checking that the default values are set")
+		//     Expect(obj.SomeFieldWithDefault).To(Equal("default_value"))
+		// })
+	})
+
+	Context("When creating or updating ApiSubscription under Validating Webhook", func() {
+		// TODO (user): Add logic for validating webhooks
+		// Example:
+		// It("Should deny creation if a required field is missing", func() {
+		//     By("simulating an invalid creation scenario")
+		//     obj.SomeRequiredField = ""
+		//     Expect(validator.ValidateCreate(ctx, obj)).Error().To(HaveOccurred())
+		// })
+		//
+		// It("Should admit creation if all required fields are present", func() {
+		//     By("simulating an invalid creation scenario")
+		//     obj.SomeRequiredField = "valid_value"
+		//     Expect(validator.ValidateCreate(ctx, obj)).To(BeNil())
+		// })
+		//
+		// It("Should validate updates correctly", func() {
+		//     By("simulating a valid update scenario")
+		//     oldObj.SomeRequiredField = "updated_value"
+		//     obj.SomeRequiredField = "updated_value"
+		//     Expect(validator.ValidateUpdate(ctx, oldObj, obj)).To(BeNil())
+		// })
+	})
+
+})

--- a/api/internal/webhook/v1/webhook_suite_test.go
+++ b/api/internal/webhook/v1/webhook_suite_test.go
@@ -1,0 +1,152 @@
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom IT GmbH
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package v1
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+
+	apiv1 "github.com/telekom/controlplane/api/api/v1"
+	// +kubebuilder:scaffold:imports
+)
+
+// These tests use Ginkgo (BDD-style Go testing framework). Refer to
+// http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
+
+var (
+	ctx       context.Context
+	cancel    context.CancelFunc
+	k8sClient client.Client
+	cfg       *rest.Config
+	testEnv   *envtest.Environment
+)
+
+func TestAPIs(t *testing.T) {
+	RegisterFailHandler(Fail)
+
+	RunSpecs(t, "Webhook Suite")
+}
+
+var _ = BeforeSuite(func() {
+	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
+
+	ctx, cancel = context.WithCancel(context.TODO())
+
+	var err error
+	err = apiv1.AddToScheme(scheme.Scheme)
+	Expect(err).NotTo(HaveOccurred())
+
+	// +kubebuilder:scaffold:scheme
+
+	By("bootstrapping test environment")
+	testEnv = &envtest.Environment{
+		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "..", "config", "crd", "bases")},
+		ErrorIfCRDPathMissing: false,
+
+		WebhookInstallOptions: envtest.WebhookInstallOptions{
+			Paths: []string{filepath.Join("..", "..", "..", "config", "webhook")},
+		},
+	}
+
+	// Retrieve the first found binary directory to allow running tests from IDEs
+	if getFirstFoundEnvTestBinaryDir() != "" {
+		testEnv.BinaryAssetsDirectory = getFirstFoundEnvTestBinaryDir()
+	}
+
+	// cfg is defined in this file globally.
+	cfg, err = testEnv.Start()
+	Expect(err).NotTo(HaveOccurred())
+	Expect(cfg).NotTo(BeNil())
+
+	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
+	Expect(err).NotTo(HaveOccurred())
+	Expect(k8sClient).NotTo(BeNil())
+
+	// start webhook server using Manager.
+	webhookInstallOptions := &testEnv.WebhookInstallOptions
+	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
+		Scheme: scheme.Scheme,
+		WebhookServer: webhook.NewServer(webhook.Options{
+			Host:    webhookInstallOptions.LocalServingHost,
+			Port:    webhookInstallOptions.LocalServingPort,
+			CertDir: webhookInstallOptions.LocalServingCertDir,
+		}),
+		LeaderElection: false,
+		Metrics:        metricsserver.Options{BindAddress: "0"},
+	})
+	Expect(err).NotTo(HaveOccurred())
+
+	err = SetupApiSubscriptionWebhookWithManager(mgr)
+	Expect(err).NotTo(HaveOccurred())
+
+	// +kubebuilder:scaffold:webhook
+
+	go func() {
+		defer GinkgoRecover()
+		err = mgr.Start(ctx)
+		Expect(err).NotTo(HaveOccurred())
+	}()
+
+	// wait for the webhook server to get ready.
+	dialer := &net.Dialer{Timeout: time.Second}
+	addrPort := fmt.Sprintf("%s:%d", webhookInstallOptions.LocalServingHost, webhookInstallOptions.LocalServingPort)
+	Eventually(func() error {
+		conn, err := tls.DialWithDialer(dialer, "tcp", addrPort, &tls.Config{InsecureSkipVerify: true})
+		if err != nil {
+			return err
+		}
+
+		return conn.Close()
+	}).Should(Succeed())
+})
+
+var _ = AfterSuite(func() {
+	By("tearing down the test environment")
+	cancel()
+	err := testEnv.Stop()
+	Expect(err).NotTo(HaveOccurred())
+})
+
+// getFirstFoundEnvTestBinaryDir locates the first binary in the specified path.
+// ENVTEST-based tests depend on specific binaries, usually located in paths set by
+// controller-runtime. When running tests directly (e.g., via an IDE) without using
+// Makefile targets, the 'BinaryAssetsDirectory' must be explicitly configured.
+//
+// This function streamlines the process by finding the required binaries, similar to
+// setting the 'KUBEBUILDER_ASSETS' environment variable. To ensure the binaries are
+// properly set up, run 'make setup-envtest' beforehand.
+func getFirstFoundEnvTestBinaryDir() string {
+	basePath := filepath.Join("..", "..", "..", "bin", "k8s")
+	entries, err := os.ReadDir(basePath)
+	if err != nil {
+		logf.Log.Error(err, "Failed to read directory", "path", basePath)
+		return ""
+	}
+	for _, entry := range entries {
+		if entry.IsDir() {
+			return filepath.Join(basePath, entry.Name())
+		}
+	}
+	return ""
+}

--- a/rover/api/v1/rover_types.go
+++ b/rover/api/v1/rover_types.go
@@ -168,3 +168,7 @@ func (r *RoverList) GetItems() []types.Object {
 func init() {
 	SchemeBuilder.Register(&Rover{}, &RoverList{})
 }
+
+func (rs *RoverStatus) IsEmpty() bool {
+	return rs.Conditions == nil || len(rs.Conditions) == 0
+}

--- a/rover/internal/webhook/rover_webhook.go
+++ b/rover/internal/webhook/rover_webhook.go
@@ -7,6 +7,8 @@ package webhook
 import (
 	"context"
 	"fmt"
+	apiapi "github.com/telekom/controlplane/api/api/v1"
+	cclient "github.com/telekom/controlplane/common/pkg/client"
 	"reflect"
 	"strings"
 
@@ -108,6 +110,9 @@ func (r *RoverValidator) ValidateCreateOrUpdate(ctx context.Context, obj runtime
 		if _, err = r.ValidateSubscription(ctx, environment, sub); err != nil {
 			return nil, err
 		}
+		if _, err = r.ValidateSubscriptionVisibility(ctx, sub, rover); err != nil {
+			return nil, err
+		}
 	}
 
 	for _, exposure := range rover.Spec.Exposures {
@@ -154,6 +159,56 @@ func (r *RoverValidator) ValidateExposure(ctx context.Context, environment strin
 	}
 
 	return
+}
+
+func (r *RoverValidator) ValidateSubscriptionVisibility(ctx context.Context, sub roverv1.Subscription, rover *roverv1.Rover) (warnings admission.Warnings, err error) {
+	scopedClient := cclient.ClientFromContextOrDie(ctx)
+
+	apiExposureList := &apiapi.ApiExposureList{}
+	err = scopedClient.List(ctx, apiExposureList,
+		client.MatchingLabels{apiapi.BasePathLabelKey: sub.Api.BasePath},
+		client.MatchingFields{"status.active": "true"})
+
+	if err != nil {
+		return nil, err
+	}
+
+	if len(apiExposureList.Items) == 0 {
+		return nil, apierrors.NewBadRequest("Active Api Exposure for this subscription not found")
+	}
+
+	exposure := &apiExposureList.Items[0]
+	exposureVisibility := exposure.Spec.Visibility
+
+	// any subscription is valid for a WORLD exposure
+	if exposureVisibility == apiapi.VisibilityWorld {
+		return nil, nil
+	}
+
+	// get the subscription zone
+	subZone := &adminv1.Zone{}
+	err = scopedClient.Get(ctx, client.ObjectKey{
+		Namespace: "default",
+		Name:      rover.Spec.Zone,
+	}, subZone)
+	if err != nil {
+		return nil, apierrors.NewBadRequest("Zone '" + rover.Spec.Zone + "' not found")
+	}
+
+	// only same zone
+	if exposureVisibility == apiapi.VisibilityZone {
+		if exposure.Spec.Zone.GetName() != subZone.GetName() {
+			return nil, apierrors.NewBadRequest("Exposure visibility is ZONE and it doesnt match the subscription zone '" + subZone.GetName() + "'")
+		}
+	}
+
+	// only enterprise zones
+	if exposureVisibility == apiapi.VisibilityEnterprise {
+		if subZone.Spec.Visibility != adminv1.ZoneVisibilityEnterprise {
+			return nil, apierrors.NewBadRequest(fmt.Sprintf("Api is exposed with visibility '%s', but subscriptions is from zone with visibility '%s'", apiapi.VisibilityEnterprise, subZone.Spec.Visibility))
+		}
+	}
+	return nil, nil
 }
 
 // MustNotHaveDuplicates checks if there are no duplicates in the subscriptions and exposures

--- a/rover/internal/webhook/validators/apisubscription_validator.go
+++ b/rover/internal/webhook/validators/apisubscription_validator.go
@@ -1,0 +1,126 @@
+package validators
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"encoding/json"
+	"github.com/pkg/errors"
+	"github.com/telekom/controlplane/common/pkg/client"
+	rover "github.com/telekom/controlplane/rover/api/v1"
+	apihandler "github.com/telekom/controlplane/rover/internal/handler/rover/api"
+	"io"
+	admissionv1 "k8s.io/api/admission/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/uuid"
+	"net/http"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+var (
+	apiSubWebhookEndpoint = "https://api-operator-webhook-service.api-operator-system.svc:443/validate-api-cp-ei-telekom-de-v1-apisubscription"
+)
+
+// CallApiSubscriptionWebhook Will call the ApiSubscription validating webhook and return a result and a reason
+func CallApiSubscriptionWebhook(ctx context.Context, c client.ScopedClient, rover rover.Rover, apiSubscription rover.ApiSubscription) (bool, error) {
+	log := log.FromContext(ctx)
+
+	httpClient := buildHttpClient()
+
+	ar, err := buildAdmissionReview(ctx, c, rover, apiSubscription)
+	if err != nil {
+		return false, errors.Wrap(err, "failed to build admission review")
+	}
+	body, err := json.Marshal(ar)
+	if err != nil {
+		return false, errors.Wrap(err, "Failed to marshal AdmissionReview")
+	}
+
+	// call the ApiSubscription webhook
+	req, err := http.NewRequest("POST", apiSubWebhookEndpoint, bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return false, errors.Wrap(err, "Failed to execute request to ApiSubscriptionWebhook")
+	}
+	defer func(Body io.ReadCloser) {
+		err := Body.Close()
+		if err != nil {
+			log.Error(err, "Failed to close response body after calling ApiSubscriptionWebhook")
+		}
+	}(resp.Body)
+
+	// parse the response
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return false, errors.Wrap(err, "Failed to read response body")
+	}
+
+	var admissionResponse admissionv1.AdmissionReview
+	err = json.Unmarshal(respBody, &admissionResponse)
+	if err != nil {
+		return false, errors.Wrap(err, "Failed to unmarshal AdmissionReview response after calling ApiSubscriptionWebhook")
+	}
+
+	if admissionResponse.Response.Allowed {
+		return true, nil
+	} else {
+		return false, errors.New("ApiSubscription webhook rejected the ApiSubscription because '" + admissionResponse.Response.Result.Message + "'")
+	}
+}
+
+func buildAdmissionReview(ctx context.Context, c client.ScopedClient, rover rover.Rover, apiSubscription rover.ApiSubscription) (*admissionv1.AdmissionReview, error) {
+	apiSub, mutator, err := apihandler.BuildApiSubscription(ctx, c, rover, apiSubscription)
+	if err != nil {
+		return nil, errors.Wrap(err, "Failed to build ApiSubscription admission review")
+	}
+	err = mutator()
+	if err != nil {
+		return nil, errors.Wrap(err, "Failed to apply mutate function to ApiSubscription admission review")
+	}
+
+	apiSubJson, err := json.Marshal(apiSub)
+	if err != nil {
+		return nil, errors.Wrap(err, "Failed to marshal ApiSubscription to JSON for admission review")
+	}
+
+	ar := admissionv1.AdmissionReview{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "admission.k8s.io/v1",
+			Kind:       "AdmissionReview",
+		},
+		Request: &admissionv1.AdmissionRequest{
+			UID: uuid.NewUUID(),
+			Kind: metav1.GroupVersionKind{
+				Group:   apiSub.GroupVersionKind().Group,
+				Version: apiSub.GroupVersionKind().Version,
+				Kind:    apiSub.GroupVersionKind().Kind,
+			},
+			Resource: metav1.GroupVersionResource{
+				Group:    apiSub.GroupVersionKind().Group,
+				Version:  apiSub.GroupVersionKind().Version,
+				Resource: "apisubscriptions",
+			},
+			Object: runtime.RawExtension{
+				Raw: apiSubJson, // marshaled JSON of the Domain2 CR you want to validate
+			},
+			Operation: admissionv1.Create, // or Update
+		},
+	}
+
+	return &ar, nil
+}
+
+// buildHttpClient WARN skips TLS verification, but its ok, because its inside the cluster and we trust each other
+func buildHttpClient() http.Client {
+	client := &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{
+				InsecureSkipVerify: true,
+			},
+		},
+	}
+	return *client
+}


### PR DESCRIPTION
During validation of a Rover resource in the webhook, make a call to the API domains webhook to validate the ApiSubscription. This will prevent creating stuck resources that would always be rejected by the target domains webhook.