### PR TITLE
feat(install-local): Add installation and quickstart guide for the controlplane in a local environment

### DIFF
--- a/docs/files/installation.md
+++ b/docs/files/installation.md
@@ -8,8 +8,9 @@ to get started right away.
 
 You can deploy the controlplane to your local Kubernetes cluster, e.g. using [kind](https://kind.sigs.k8s.io/).
 
-> **ℹ️ Important:** Before you start executing commands, please read the complete documentation for this chapter. 
-> Otherwise, you might need to do some backtracking.
+> [!IMPORTANT]
+> Before you start executing commands, please read the complete documentation for this chapter. Otherwise, you 
+> might need to do some backtracking.
 
 ### Installing local kind Cluster
 
@@ -119,11 +120,11 @@ can do:
 
 #### Option 2
 
-
-> **⚠️ Important:** You cannot test any webhook logic by running the controller like this!
+> [!WARNING]
+> You cannot test any webhook logic by running the controller like this!
 
 1. Before you run [Installing the Controlplane](#installing-the-controlplane), navigate to `install/local/kustomization.yaml`
-2. Edit the file and comment out all controller that you want to test locally, e. g. if I want to test rover, api and gateway:
+2. Edit the file and comment out all controller that you want to test locally, e.g. if I want to test rover, api and gateway:
     ```yaml
     resources:
       - ../../secret-manager/config/default

--- a/docs/files/installation.md
+++ b/docs/files/installation.md
@@ -1,2 +1,149 @@
 # Installation 
 
+This is an installation guide for the controlplane project. It will help you to set up the controlplane in a local 
+Kubernetes cluster. If you already know how it works, you can switch to the [Quickstart Guide](https://github.com/telekom/controlplane/tree/main/docs/files/quickstart.md) 
+to get started right away.
+
+## Local Setup
+
+You can deploy the controlplane to your local Kubernetes cluster, e.g. using [kind](https://kind.sigs.k8s.io/).
+
+> **ℹ️ Important:** Before you start executing commands, please read the complete documentation for this chapter. 
+> Otherwise, you might need to do some backtracking.
+
+### Installing local kind Cluster
+
+```bash
+# [optional] clone the controlplane repo
+git clone --branch main https://github.com/telekom/controlplane.git
+cd controlplane
+
+# [optional] create a new kind cluster
+kind create cluster
+
+# make sure you are connected to the correct Kubernetes context
+kubectl config current-context
+# > kind-kind
+
+# Install the required components
+## At the moment this install.sh depends on this namespace to exist, you need to create it manually
+kubectl create namespace secret-manager-system
+## Download the install.sh script and use it to install the components
+## You might need to set the GITHUB_TOKEN variable to avoid the rate-limits
+export GITHUB_TOKEN=$(gh auth token)
+bash ./install.sh --with-cert-manager --with-trust-manager --with-monitoring-crds
+
+# Now your local kind-cluster is setup with the required cert-manager, trust-manager and monitoring crds
+```
+
+### Installing the Controlplane
+
+Have a look at the [docs](https://github.com/telekom/controlplane/tree/main/install/local) on how to install it locally.
+
+```bash
+cd install/local
+kubectl apply -k .
+
+#verify installation
+kubectl get pods -A -l control-plane=controller-manager
+```
+
+### Creating the required Admin Resource
+
+Navigate to the [example admin resource](https://github.com/telekom/controlplane/tree/main/install/local/resources/admin). 
+Adjust these resource as needed.
+
+Install the admin resources to your local cluster:
+```bash
+kubectl apply -k resources/admin
+
+# Verify
+kubectl wait --for=condition=Ready -n controlplane zones/dataplane1
+```
+
+### Creating the required Organization Resource
+
+Navigate to the [example organization resource](https://github.com/telekom/controlplane/tree/main/install/local/resources/org). 
+Adjust these resource as needed.
+
+Install the organization resources to your local cluster:
+```bash
+kubectl apply -k resources/org
+
+# Verify
+kubectl wait --for=condition=Ready -n controlplane teams/phoenix--firebirds
+```
+
+### Creating the required Rover Resource
+
+Navigate to the [example rover resource](https://github.com/telekom/controlplane/tree/main/install/local/resources/rover). 
+Adjust these resource as needed.
+
+Install the rover resources to your local cluster:
+```bash
+kubectl apply -k resources/rover
+
+# Verify 
+kubectl wait --for=condition=Ready -n controlplane--phoenix--firebirds rovers/rover-echo-v1
+```
+
+### Testing my local Controllers
+
+To test your locally developed controller, you have multiple options that are described below.
+
+#### Option 1
+
+You now have the `stable` release deployed on your local kind-cluster. To change specific versions of controllers, you 
+can do:
+
+1. Navigate to `install/local/kustomization.yaml`
+2. Build the controller you want to test:
+    ```bash
+    # Example for rover controller
+    cd rover
+    
+    export KO_DOCKER_REPO=ko.local
+    ko build --bare cmd/main.go --tags rover-test
+    kind load docker-image ko.local:rover-test
+    ```
+3. Update `install/local/kustomization.yaml` with the new rover-controller image
+4. Install again:
+    ```bash
+    # [optional] navigate back to the install/local directory
+    cd install/local
+    # Apply the changes
+    kubectl apply -k .
+    ```
+5. 🎉 Success: Your controller should now run with your local version
+
+
+#### Option 2
+
+
+> **⚠️ Important:** You cannot test any webhook logic by running the controller like this!
+
+1. Before you run [Installing the Controlplane](#installing-the-controlplane), navigate to `install/local/kustomization.yaml`
+2. Edit the file and comment out all controller that you want to test locally, e. g. if I want to test rover, api and gateway:
+    ```yaml
+    resources:
+      - ../../secret-manager/config/default
+      - ../../identity/config/default
+    #  - ../../gateway/config/default
+      - ../../approval/config/default
+    #  - ../../rover/config/default
+      - ../../application/config/default
+      - ../../organization/config/default
+      # - ../../api/config/default
+      - ../../admin/config/default
+    ```
+3. Apply it using `kubectl apply -k .`
+4. Now, the rover-, api- and gateway-controllers were not deployed. You need to do it manually
+    ```bash
+    # forEach controller
+    cd rover
+    make install # install the CRDs
+    export ENABLE_WEBHOOKS=false # if applicable, disable webhooks
+    go run cmd/main.go # start the controller process
+    ```
+5. 🎉 Success: Your controllers should now run as a seperate process connected to the kind-cluster
+

--- a/docs/files/quickstart.md
+++ b/docs/files/quickstart.md
@@ -5,6 +5,10 @@
 ### Prepare local kind Cluster
 
 ```bash
+# [optional] clone the controlplane repo
+git clone --branch main https://github.com/telekom/controlplane.git
+cd controlplane
+
 # kind cluster
 kind create cluster
 

--- a/docs/files/quickstart.md
+++ b/docs/files/quickstart.md
@@ -1,0 +1,59 @@
+# Quickstart Guide
+
+## Local Setup
+
+### Prepare local kind Cluster
+
+```bash
+# kind cluster
+kind create cluster
+
+# namespace
+kubectl create namespace secret-manager-system
+
+# gh-auth
+export GITHUB_TOKEN=$(gh auth token)
+
+# install
+bash ./install.sh --with-cert-manager --with-trust-manager --with-monitoring-crds
+```
+
+### Install Controlplane
+
+```bash
+# cd install/local
+kubectl apply -k .
+
+#verify installation
+kubectl get pods -A -l control-plane=controller-manager
+```
+
+If you want to use local controllers to test the controlplane, please have a look at the 
+[Installation Guide](https://github.com/telekom/controlplane/tree/main/docs/files/installation.md) and the section
+`Testing my local Controllers`.
+
+### Install sample resources
+
+**admin custom resources**
+```bash
+kubectl apply -k resources/admin
+
+# Verify
+kubectl wait --for=condition=Ready -n controlplane zones/dataplane1
+```
+
+**organization custom resources**
+```bash
+kubectl apply -k resources/org
+
+# Verify
+kubectl wait --for=condition=Ready -n controlplane teams/phoenix--firebirds
+```
+
+**rover custom resources**
+```bash
+kubectl apply -k resources/rover
+
+# Verify 
+kubectl wait --for=condition=Ready -n controlplane--phoenix--firebirds rovers/rover-echo-v1
+```

--- a/install/local/README.md
+++ b/install/local/README.md
@@ -7,6 +7,35 @@ SPDX-License-Identifier: CC0-1.0
 
 # Local Installation 
 
+## Updating resources
+
+Before installing the operators and CRDs, ensure that you have updated the resources in the `resources\admin\zones`
+directory. This is important, because they contain configuration for the identity provider and the gateway. You either
+need to provide them on your local machine or use existing resources from a running environment.
+
+Please update `dataplane1.yaml` and `dataplane2.yaml` in the `resources/admin/zones` directory with your identity 
+provider and gateway configuration:
+
+**IdentityProvider**
+```yaml
+  identityProvider:
+    admin:
+      clientId: admin-cli
+      userName: admin
+      password: somePassword
+    url: https://my-idp.example.com/
+```
+
+**Gateway**
+```yaml
+  gateway:
+    admin:
+      clientSecret: someSecret
+      url: https://my-gateway-admin.example.com/admin-api
+    url: https://my-gateway-admin.example.com/
+```
+
+
 ## Installing Operators
 
 To install all operators and CRDs locally, you can use the following command:
@@ -30,7 +59,7 @@ To install the admin CRs, you can use the following command. This will create an
 kubectl apply -k resources/admin
 
 # Verify
-kubectl wait --for=condition=Ready -n default zones/zone-a
+kubectl wait --for=condition=Ready -n controlplane zones/dataplane1
 ```
 
 ## Install Organisational CRs
@@ -41,7 +70,7 @@ To install the organisational CRs, you can use the following command. This will 
 kubectl apply -k resources/org
 
 # Verify
-kubectl wait --for=condition=Ready -n default teams/group-sample--team-sample
+kubectl wait --for=condition=Ready -n controlplane teams/phoenix--firebirds
 ```
 
 ## Install Rover CRs
@@ -52,6 +81,6 @@ To install the rover CRs, you can use the following command. This will create a 
 kubectl apply -k resources/rover
 
 # Verify 
-kubectl wait --for=condition=Ready -n default--group-sample--team-sample rovers/rover-sample
+kubectl wait --for=condition=Ready -n controlplane--phoenix--firebirds rovers/rover-echo-v1
 ```
 

--- a/install/local/README.md
+++ b/install/local/README.md
@@ -13,8 +13,9 @@ Before installing the operators and CRDs, ensure that you have updated the resou
 directory. This is important, because they contain configuration for the identity provider and the gateway. You either
 need to provide them on your local machine or use existing resources from a running environment.
 
-Please update `dataplane1.yaml` and `dataplane2.yaml` in the `resources/admin/zones` directory with your identity 
-provider and gateway configuration:
+> [!IMPORTANT]
+> Please update `dataplane1.yaml` and `dataplane2.yaml` in the `resources/admin/zones` directory with your identity 
+> provider and gateway configuration:
 
 **IdentityProvider**
 ```yaml

--- a/install/local/README.md
+++ b/install/local/README.md
@@ -32,7 +32,7 @@ provider and gateway configuration:
     admin:
       clientSecret: someSecret
       url: https://my-gateway-admin.example.com/admin-api
-    url: https://my-gateway-admin.example.com/
+    url: https://my-gateway.example.com/
 ```
 
 

--- a/install/local/resources/.gitignore
+++ b/install/local/resources/.gitignore
@@ -3,3 +3,4 @@
 # SPDX-License-Identifier: Apache-2.0
 
 .local
+**/*.local

--- a/install/local/resources/admin/environment.yaml
+++ b/install/local/resources/admin/environment.yaml
@@ -5,10 +5,14 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: default
+  name: controlplane
 ---
 apiVersion: admin.cp.ei.telekom.de/v1
 kind: Environment
 metadata:
-  name: default
+  labels:
+    cp.ei.telekom.de/environment: controlplane
+  name: controlplane
+  namespace: controlplane
 spec:
+---

--- a/install/local/resources/admin/kustomization.yaml
+++ b/install/local/resources/admin/kustomization.yaml
@@ -2,14 +2,14 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-namespace: default
+namespace: controlplane
 
 labels:
   - includeSelectors: true
     pairs:
-      cp.ei.telekom.de/environment: default
+      cp.ei.telekom.de/environment: controlplane
       app.kubernetes.io/managed-by: kustomize
 
 resources:
   - environment.yaml
-  - zone.yaml
+  - zones

--- a/install/local/resources/admin/zones/dataplane1.yaml
+++ b/install/local/resources/admin/zones/dataplane1.yaml
@@ -29,3 +29,4 @@ spec:
     password: somePassword
   teamApis:
     apis: []
+  visibility: Enterprise

--- a/install/local/resources/admin/zones/dataplane1.yaml
+++ b/install/local/resources/admin/zones/dataplane1.yaml
@@ -22,7 +22,7 @@ spec:
     admin:
       clientSecret: someSecret
       url: https://my-gateway-admin.example.com/admin-api
-    url: https://my-gateway-admin.example.com/
+    url: https://my-gateway.example.com/
   redis:
     host: my-redis-host
     port: 6379

--- a/install/local/resources/admin/zones/dataplane1.yaml
+++ b/install/local/resources/admin/zones/dataplane1.yaml
@@ -5,22 +5,27 @@
 apiVersion: admin.cp.ei.telekom.de/v1
 kind: Zone
 metadata:
-  name: zone-a
+  labels:
+    app.kubernetes.io/name: dataplane1
+    app.kubernetes.io/managed-by: kustomize
+    cp.ei.telekom.de/environment: controlplane
+  name: dataplane1
+  namespace: controlplane
 spec:
-  teamApis:
-    apis: []
   identityProvider:
     admin:
       clientId: admin-cli
       userName: admin
       password: somePassword
-    url: https://my-idp.example.com
+    url: https://my-idp.example.com/
   gateway:
     admin:
       clientSecret: someSecret
       url: https://my-gateway-admin.example.com/admin-api
-    url: https://my-gateway.example.com
+    url: https://my-gateway-admin.example.com/
   redis:
-    host: foo
-    password: topsecret
+    host: my-redis-host
     port: 6379
+    password: somePassword
+  teamApis:
+    apis: []

--- a/install/local/resources/admin/zones/dataplane2.yaml
+++ b/install/local/resources/admin/zones/dataplane2.yaml
@@ -29,3 +29,4 @@ spec:
     password: somePassword
   teamApis:
     apis: []
+  visibility: Enterprise

--- a/install/local/resources/admin/zones/dataplane2.yaml
+++ b/install/local/resources/admin/zones/dataplane2.yaml
@@ -22,7 +22,7 @@ spec:
     admin:
       clientSecret: someSecret
       url: https://my-gateway-admin.example.com/admin-api
-    url: https://my-gateway-admin.example.com/
+    url: https://my-gateway.example.com/
   redis:
     host: my-redis-host
     port: 6379

--- a/install/local/resources/admin/zones/dataplane2.yaml
+++ b/install/local/resources/admin/zones/dataplane2.yaml
@@ -1,0 +1,31 @@
+# Copyright 2025 Deutsche Telekom IT GmbH
+#
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: admin.cp.ei.telekom.de/v1
+kind: Zone
+metadata:
+  labels:
+    app.kubernetes.io/name: dataplane2
+    app.kubernetes.io/managed-by: kustomize
+    cp.ei.telekom.de/environment: controlplane
+  name: dataplane2
+  namespace: controlplane
+spec:
+  identityProvider:
+    admin:
+      clientId: admin-cli
+      userName: admin
+      password: somePassword
+    url: https://my-idp.example.com/
+  gateway:
+    admin:
+      clientSecret: someSecret
+      url: https://my-gateway-admin.example.com/admin-api
+    url: https://my-gateway-admin.example.com/
+  redis:
+    host: my-redis-host
+    port: 6379
+    password: somePassword
+  teamApis:
+    apis: []

--- a/install/local/resources/admin/zones/kustomization.yaml
+++ b/install/local/resources/admin/zones/kustomization.yaml
@@ -1,0 +1,7 @@
+# Copyright 2025 Deutsche Telekom IT GmbH
+#
+# SPDX-License-Identifier: Apache-2.0
+
+resources:
+  - dataplane1.yaml
+  - dataplane2.yaml

--- a/install/local/resources/org/group.yaml
+++ b/install/local/resources/org/group.yaml
@@ -5,7 +5,7 @@
 apiVersion: organization.cp.ei.telekom.de/v1
 kind: Group
 metadata:
-  name: group-sample
+  name: phoenix
 spec:
-  displayName: group-sample
-  description: "This is a sample group"
+  displayName: phoenix
+  description: "This is a sample group called phoenix"

--- a/install/local/resources/org/kustomization.yaml
+++ b/install/local/resources/org/kustomization.yaml
@@ -2,12 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-namespace: default
+namespace: controlplane
 
 labels:
   - includeSelectors: true
     pairs:
-      cp.ei.telekom.de/environment: default
+      cp.ei.telekom.de/environment: controlplane
       app.kubernetes.io/managed-by: kustomize
 
 resources:

--- a/install/local/resources/org/team.yaml
+++ b/install/local/resources/org/team.yaml
@@ -5,11 +5,11 @@
 apiVersion: organization.cp.ei.telekom.de/v1
 kind: Team
 metadata:
-  name: group-sample--team-sample
+  name: phoenix--firebirds
 spec:
-  name: team-sample
-  group: group-sample
-  email: team-sample-mail@example.com
+  name: firebirds
+  group: phoenix
+  email: firebirds-mail@example.com
   members:
     - name: user1
       email: user1@example.com

--- a/install/local/resources/rover/apispec.yaml
+++ b/install/local/resources/rover/apispec.yaml
@@ -5,17 +5,34 @@
 apiVersion: rover.cp.ei.telekom.de/v1
 kind: ApiSpecification
 metadata:
-  name: eni-foo-v2
+  name: phoenix-echo-v1
 spec:
   specification: |
     openapi: "3.0.0"
     info:
       version: "1.0.0"
-      title: "Test API"
+      title: "Echo API"
       x-category: "test"
     servers:
-      - url: "https://example.com/eni/foo/v2"
+      - url: "https://example.com/phoenix/echo/v1"
     security:
       - oauth2:
           - read
           - write
+    components:
+      securitySchemes:
+        filestore_auth:
+          type: oauth2
+          flows:
+            implicit:
+              authorizationUrl: 'https://scope.swagger.io/oauth/authorize'
+              scopes:
+                'write:file': modify file in your account
+                'read:file': read your file
+            clientCredentials:
+              tokenUrl: >-
+                http://localhost:8080/proxy/auth/realms/default/protocol/openid-connect/token
+              scopes:
+                read: read all files
+                write: write to all files
+                admin: write to all files

--- a/install/local/resources/rover/kustomization.yaml
+++ b/install/local/resources/rover/kustomization.yaml
@@ -2,12 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-namespace: default--group-sample--team-sample # team namespace
+namespace: controlplane--phoenix--firebirds # team namespace
 
 labels:
   - includeSelectors: true
     pairs:
-      cp.ei.telekom.de/environment: default
+      cp.ei.telekom.de/environment: controlplane
       app.kubernetes.io/managed-by: kustomize
 
 resources:

--- a/install/local/resources/rover/rover.yaml
+++ b/install/local/resources/rover/rover.yaml
@@ -32,3 +32,14 @@ spec:
             scopes:
               - read
               - write
+---
+apiVersion: rover.cp.ei.telekom.de/v1
+kind: Rover
+metadata:
+  name: rover-echo-consumer
+spec:
+  zone: dataplane1
+  clientSecret: someSecret
+  subscriptions:
+    - api:
+        basePath: /phoenix/echo/v1

--- a/install/local/resources/rover/rover.yaml
+++ b/install/local/resources/rover/rover.yaml
@@ -5,18 +5,30 @@
 apiVersion: rover.cp.ei.telekom.de/v1
 kind: Rover
 metadata:
-  name: rover-sample
+  name: rover-echo-v1
 spec:
-  zone: zone-a
+  zone: dataplane1
+  clientSecret: someSecret
   exposures:
     - api:
-        basePath: /eni/foo/v2
-        upstream: https://httpbin.org/anything
+        basePath: /phoenix/echo/v1
+        upstreams:
+          - url: https://httpbin.org/anything
+            weight: 50
+          - url: https://httpbin.org/anything/balancing-the-load
+            weight: 50
         visibility: World
-        approval: Auto
+        approval:
+          strategy: Auto
+        security:
+          m2m:
+            scopes:
+              - read
   subscriptions:
     - api:
-        basePath: /eni/foo/v2
-        oauth2Scopes:
-          - read
-          - write
+        basePath: /phoenix/echo/v1
+        security:
+          m2m:
+            scopes:
+              - read
+              - write


### PR DESCRIPTION
- Add installation and quickstart guide for the controlplane in a local environment
- Update resources for admin, org and rover to install a sample in the local environment