### PR TITLE
docs: fix typo in installation guide

### DIFF
--- a/docs/files/installation.md
+++ b/docs/files/installation.md
@@ -146,5 +146,5 @@ can do:
     export ENABLE_WEBHOOKS=false # if applicable, disable webhooks
     go run cmd/main.go # start the controller process
     ```
-5. 🎉 Success: Your controllers should now run as a seperate process connected to the kind-cluster
+5. 🎉 Success: Your controllers should now run as a separate process connected to the kind-cluster
 


### PR DESCRIPTION
## Description
Fixed a spelling error in the installation documentation.

## Changes
- Fixed "seperate" to "separate" in `docs/files/installation.md`

## Type of Change
- [x] Documentation update
- [ ] Bug fix
- [ ] New feature
