### PR TITLE
fix(secret-manager): exit application on fatal error when init secret-manager; changed localhost default url; skip-tls-verify=true for localhost

### DIFF
--- a/secret-manager/api/api.go
+++ b/secret-manager/api/api.go
@@ -15,7 +15,8 @@ import (
 )
 
 const (
-	localhost = "http://localhost:9090/api"
+	// Using port-forward to the secret manager API in the cluster
+	localhost = "https://localhost:9090/api"
 	inCluster = "https://secret-manager.secret-manager-system.svc.cluster.local/api"
 	StartTag  = "$<"
 	EndTag    = ">"

--- a/secret-manager/api/global.go
+++ b/secret-manager/api/global.go
@@ -6,6 +6,7 @@ package api
 
 import (
 	"context"
+	"log"
 	"sync"
 
 	"github.com/go-logr/logr"
@@ -60,6 +61,10 @@ var API = func() SecretManager {
 		once.Do(func() {
 			api = New()
 		})
+
+		if api == nil {
+			log.Fatal("SecretManager API is not initialized.")
+		}
 	}
 	return api
 }

--- a/secret-manager/api/util/util.go
+++ b/secret-manager/api/util/util.go
@@ -10,6 +10,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
+	"log"
 	"net/http"
 	"os"
 	"time"
@@ -45,7 +46,7 @@ func NewHttpClientOrDie(skipTlsVerify bool, caFilepath string) client.HttpReques
 		certRefresher := NewCertRefresher(caFilepath)
 		err := certRefresher.Start(context.Background())
 		if err != nil {
-			panic(err)
+			log.Fatalf("Failed to start cert refresher: %v", err)
 		}
 		caPool = certRefresher.Pool
 	}
@@ -62,7 +63,7 @@ func NewHttpClientOrDie(skipTlsVerify bool, caFilepath string) client.HttpReques
 		var err error
 		timeout, err = time.ParseDuration(ClientTimeout)
 		if err != nil {
-			panic(errors.Wrap(err, "failed to parse CLIENT_TIMEOUT"))
+			log.Fatalf("Invalid CLIENT_TIMEOUT value: %v", err)
 		}
 	}
 


### PR DESCRIPTION
Secret-Manager API-Client is initialized just-in-time when the first secret is being resolved. However, this happens in the controller reconciler loop: Here kubebuilder automatically recovers from panics...
This is a problem because a failure to initialize the SM-Client cannot be recovered. Therefore, we need to exit(1).