### PR TITLE
feat(loadbalancing): Add loadbalancing feature in the gateway domain using Upstreams in the RouteSpec

### DIFF
--- a/gateway/api/v1/features.go
+++ b/gateway/api/v1/features.go
@@ -18,4 +18,5 @@ const (
 	FeatureTypeLastMileSecurity FeatureType = "LastMileSecurity" // depends on AccessControl
 	FeatureTypeExternalIDP      FeatureType = "ExternalIDP"      // depends on LastMileSecurity
 	FeatureTypeCustomScopes     FeatureType = "CustomScopes"     // depends on LastMileSecurity
+	FeatureTypeLoadBalancing    FeatureType = "LoadBalancing"    // depends on LastMileSecurity
 )

--- a/gateway/api/v1/route_types.go
+++ b/gateway/api/v1/route_types.go
@@ -13,6 +13,9 @@ import (
 )
 
 type Upstream struct {
+	Url    string `json:"url"`
+	Weight int    `json:"weight,omitempty"`
+	// TODO remove parts and only keep Url
 	Scheme       string `json:"scheme"`
 	Host         string `json:"host"`
 	Port         int    `json:"port"`

--- a/gateway/config/crd/bases/gateway.cp.ei.telekom.de_routes.yaml
+++ b/gateway/config/crd/bases/gateway.cp.ei.telekom.de_routes.yaml
@@ -100,11 +100,16 @@ spec:
                       type: integer
                     scheme:
                       type: string
+                    url:
+                      type: string
+                    weight:
+                      type: integer
                   required:
                   - host
                   - path
                   - port
                   - scheme
+                  - url
                   type: object
                 type: array
             required:

--- a/gateway/internal/features/builder_load_balancing_test.go
+++ b/gateway/internal/features/builder_load_balancing_test.go
@@ -6,6 +6,7 @@ package features_test
 
 import (
 	"context"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/telekom/controlplane/common/pkg/util/contextutil"

--- a/gateway/internal/features/builder_load_balancing_test.go
+++ b/gateway/internal/features/builder_load_balancing_test.go
@@ -1,0 +1,175 @@
+// Copyright 2025 Deutsche Telekom IT GmbH
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package features_test
+
+import (
+	"context"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/telekom/controlplane/common/pkg/util/contextutil"
+	gatewayv1 "github.com/telekom/controlplane/gateway/api/v1"
+	"github.com/telekom/controlplane/gateway/internal/features"
+	"github.com/telekom/controlplane/gateway/internal/features/feature"
+	"github.com/telekom/controlplane/gateway/pkg/kong/client/mock"
+	"github.com/telekom/controlplane/gateway/pkg/kong/client/plugin"
+	"go.uber.org/mock/gomock"
+)
+
+func NewLoadBalancingUpstreams(isProxyRoute bool) []gatewayv1.Upstream {
+	var issuerUrl string
+	if isProxyRoute {
+		issuerUrl = "https://upstream.issuer.url"
+	} else {
+		issuerUrl = ""
+	}
+
+	return []gatewayv1.Upstream{
+		{
+			Url:       "http://upstream.url:8080/api/v1",
+			Weight:    2,
+			Scheme:    "http",
+			Host:      "upstream.url",
+			Port:      8080,
+			Path:      "/api/v1",
+			IssuerUrl: issuerUrl,
+		},
+		{
+			Url:       "http://upstream2.url:8080/api/v1",
+			Weight:    1,
+			Scheme:    "http",
+			Host:      "upstream2.url",
+			Port:      8080,
+			Path:      "/api/v1",
+			IssuerUrl: issuerUrl,
+		},
+	}
+}
+
+var _ = Describe("FeatureBuilder LoadBalancing", Ordered, func() {
+	var ctx = context.Background()
+	ctx = contextutil.WithEnv(ctx, "test")
+	BeforeEach(func() {
+		mockKc = mock.NewMockKongClient(mockCtrl)
+	})
+
+	Context("Applying and Creating", Ordered, func() {
+		It("should apply the LoadBalancing feature isolated", func() {
+			loadBalancingRoute := enableLoadBalancing(false)
+			configureMocks(ctx, loadBalancingRoute)
+
+			By("building the features")
+			builder := buildLoadBalancingFeature(ctx, loadBalancingRoute, false)
+
+			By("checking the jumper config")
+			verifyJumperConfig(builder)
+
+			By("checking the request-transformer plugin")
+			verifyRequestTransformerPluginIsolated(builder)
+		})
+
+		It("should apply the LoadBalancing feature with LastMileSecurity for a real route", func() {
+			loadBalancingRoute := enableLoadBalancing(false)
+			configureMocks(ctx, loadBalancingRoute)
+
+			By("building the features")
+			builder := buildLoadBalancingFeature(ctx, loadBalancingRoute, true)
+
+			By("checking the jumper config")
+			verifyJumperConfig(builder)
+
+			By("checking the request-transformer plugin")
+			verifyRequestTransformerPluginRealRoute(builder)
+		})
+
+		It("should apply the LoadBalancing feature with LastMileSecurity for a proxy route", func() {
+			loadBalancingRoute := enableLoadBalancing(true)
+			configureMocks(ctx, loadBalancingRoute)
+
+			By("building the features")
+			builder := buildLoadBalancingFeature(ctx, loadBalancingRoute, true)
+
+			By("checking the jumper config")
+			verifyJumperConfig(builder)
+
+			By("checking the request-transformer plugin")
+			verifyRequestTransformerPluginProxyRoute(builder)
+		})
+	})
+
+})
+
+func verifyRequestTransformerPluginIsolated(builder *features.Builder) {
+	rtPlugin, ok := builder.Plugins["request-transformer"].(*plugin.RequestTransformerPlugin)
+	Expect(ok).To(BeTrue())
+
+	By("checking the request-transformer plugin config")
+	Expect(rtPlugin.Config.Append.Headers).To(BeNil())
+	Expect(rtPlugin.Config.Remove.Headers).To(BeNil())
+}
+
+func verifyRequestTransformerPluginRealRoute(builder *features.Builder) {
+	rtPlugin, ok := builder.Plugins["request-transformer"].(*plugin.RequestTransformerPlugin)
+	Expect(ok).To(BeTrue())
+
+	By("checking the request-transformer plugin config")
+	Expect(rtPlugin.Config.Append.Headers.Contains("remote_api_url")).To(BeFalse())
+	Expect(rtPlugin.Config.Append.Headers.Contains("api_base_path")).To(BeTrue())
+	Expect(rtPlugin.Config.Append.Headers.Contains("access_token_forwarding")).To(BeTrue())
+	Expect(rtPlugin.Config.Append.Headers.Contains(plugin.JumperConfigKey)).To(BeTrue())
+	Expect(rtPlugin.Config.Remove.Headers.Contains("consumer-token")).To(BeTrue())
+}
+
+func verifyRequestTransformerPluginProxyRoute(builder *features.Builder) {
+	rtPlugin, ok := builder.Plugins["request-transformer"].(*plugin.RequestTransformerPlugin)
+	Expect(ok).To(BeTrue())
+
+	By("checking the request-transformer plugin config")
+	Expect(rtPlugin.Config.Append.Headers.Contains("issuer")).To(BeTrue())
+	Expect(rtPlugin.Config.Append.Headers.Contains("client_id")).To(BeTrue())
+	Expect(rtPlugin.Config.Append.Headers.Contains("client_secret")).To(BeTrue())
+	Expect(rtPlugin.Config.Append.Headers.Contains("remote_api_url")).To(BeTrue())
+	Expect(rtPlugin.Config.Append.Headers.Contains(plugin.JumperConfigKey)).To(BeTrue())
+	Expect(rtPlugin.Config.Remove.Headers).To(BeNil())
+}
+
+func verifyJumperConfig(builder *features.Builder) {
+	jumperConfig := builder.JumperConfig()
+	By("Checking that JumperConfig contains both upstreams with weights")
+	Expect(jumperConfig).NotTo(BeNil())
+	Expect(jumperConfig.LoadBalancing).NotTo(BeNil())
+	Expect(jumperConfig.LoadBalancing.Servers).To(HaveLen(2))
+	Expect(jumperConfig.LoadBalancing.Servers[0].Upstream).To(Equal("http://upstream.url:8080/api/v1"))
+	Expect(jumperConfig.LoadBalancing.Servers[0].Weight).To(Equal(2))
+	Expect(jumperConfig.LoadBalancing.Servers[1].Upstream).To(Equal("http://upstream2.url:8080/api/v1"))
+	Expect(jumperConfig.LoadBalancing.Servers[1].Weight).To(Equal(1))
+}
+
+func buildLoadBalancingFeature(ctx context.Context, loadBalancingRoute *gatewayv1.Route, withLastMileSecurity bool) *features.Builder {
+	builder := features.NewFeatureBuilder(mockKc, loadBalancingRoute, realm, gateway)
+	builder.EnableFeature(feature.InstanceLoadBalancingFeature)
+	if withLastMileSecurity {
+		builder.EnableFeature(feature.InstanceLastMileSecurityFeature)
+	}
+	err := builder.Build(ctx)
+	Expect(err).ToNot(HaveOccurred())
+
+	b, ok := builder.(*features.Builder)
+	Expect(ok).To(BeTrue())
+	return b
+}
+
+func enableLoadBalancing(isProxyRoute bool) *gatewayv1.Route {
+	loadBalancingRoute := route.DeepCopy()
+	loadBalancingRoute.Spec.PassThrough = false
+	loadBalancingRoute.Spec.Upstreams = NewLoadBalancingUpstreams(isProxyRoute)
+
+	return loadBalancingRoute
+}
+
+func configureMocks(ctx context.Context, loadBalancingRoute *gatewayv1.Route) {
+	mockKc.EXPECT().CreateOrReplaceRoute(ctx, loadBalancingRoute, gomock.Any()).Return(nil).Times(1)
+	mockKc.EXPECT().CreateOrReplacePlugin(ctx, gomock.Any()).Return(nil, nil).Times(1)
+	mockKc.EXPECT().CleanupPlugins(ctx, gomock.Any(), gomock.Any()).Return(nil).Times(1)
+}

--- a/gateway/internal/features/builder_test.go
+++ b/gateway/internal/features/builder_test.go
@@ -6,6 +6,7 @@ package features_test
 
 import (
 	"context"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/telekom/controlplane/common/pkg/types"

--- a/gateway/internal/features/feature/load_balancing.go
+++ b/gateway/internal/features/feature/load_balancing.go
@@ -6,6 +6,7 @@ package feature
 
 import (
 	"context"
+
 	"github.com/telekom/controlplane/gateway/pkg/kong/client"
 	"github.com/telekom/controlplane/gateway/pkg/kong/client/plugin"
 

--- a/gateway/internal/features/feature/load_balancing.go
+++ b/gateway/internal/features/feature/load_balancing.go
@@ -1,0 +1,89 @@
+// Copyright 2025 Deutsche Telekom IT GmbH
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package feature
+
+import (
+	"context"
+	"github.com/telekom/controlplane/gateway/pkg/kong/client"
+	"github.com/telekom/controlplane/gateway/pkg/kong/client/plugin"
+
+	gatewayv1 "github.com/telekom/controlplane/gateway/api/v1"
+	"github.com/telekom/controlplane/gateway/internal/features"
+)
+
+var _ features.Feature = &LoadBalancingFeature{}
+
+type LoadBalancingFeature struct {
+	priority int
+}
+
+var InstanceLoadBalancingFeature = &LoadBalancingFeature{
+	priority: InstanceLastMileSecurityFeature.priority + 2,
+}
+
+func (f *LoadBalancingFeature) Name() gatewayv1.FeatureType {
+	return gatewayv1.FeatureTypeLoadBalancing
+}
+
+func (f *LoadBalancingFeature) Priority() int {
+	return f.priority
+}
+
+func (f *LoadBalancingFeature) IsUsed(ctx context.Context, builder features.FeaturesBuilder) bool {
+	route := builder.GetRoute()
+	return len(route.Spec.Upstreams) > 1
+}
+
+func (f *LoadBalancingFeature) Apply(ctx context.Context, builder features.FeaturesBuilder) (err error) {
+	route := builder.GetRoute()
+	upstreams := route.Spec.Upstreams
+
+	// Upstream URL is always set to jumper proxy URL (localhost for sidecar proxy)
+	builder.SetUpstream(client.NewUpstreamOrDie(plugin.LocalhostProxyUrl))
+
+	// Load Balancing is added to JumperConfig
+	jumperConfig := builder.JumperConfig()
+	loadBalancingServer := mapToLoadBalancingServers(upstreams)
+	jumperConfig.LoadBalancing = &loadBalancingServer
+
+	// Check if the remote API URL header should be removed when using Last Mile Security
+	RemoveRemoteApiUrlHeaderIfNeeded(builder)
+
+	return nil
+}
+
+func mapToLoadBalancingServers(upstreams []gatewayv1.Upstream) plugin.LoadBalancing {
+	servers := make([]plugin.LoadBalancingServer, 0, len(upstreams))
+	for _, upstream := range upstreams {
+		servers = append(servers, mapToLoadBalancingServer(upstream))
+	}
+	return plugin.LoadBalancing{
+		Servers: servers,
+	}
+}
+
+func mapToLoadBalancingServer(upstream gatewayv1.Upstream) plugin.LoadBalancingServer {
+	return plugin.LoadBalancingServer{
+		Upstream: upstream.Url,
+		Weight:   upstream.Weight,
+	}
+}
+
+func RemoveRemoteApiUrlHeaderIfNeeded(builder features.FeaturesBuilder) {
+	route := builder.GetRoute()
+	lastMileSecurityIsUsed := !route.Spec.PassThrough
+	realRoute := !route.IsProxy()
+
+	if realRoute && lastMileSecurityIsUsed {
+		rtpPlugin := builder.RequestTransformerPlugin()
+
+		// Remove the remote_api_url header if it exists:
+		// This is necessary to avoid conflicts with Last Mile Security in Jumper, because Jumper will
+		// only consider LoadBalancing servers if the remote_api_url header is not set.
+		if rtpPlugin.Config.Append.Headers != nil && rtpPlugin.Config.Append.Headers.Contains("remote_api_url") {
+			rtpPlugin.Config.Append.Headers.Remove("remote_api_url")
+		}
+	}
+}

--- a/gateway/internal/features/suite_test.go
+++ b/gateway/internal/features/suite_test.go
@@ -5,6 +5,11 @@
 package features_test
 
 import (
+	"github.com/telekom/controlplane/common/pkg/types"
+	gatewayv1 "github.com/telekom/controlplane/gateway/api/v1"
+	"github.com/telekom/controlplane/gateway/pkg/kong/client/mock"
+	"go.uber.org/mock/gomock"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -15,3 +20,100 @@ func TestFeatures(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Features Suite")
 }
+
+func NewMockRoute() *gatewayv1.Route {
+	return &gatewayv1.Route{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "default",
+		},
+		Spec: gatewayv1.RouteSpec{
+			Realm: types.ObjectRef{
+				Name:      "realm",
+				Namespace: "default",
+			},
+			PassThrough: false,
+			Upstreams: []gatewayv1.Upstream{
+				{
+					Url: "http://upstream.url:8080/api/v1",
+					// Default is used for Weight
+					Scheme: "http",
+					Host:   "upstream.url",
+					Port:   8080,
+					Path:   "/api/v1",
+				},
+			},
+			Downstreams: []gatewayv1.Downstream{
+				{
+					Host:      "downstream.url",
+					Port:      8080,
+					Path:      "/test/v1",
+					IssuerUrl: "issuer.url",
+				},
+			},
+		},
+	}
+}
+
+func NewMockConsumeRoute(routeRef types.ObjectRef) *gatewayv1.ConsumeRoute {
+	return &gatewayv1.ConsumeRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-consumer",
+			Namespace: "default",
+		},
+		Spec: gatewayv1.ConsumeRouteSpec{
+			ConsumerName: "test-consumer-name",
+			Route:        routeRef,
+		},
+	}
+}
+
+func NewMockRealm() *gatewayv1.Realm {
+	return &gatewayv1.Realm{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-realm",
+			Namespace: "default",
+		},
+		Spec: gatewayv1.RealmSpec{
+			Url:       "https://realm.url",
+			IssuerUrl: "https://issuer.url",
+			DefaultConsumers: []string{
+				"gateway",
+				"test",
+			},
+		},
+	}
+}
+
+func NewMockGateway() *gatewayv1.Gateway {
+	return &gatewayv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-gateway",
+			Namespace: "default",
+		},
+		Spec: gatewayv1.GatewaySpec{
+			Admin: gatewayv1.AdminConfig{
+				ClientId:     "admin",
+				ClientSecret: "topsecret",
+				IssuerUrl:    "https://issuer.url",
+				Url:          "https://admin.test.url",
+			},
+		},
+	}
+}
+
+var (
+	mockKc   *mock.MockKongClient
+	mockCtrl *gomock.Controller
+	route    *gatewayv1.Route
+	realm    *gatewayv1.Realm
+	gateway  *gatewayv1.Gateway
+)
+
+var _ = BeforeSuite(func() {
+	mockKc = mock.NewMockKongClient(mockCtrl)
+	mockCtrl = gomock.NewController(GinkgoT())
+	route = NewMockRoute()
+	realm = NewMockRealm()
+	gateway = NewMockGateway()
+})

--- a/gateway/internal/handler/route/handler.go
+++ b/gateway/internal/handler/route/handler.go
@@ -143,6 +143,7 @@ func NewFeatureBuilder(ctx context.Context, route *gatewayv1.Route) (features.Fe
 	builder.EnableFeature(feature.InstanceAccessControlFeature)
 	builder.EnableFeature(feature.InstancePassThroughFeature)
 	builder.EnableFeature(feature.InstanceLastMileSecurityFeature)
+	builder.EnableFeature(feature.InstanceLoadBalancingFeature)
 	// builder.EnableFeature(feature.InstanceCustomScopesFeature)
 	// builder.EnableFeature(feature.InstanceExternalIDPFeature)
 	// builder.EnableFeature(feature.InstanceRateLimitFeature)

--- a/gateway/pkg/kong/client/plugin/jumper.go
+++ b/gateway/pkg/kong/client/plugin/jumper.go
@@ -11,6 +11,8 @@ import (
 	"github.com/pkg/errors"
 )
 
+const LocalhostProxyUrl = "http://localhost:8080/proxy"
+
 type ConsumerId string
 
 type OauthCredentials struct {
@@ -24,9 +26,19 @@ type BasicAuthCredentials struct {
 	Password string `json:"password"`
 }
 
+type LoadBalancing struct {
+	Servers []LoadBalancingServer `json:"servers"`
+}
+
+type LoadBalancingServer struct {
+	Upstream string `json:"upstream"`
+	Weight   int    `json:"weight,omitempty"`
+}
+
 type JumperConfig struct {
-	OAuth     map[ConsumerId]OauthCredentials     `json:"oauth,omitempty"`
-	BasicAuth map[ConsumerId]BasicAuthCredentials `json:"basicAuth,omitempty"`
+	OAuth         map[ConsumerId]OauthCredentials     `json:"oauth,omitempty"`
+	BasicAuth     map[ConsumerId]BasicAuthCredentials `json:"basicAuth,omitempty"`
+	LoadBalancing *LoadBalancing                      `json:"loadBalancing,omitempty"`
 }
 
 func NewJumperConfig() *JumperConfig {

--- a/gateway/pkg/kong/client/plugin/suite_test.go
+++ b/gateway/pkg/kong/client/plugin/suite_test.go
@@ -55,9 +55,21 @@ var _ = Describe("Plugin", func() {
 						Scopes:       "scope1 scope2",
 					},
 				},
+				LoadBalancing: &LoadBalancing{
+					Servers: []LoadBalancingServer{
+						{
+							Upstream: "http://upstream.url:8080/api/v1",
+							Weight:   2,
+						},
+						{
+							Upstream: "http://upstream2.url:8080/api/v1",
+							Weight:   1,
+						},
+					},
+				},
 			}
 			// This must be the base64 encoded version of the expected JumperConfig
-			encodedJumperConfig = "eyJvYXV0aCI6eyIxMjMiOnsiY2xpZW50SWQiOiJjbGllbnQtaWQiLCJjbGllbnRTZWNyZXQiOiJ0b3BzZWNyZXQiLCJzY29wZXMiOiJzY29wZTEgc2NvcGUyIn19fQ=="
+			encodedJumperConfig = "eyJvYXV0aCI6eyIxMjMiOnsiY2xpZW50SWQiOiJjbGllbnQtaWQiLCJjbGllbnRTZWNyZXQiOiJ0b3BzZWNyZXQiLCJzY29wZXMiOiJzY29wZTEgc2NvcGUyIn19LCJsb2FkQmFsYW5jaW5nIjp7InNlcnZlcnMiOlt7InVwc3RyZWFtIjoiaHR0cDovL3Vwc3RyZWFtLnVybDo4MDgwL2FwaS92MSIsIndlaWdodCI6Mn0seyJ1cHN0cmVhbSI6Imh0dHA6Ly91cHN0cmVhbTIudXJsOjgwODAvYXBpL3YxIiwid2VpZ2h0IjoxfV19fQ=="
 		)
 
 		It("should return an empty JumperConfig", func() {
@@ -66,6 +78,7 @@ var _ = Describe("Plugin", func() {
 			Expect(actual).To(Equal(&JumperConfig{
 				OAuth:     map[ConsumerId]OauthCredentials{},
 				BasicAuth: map[ConsumerId]BasicAuthCredentials{},
+				// LoadBalancing is optional and not set by default
 			}))
 
 		})


### PR DESCRIPTION
* Add loadbalancing feature in the gateway domain using Upstreams in the RouteSpec
  * Input: Upstreams in RouteSpec
  * Output: JumperConfig with LoadBalancing (servers)
  * Feature LoadBalancing depends on LastMileSecurity
  * If LastMileSecurity is enabled and a real Route is used, the `remote_api_url` header has to be removed

* Extract load_balancing builder tests into a separate file
  * builder tests now have a common setup in the suite
  * load_balancing builder tests are located in a separate file  