### PR TITLE
fix(ci): build image in PRs

### DIFF
--- a/.github/workflows/reusable-go-ci.yaml
+++ b/.github/workflows/reusable-go-ci.yaml
@@ -30,7 +30,7 @@ on:
         description: "Set to true to build the container image using Ko"
         required: false
         type: boolean
-        default: ${{ github.event_name == 'push' }}
+        default: ${{ github.event_name == 'pull_request' || github.ref_name == 'main' }}
       ko_build_path:
         description: "Path to the main package for ko build (e.g., cmd/main.go or ./cmd/server)"
         required: false


### PR DESCRIPTION
This pull request updates the default behavior for building container images in the GitHub Actions workflow. The change ensures that the container image is built both for pull requests and when changes are pushed to the `main` branch.

Workflow configuration update:

* [`.github/workflows/reusable-go-ci.yaml`](diffhunk://#diff-497db01179e35d15731a99752175d278a0ea8380bf3db2c494daa5a1e7b9d320L33-R33): Changed the default value for the `build_container_image` input to trigger builds on pull requests or when the branch is `main`, instead of only on push events.