### PR TITLE
feat(install): add PriorityClasses to schedule secret-manager before other operators

### DIFF
--- a/install/kustomization.yaml
+++ b/install/kustomization.yaml
@@ -7,6 +7,7 @@ namespace: controlplane-system
 resources:
   - namespace.yaml
   - issuer.yaml # currently this creates a self-signed issuer, in future this should be replaced by a proper issuer (e.g. ACME)
+  - priority-classes
   - https://github.com/telekom/controlplane//approval/config/default/?timeout=120&ref=v0.17.0
   - https://github.com/telekom/controlplane//secret-manager/config/default/?timeout=120&ref=v0.17.0
   - https://github.com/telekom/controlplane//rover/config/default/?timeout=120&ref=v0.17.0
@@ -18,6 +19,24 @@ resources:
   - https://github.com/telekom/controlplane//admin/config/default/?timeout=120&ref=v0.17.0
   - https://github.com/telekom/controlplane//rover-server/config/default/?timeout=120&ref=v0.17.0
   - https://github.com/telekom/controlplane//file-manager/config/default/?timeout=120&ref=v0.17.0
+
+patches:
+  # High priority: secret-manager is scheduled before all other operators
+  - target:
+      kind: Deployment
+      name: secret-manager
+    patch: |-
+      - op: add
+        path: /spec/template/spec/priorityClassName
+        value: controlplane-critical
+  # Default priority for all other operators
+  - target:
+      kind: Deployment
+      name: ".*controller-manager|file-manager|rover-server"
+    patch: |-
+      - op: add
+        path: /spec/template/spec/priorityClassName
+        value: controlplane-default
 
 images:
   - name: ghcr.io/telekom/controlplane/approval

--- a/install/local/kustomization.yaml
+++ b/install/local/kustomization.yaml
@@ -7,6 +7,7 @@ namespace: controlplane-system
 resources:
   - namespace.yaml
   - issuer.yaml
+  - ../priority-classes
   - ../../file-manager/config/default
   - ../../secret-manager/config/default
   - ../../identity/config/default
@@ -62,6 +63,22 @@ patches:
       - op: replace
         path: /spec/template/spec/containers/0/imagePullPolicy
         value: IfNotPresent
+  # High priority: secret-manager is scheduled before all other operators
+  - target:
+      kind: Deployment
+      name: secret-manager
+    patch: |-
+      - op: add
+        path: /spec/template/spec/priorityClassName
+        value: controlplane-critical
+  # Default priority for all other operators
+  - target:
+      kind: Deployment
+      name: ".*controller-manager|file-manager|rover-server"
+    patch: |-
+      - op: add
+        path: /spec/template/spec/priorityClassName
+        value: controlplane-default
 
 images:
   - name: ghcr.io/telekom/controlplane/approval

--- a/install/priority-classes/kustomization.yaml
+++ b/install/priority-classes/kustomization.yaml
@@ -1,0 +1,6 @@
+# Copyright 2025 Deutsche Telekom IT GmbH
+#
+# SPDX-License-Identifier: Apache-2.0
+
+resources:
+  - priority-classes.yaml

--- a/install/priority-classes/priority-classes.yaml
+++ b/install/priority-classes/priority-classes.yaml
@@ -1,0 +1,21 @@
+# Copyright 2025 Deutsche Telekom IT GmbH
+#
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: controlplane-critical
+value: 1000000
+globalDefault: false
+preemptionPolicy: PreemptLowerPriority
+description: "High priority for critical control plane infrastructure (e.g. secret-manager)"
+---
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: controlplane-default
+value: 100000
+globalDefault: false
+preemptionPolicy: PreemptLowerPriority
+description: "Default priority for control plane operators"

--- a/install/priority-classes/priority-classes.yaml
+++ b/install/priority-classes/priority-classes.yaml
@@ -17,5 +17,5 @@ metadata:
   name: controlplane-default
 value: 100000
 globalDefault: false
-preemptionPolicy: PreemptLowerPriority
+preemptionPolicy: Never
 description: "Default priority for control plane operators"


### PR DESCRIPTION
Introduce two Kubernetes PriorityClasses (controlplane-critical and
controlplane-default) and assign them via Kustomize patches so that the
secret-manager pod is scheduled with higher priority than all other
control plane operators. This ensures the secret-manager is started
first when resources are constrained.
