### PR TITLE
build: add linters and config for golangci-lint

### DIFF
--- a/.github/workflows/reusable-go-ci.yaml
+++ b/.github/workflows/reusable-go-ci.yaml
@@ -55,6 +55,11 @@ on:
         required: false
         type: boolean
         default: ${{ github.event_name == 'pull_request' || github.ref_name == 'main' }}
+      lint_fail_on_issues:
+        description: "Set to true to fail the build when golangci-lint finds issues"
+        required: false
+        type: boolean
+        default: false
       github_repository:
         description: "GitHub repository (owner/repo), e.g., github.repository. Required if run_build_image is true."
         required: false
@@ -128,7 +133,7 @@ jobs:
         with:
           version: v2.11
           working-directory: ${{ inputs.module }}
-          args: --timeout 5m --issues-exit-code=0 --config ../.golangci.yml 
+          args: --timeout 5m --issues-exit-code=${{ inputs.lint_fail_on_issues && '1' || '0' }} --config ../.golangci.yml
 
   tests:
     name: "Tests & Coverage for ${{ inputs.module }}"

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -5,17 +5,25 @@
 version: "2"
 run:
   allow-parallel-runners: true
+  modules-download-mode: readonly
+  relative-path-mode: gomod
 linters:
   default: none
   enable:
     - copyloopvar
     - dupl
     - errcheck
+    - errorlint
     - ginkgolinter
+    - goconst
+    - gocritic
     - gocyclo
+    - gosec
     - govet
     - ineffassign
     - misspell
+    - nestif
+    - nolintlint
     - prealloc
     - revive
     - staticcheck
@@ -23,22 +31,90 @@ linters:
     - unparam
     - unused
   settings:
+    errcheck:
+      check-type-assertions: true
+      check-blank: true
+    errorlint:
+      errorf: true
+      asserts: true
+      comparison: true
+    goconst:
+      numbers: true
+    gocritic:
+      disabled-checks:
+        - unnamedResult
+      enabled-tags:
+        - diagnostic
+        - style
+        - performance
+        - experimental
+        - opinionated
+    gocyclo:
+      min-complexity: 20
+    govet:
+      enable-all: true
+      disable:
+        - fieldalignment
+    nestif:
+      min-complexity: 5
+    nolintlint:
+      require-explanation: true
+      require-specific: true
     revive:
+      confidence: 0.8
       rules:
         - name: comment-spacings
+    staticcheck:
+      checks:
+        - all
+        - -ST1000
+        - -ST1020
+        - -ST1021
+        - -ST1003
+        - -ST1022
   exclusions:
     generated: lax
+    rules:
+      - linters:
+          - dupl
+          - gocyclo
+          - gosec
+          - goconst
+          - errcheck
+        path: _test\.go
     paths:
       - third_party$
       - builtin$
       - examples$
+issues:
+  max-issues-per-linter: 0
+  max-same-issues: 0
 formatters:
   enable:
     - gofmt
+    - gofumpt
     - goimports
+    - gci
+  settings:
+    gci:
+      sections:
+        - standard
+        - default
+        - prefix(github.com/telekom/controlplane/)
+        - blank
+        - dot
+      custom-order: true
+    gofumpt:
+      extra-rules: true
   exclusions:
     generated: lax
     paths:
       - third_party$
       - builtin$
       - examples$
+output:
+  sort-order:
+    - linter
+    - severity
+    - file
+  show-stats: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,6 +2,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+# Run `golangci-lint linters` to see all enabled/disabled linters with descriptions.
+
 version: "2"
 run:
   allow-parallel-runners: true


### PR DESCRIPTION
 ## Summary

Overhaul the golangci-lint configuration to add more linters, tune settings, and reduce noise — while keeping the whitelist (default: none + enable) approach for predictable CI behavior across upgrades.

### New linters

  - errorlint — catches incorrect error wrapping (%v instead of %w) and misuse of errors.Is/errors.As
  - goconst — flags repeated magic strings and numbers
  - gocritic — broad diagnostics, style, and performance checks (all tags enabled, unnamedResult disabled)
  - gosec — security-focused checks (relaxed in test files)
  - nestif — flags deeply nested conditionals, encourages early returns
  - nolintlint — ensures //nolint directives have an explanation and name the specific linter

 ### Linter settings

  - errcheck: now checks type assertions and blank assignments                                                                                                                                                                      
  - errorlint: all three modes enabled (errorf, asserts, comparison)
  - goconst: includes numbers                                                                                                                                                                                                       
  - gocyclo: complexity threshold lowered from 30 (default) to 20                                                                                                                                                                   
  - govet: all analyzers enabled except fieldalignment                                                                                                                                                                              
  - nestif: min complexity 5                                                                                                                                                                                                        
  - nolintlint: requires explanation and specific linter name                                                                                                                                                                       
  - revive: confidence threshold set to 0.8                                                                                                                                                                                         
  - staticcheck: all checks enabled except ST1000, ST1003, ST1020-1022 (package/export comment and naming convention checks)                                                                                                           
                                                                                                                                                                                                                                    
  ### Test file exclusions                                                                                                                                                                                                              
                                                                                                                                                                                                                                    
  dupl, gocyclo, gosec, goconst, and errcheck are excluded from _test.go files — test code is naturally more verbose and repetitive.                                                                                                
                  
 ### Formatters                                                                                                                                                                                                                        
                  
  - Added gofumpt (stricter gofmt) with extra rules                                                                                                                                                                                 
  - Added gci for consistent import grouping with github.com/telekom/controlplane/ as its own section
                                                                                                                                                                                                                                    
  ### Output & issues                                                                                                                                                                                                                   
                                                                                                                                                                                                                                    
  - Removed issue caps (max-issues-per-linter: 0, max-same-issues: 0) so all issues are reported                                                                                                                                    
  - Enabled show-stats and sorted output by linter, severity, file
                                                                                                                                                                                                                                    
  ### Run settings                                                                                                                                                                                                                      
                                                                                                                                                                                                                                    
  - Set modules-download-mode: readonly and relative-path-mode: gomod

### CI workflow
 - Add `lint_fail_on_issues` input to the reusable Go CI workflow (defaults to `false`)                                                                                                                                                                                                                          
  - When set to `true`, `golangci-lint` will fail the build if it finds any issues                                                                                                                                                                                                                                  
  - Allows modules that are already lint-clean to enforce no regressions, while other modules continue with non-blocking lint 