### PR TITLE
fix(rover-server): add fuzzy matcher for responseFilterMode

### DIFF
--- a/rover-server/internal/mapper/rover/in/exposure.go
+++ b/rover-server/internal/mapper/rover/in/exposure.go
@@ -249,7 +249,7 @@ func mapEventTrigger(in api.EventTrigger) *roverv1.EventTrigger {
 	if in.ResponseFilter != nil {
 		out.ResponseFilter = &roverv1.EventResponseFilter{
 			Paths: in.ResponseFilter,
-			Mode:  roverv1.EventResponseFilterMode(in.ResponseFilterMode),
+			Mode:  FuzzyMatchEventResponseFilterMode(string(in.ResponseFilterMode)),
 		}
 	}
 

--- a/rover-server/internal/mapper/rover/in/fuzzy_match.go
+++ b/rover-server/internal/mapper/rover/in/fuzzy_match.go
@@ -29,3 +29,15 @@ func FuzzyMatchEventPayloadType(in string) roverv1.EventPayloadType {
 		return roverv1.EventPayloadType(in)
 	}
 }
+
+// FuzzyMatchEventResponseFilterMode performs a fuzzy match on the input string to determine the EventResponseFilterMode.
+func FuzzyMatchEventResponseFilterMode(in string) roverv1.EventResponseFilterMode {
+	switch in {
+	case "include", "INCLUDE", "Include":
+		return roverv1.EventResponseFilterModeInclude
+	case "exclude", "EXCLUDE", "Exclude":
+		return roverv1.EventResponseFilterModeExclude
+	default:
+		return roverv1.EventResponseFilterMode(in)
+	}
+}

--- a/rover-server/internal/mapper/rover/in/fuzzy_match_test.go
+++ b/rover-server/internal/mapper/rover/in/fuzzy_match_test.go
@@ -46,3 +46,20 @@ var _ = DescribeTable("FuzzyMatchEventPayloadType",
 	Entry("unknown passthrough", "binary", roverv1.EventPayloadType("binary")),
 	Entry("empty passthrough", "", roverv1.EventPayloadType("")),
 )
+
+var _ = DescribeTable("FuzzyMatchEventResponseFilterMode",
+	func(input string, expected roverv1.EventResponseFilterMode) {
+		Expect(FuzzyMatchEventResponseFilterMode(input)).To(Equal(expected))
+	},
+	// Include variants
+	Entry("include", "include", roverv1.EventResponseFilterModeInclude),
+	Entry("INCLUDE", "INCLUDE", roverv1.EventResponseFilterModeInclude),
+	Entry("Include", "Include", roverv1.EventResponseFilterModeInclude),
+	// Exclude variants
+	Entry("exclude", "exclude", roverv1.EventResponseFilterModeExclude),
+	Entry("EXCLUDE", "EXCLUDE", roverv1.EventResponseFilterModeExclude),
+	Entry("Exclude", "Exclude", roverv1.EventResponseFilterModeExclude),
+	// Default passthrough
+	Entry("unknown passthrough", "filter", roverv1.EventResponseFilterMode("filter")),
+	Entry("empty passthrough", "", roverv1.EventResponseFilterMode("")),
+)

--- a/rover-server/internal/mapper/rover/in/subscription.go
+++ b/rover-server/internal/mapper/rover/in/subscription.go
@@ -161,7 +161,7 @@ func mapEventTriggerForSubscription(in api.EventTrigger) *roverv1.EventTrigger {
 	if in.ResponseFilter != nil {
 		out.ResponseFilter = &roverv1.EventResponseFilter{
 			Paths: in.ResponseFilter,
-			Mode:  roverv1.EventResponseFilterMode(in.ResponseFilterMode),
+			Mode:  FuzzyMatchEventResponseFilterMode(string(in.ResponseFilterMode)),
 		}
 	}
 


### PR DESCRIPTION
## Summary

- Adds `FuzzyMatchEventResponseFilterMode` to normalize `responseFilterMode` casing variants (`include`/`INCLUDE`/`Include`, `exclude`/`EXCLUDE`/`Exclude`) to the PascalCase values (`Include`/`Exclude`) expected by the CRD.
- Replaces the raw type cast in both `subscription.go` and `exposure.go` with the new fuzzy matcher, consistent with how `deliveryType` and `payloadType` are already handled.

## Problem

The rover-server OpenAPI spec defines `responseFilterMode` as lowercase (`include`/`exclude`), but the CRD (`EventResponseFilterMode`) only accepts PascalCase (`Include`/`Exclude`).

Unlike `deliveryType` and `payloadType` — which already have `FuzzyMatchEventDeliveryType` and `FuzzyMatchEventPayloadType` functions — `responseFilterMode` was mapped via a raw type cast:

```go
Mode: roverv1.EventResponseFilterMode(in.ResponseFilterMode)
```

This meant lowercase values from the API were passed through as-is, silently failing CRD validation.

## Changes

| File | Change |
|------|--------|
| `fuzzy_match.go` | Added `FuzzyMatchEventResponseFilterMode` function |
| `fuzzy_match_test.go` | Added 8 test cases (include/INCLUDE/Include, exclude/EXCLUDE/Exclude, unknown passthrough, empty passthrough) |
| `subscription.go` | Replaced raw cast with `FuzzyMatchEventResponseFilterMode(string(...))` |
| `exposure.go` | Same replacement |

## Testing

All 107 mapper specs pass (up from 99 — 8 new tests added).