### PR TITLE
fix(gateway): fixed bug where acl was not created; only consumers that are not being deleted are considered; removed obsolete code

### DIFF
--- a/gateway/pkg/kong/client/client.go
+++ b/gateway/pkg/kong/client/client.go
@@ -533,7 +533,7 @@ func (c *kongClient) addConsumerToGroup(ctx context.Context, consumerName string
 	if err != nil {
 		return err
 	}
-	if err := CheckStatusCode(response, 200); err != nil {
+	if err := CheckStatusCode(response, 200, 201); err != nil {
 		return fmt.Errorf("failed to add consumer to group (%d): %s", response.StatusCode(), string(response.Body))
 	}
 


### PR DESCRIPTION
- fix(route-handler): only consumeroutes which are not marked for deletion are considered for config
- fix(acl): acl-plugin was not created if route.Spec.Secrutiy was empty. This was a major bug
- fix(consumer-group): add consumer to group can also return 201
- fix(delete-consumeroute): removed obsolete code which is now handled by the feature-builder