### PR TITLE
ci: Update configuration of GitHub workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,27 +8,38 @@ updates:
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: weekly
+      interval: "monthly"
   - package-ecosystem: "gomod"
     schedule:
-      interval: "weekly"
-    directories: 
+      interval: "monthly"
+    directories:
+      - admin
+      - admin/api
+      - api
+      - api/api
+      - application
+      - application/api
+      - approval
+      - approval/api
       - common
       - common-server
-      - secret-manager
-      - organization
+      - cpapi/api
       - file-manager
       - gateway
+      - gateway/api
       - identity
-      - admin
-      - application
-      - api
+      - identity/api
+      - organization
+      - organization/api
       - rover
-      - approval
-      - rover-server
+      - rover/api
       - rover-ctl
+      - rover-server
+      - secret-manager
+      - tools/route-tester
+      - tools/snapshotter
     groups:
-      default: 
+      minor-patch:
         update-types:
           - patch
           - minor

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,9 +7,11 @@ name: Run CI
 on:
   workflow_dispatch:
   push:
-  pull_request:
     branches:
       - "main"
+    tags:
+      - 'v*'
+  pull_request:
   schedule:
     - cron: '0 0 * * *'  # Runs every day at midnight UTC
 

--- a/.github/workflows/docs-build.yaml
+++ b/.github/workflows/docs-build.yaml
@@ -6,8 +6,10 @@ name: Build Docs
 
 on:
   pull_request:
-    branches:
-      - main
+    paths:
+      - 'docs/**'
+      - '.github/workflows/docs-build.yml'
+      - '.github/workflows/docs-deploy.yml'
 
 jobs:
   build:

--- a/.github/workflows/docs-deploy.yaml
+++ b/.github/workflows/docs-deploy.yaml
@@ -9,7 +9,10 @@ on:
   push:
     branches:
       - main
-      - docs/pages
+    paths:
+      - 'docs/**'
+      - '.github/workflows/docs-build.yml'
+      - '.github/workflows/docs-deploy.yml'
 
 jobs:
   build:

--- a/.github/workflows/reusable-go-ci.yaml
+++ b/.github/workflows/reusable-go-ci.yaml
@@ -20,7 +20,7 @@ on:
         description: "Set to true to run unit tests and code coverage"
         required: false
         type: boolean
-        default: true
+        default: ${{ github.event_name == 'pull_request' || github.ref_name == 'main' }}
       allow_tests_failure:
         description: "Set to true to allow tests to fail without failing the job"
         required: false


### PR DESCRIPTION
Configuration changes:
- "Run CI" workflow only runs on 
  1. PRs
  2. push to main branch
  3. release tags
- "run_tests" job by default runs on
  1. PRs
  2. push to main branch
- Dependabot runs monthly on all modules grouped by minor-patch
- Documentation is built/deployed if there are changes in the docs folder or the github action for docs 