### PR TITLE
chore(deps): Update go to version 1.25.9 (fix security issue)

### DIFF
--- a/admin/api/go.mod
+++ b/admin/api/go.mod
@@ -4,7 +4,7 @@
 
 module github.com/telekom/controlplane/admin/api
 
-go 1.25.8
+go 1.25.9
 
 require (
 	github.com/telekom/controlplane/common v0.0.0

--- a/admin/go.mod
+++ b/admin/go.mod
@@ -4,7 +4,7 @@
 
 module github.com/telekom/controlplane/admin
 
-go 1.25.8
+go 1.25.9
 
 require (
 	github.com/telekom/controlplane/admin/api v0.0.0

--- a/api/api/go.mod
+++ b/api/api/go.mod
@@ -4,7 +4,7 @@
 
 module github.com/telekom/controlplane/api/api
 
-go 1.25.8
+go 1.25.9
 
 require (
 	github.com/onsi/ginkgo/v2 v2.28.1

--- a/api/go.mod
+++ b/api/go.mod
@@ -4,7 +4,7 @@
 
 module github.com/telekom/controlplane/api
 
-go 1.25.8
+go 1.25.9
 
 require (
 	github.com/telekom/controlplane/admin/api v0.0.0

--- a/application/api/go.mod
+++ b/application/api/go.mod
@@ -4,7 +4,7 @@
 
 module github.com/telekom/controlplane/application/api
 
-go 1.25.8
+go 1.25.9
 
 require (
 	github.com/telekom/controlplane/common v0.0.0

--- a/application/go.mod
+++ b/application/go.mod
@@ -4,7 +4,7 @@
 
 module github.com/telekom/controlplane/application
 
-go 1.25.8
+go 1.25.9
 
 require (
 	github.com/telekom/controlplane/admin/api v0.0.0

--- a/approval/api/go.mod
+++ b/approval/api/go.mod
@@ -4,7 +4,7 @@
 
 module github.com/telekom/controlplane/approval/api
 
-go 1.25.8
+go 1.25.9
 
 require (
 	github.com/onsi/ginkgo/v2 v2.28.1

--- a/approval/go.mod
+++ b/approval/go.mod
@@ -4,7 +4,7 @@
 
 module github.com/telekom/controlplane/approval
 
-go 1.25.8
+go 1.25.9
 
 require (
 	github.com/telekom/controlplane/approval/api v0.0.0

--- a/common-server/go.mod
+++ b/common-server/go.mod
@@ -4,7 +4,7 @@
 
 module github.com/telekom/controlplane/common-server
 
-go 1.25.8
+go 1.25.9
 
 require github.com/telekom/controlplane/secret-manager v0.0.0
 

--- a/common/go.mod
+++ b/common/go.mod
@@ -4,7 +4,7 @@
 
 module github.com/telekom/controlplane/common
 
-go 1.25.8
+go 1.25.9
 
 require (
 	github.com/onsi/ginkgo/v2 v2.28.1

--- a/controlplane-api/go.mod
+++ b/controlplane-api/go.mod
@@ -4,7 +4,7 @@
 
 module github.com/telekom/controlplane/controlplane-api
 
-go 1.25.8
+go 1.25.9
 
 require (
 	entgo.io/contrib v0.7.0

--- a/cpapi/api/go.mod
+++ b/cpapi/api/go.mod
@@ -4,7 +4,7 @@
 
 module github/telekom/controplane/cpapi/api
 
-go 1.25.8
+go 1.25.9
 
 require (
 	github.com/oapi-codegen/runtime v1.3.1

--- a/discovery-server/go.mod
+++ b/discovery-server/go.mod
@@ -4,7 +4,7 @@
 
 module github.com/telekom/controlplane/discovery-server
 
-go 1.25.8
+go 1.25.9
 
 require (
 	github.com/telekom/controlplane/admin/api v0.0.0

--- a/docs/docs/developer-journey/creating-an-operator.md
+++ b/docs/docs/developer-journey/creating-an-operator.md
@@ -10,7 +10,7 @@ This guide walks you through scaffolding a new operator and wiring it into the f
 
 ## Prerequisites
 
-- **Go 1.25.8**
+- **go 1.25.9**
 - **Kubebuilder 4.9.0** — see the [installation instructions](https://book.kubebuilder.io/quick-start#installation)
 - **A working Control Plane installation** — see [Local Development](./local-development.md)
 - **Familiarity with the architecture** — review the [Architecture Overview](../architecture/overview.md) before continuing

--- a/event/api/go.mod
+++ b/event/api/go.mod
@@ -4,7 +4,7 @@
 
 module github.com/telekom/controlplane/event/api
 
-go 1.25.8
+go 1.25.9
 
 require (
 	github.com/onsi/ginkgo/v2 v2.28.1

--- a/event/go.mod
+++ b/event/go.mod
@@ -4,7 +4,7 @@
 
 module github.com/telekom/controlplane/event
 
-go 1.25.8
+go 1.25.9
 
 require (
 	github.com/telekom/controlplane/admin/api v0.0.0

--- a/file-manager/go.mod
+++ b/file-manager/go.mod
@@ -4,7 +4,7 @@
 
 module github.com/telekom/controlplane/file-manager
 
-go 1.25.8
+go 1.25.9
 
 require github.com/telekom/controlplane/common-server v0.0.0
 

--- a/gateway/api/go.mod
+++ b/gateway/api/go.mod
@@ -4,7 +4,7 @@
 
 module github.com/telekom/controlplane/gateway/api
 
-go 1.25.8
+go 1.25.9
 
 require (
 	github.com/telekom/controlplane/common v0.0.0

--- a/gateway/go.mod
+++ b/gateway/go.mod
@@ -4,7 +4,7 @@
 
 module github.com/telekom/controlplane/gateway
 
-go 1.25.8
+go 1.25.9
 
 require (
 	github.com/telekom/controlplane/common v0.0.0

--- a/identity/api/go.mod
+++ b/identity/api/go.mod
@@ -4,7 +4,7 @@
 
 module github.com/telekom/controlplane/identity/api
 
-go 1.25.8
+go 1.25.9
 
 require (
 	github.com/telekom/controlplane/common v0.0.0

--- a/identity/go.mod
+++ b/identity/go.mod
@@ -4,7 +4,7 @@
 
 module github.com/telekom/controlplane/identity
 
-go 1.25.8
+go 1.25.9
 
 require (
 	github.com/telekom/controlplane/common v0.0.0

--- a/notification/api/go.mod
+++ b/notification/api/go.mod
@@ -4,7 +4,7 @@
 
 module github.com/telekom/controlplane/notification/api
 
-go 1.25.8
+go 1.25.9
 
 require github.com/telekom/controlplane/common v0.0.0
 

--- a/notification/go.mod
+++ b/notification/go.mod
@@ -4,7 +4,7 @@
 
 module github.com/telekom/controlplane/notification
 
-go 1.25.8
+go 1.25.9
 
 require (
 	github.com/telekom/controlplane/common v0.0.0

--- a/organization/api/go.mod
+++ b/organization/api/go.mod
@@ -4,7 +4,7 @@
 
 module github.com/telekom/controlplane/organization/api
 
-go 1.25.8
+go 1.25.9
 
 require (
 	github.com/onsi/gomega v1.39.1

--- a/organization/go.mod
+++ b/organization/go.mod
@@ -4,7 +4,7 @@
 
 module github.com/telekom/controlplane/organization
 
-go 1.25.8
+go 1.25.9
 
 require (
 	github.com/telekom/controlplane/admin/api v0.0.0

--- a/projector/go.mod
+++ b/projector/go.mod
@@ -4,7 +4,7 @@
 
 module github.com/telekom/controlplane/projector
 
-go 1.25.8
+go 1.25.9
 
 require (
 	entgo.io/ent v0.14.5

--- a/pubsub/api/go.mod
+++ b/pubsub/api/go.mod
@@ -4,7 +4,7 @@
 
 module github.com/telekom/controlplane/pubsub/api
 
-go 1.25.8
+go 1.25.9
 
 require (
 	github.com/telekom/controlplane/common v0.0.0

--- a/pubsub/go.mod
+++ b/pubsub/go.mod
@@ -4,7 +4,7 @@
 
 module github.com/telekom/controlplane/pubsub
 
-go 1.25.8
+go 1.25.9
 
 require (
 	github.com/telekom/controlplane/common v0.0.0

--- a/rover-ctl/go.mod
+++ b/rover-ctl/go.mod
@@ -4,7 +4,7 @@
 
 module github.com/telekom/controlplane/rover-ctl
 
-go 1.25.8
+go 1.25.9
 
 require (
 	github.com/go-logr/logr v1.4.3

--- a/rover-server/go.mod
+++ b/rover-server/go.mod
@@ -4,7 +4,7 @@
 
 module github.com/telekom/controlplane/rover-server
 
-go 1.25.8
+go 1.25.9
 
 require (
 	github.com/telekom/controlplane/admin/api v0.0.0

--- a/rover/api/go.mod
+++ b/rover/api/go.mod
@@ -4,7 +4,7 @@
 
 module github.com/telekom/controlplane/rover/api
 
-go 1.25.8
+go 1.25.9
 
 require (
 	github.com/onsi/ginkgo/v2 v2.28.1

--- a/rover/go.mod
+++ b/rover/go.mod
@@ -4,7 +4,7 @@
 
 module github.com/telekom/controlplane/rover
 
-go 1.25.8
+go 1.25.9
 
 require (
 	github.com/telekom/controlplane/admin/api v0.0.0

--- a/secret-manager/go.mod
+++ b/secret-manager/go.mod
@@ -4,7 +4,7 @@
 
 module github.com/telekom/controlplane/secret-manager
 
-go 1.25.8
+go 1.25.9
 
 require github.com/telekom/controlplane/common-server v0.0.0
 

--- a/tools/e2e-tester/go.mod
+++ b/tools/e2e-tester/go.mod
@@ -4,7 +4,7 @@
 
 module github.com/telekom/controlplane/tools/e2e-tester
 
-go 1.25.8
+go 1.25.9
 
 require (
 	github.com/fatih/color v1.18.0

--- a/tools/route-tester/go.mod
+++ b/tools/route-tester/go.mod
@@ -4,7 +4,7 @@
 
 module github.com/telekom/controlplane/tools/route-tester
 
-go 1.25.8
+go 1.25.9
 
 require (
 	github.com/telekom/controlplane/application/api v0.0.0

--- a/tools/snapshotter/go.mod
+++ b/tools/snapshotter/go.mod
@@ -4,7 +4,7 @@
 
 module github.com/telekom/controlplane/tools/snapshotter
 
-go 1.25.8
+go 1.25.9
 
 require github.com/telekom/controlplane/gateway v0.0.0
 


### PR DESCRIPTION
Fix trivy security issue

│ Library │ Vulnerability  │ Severity │ Status │ Installed Version │ Fixed Version  │  
│ stdlib  │ CVE-2026-32280 │ HIGH     │ fixed  │ v1.25.8           │ 1.25.9, 1.26.2
