### PR TITLE
fix(admin): Fix golangci-lint issues

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -130,6 +130,7 @@ jobs:
       module: admin
       run_check_generated_files: true
       ko_build_path: "cmd/main.go"
+      lint_fail_on_issues: true
 
   application:
     name: Application

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -84,6 +84,11 @@ linters:
           - goconst
           - errcheck
         path: _test\.go
+      # GetEventRecorderFor is deprecated (SA1019) in favor of GetEventRecorder (events API).
+      # Migrating requires switching common pkg from record.EventRecorder to events.EventRecorder.
+      - linters:
+          - staticcheck
+        text: "SA1019: .*GetEventRecorderFor"
     paths:
       - third_party$
       - builtin$

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -119,6 +119,9 @@ formatters:
       - third_party$
       - builtin$
       - examples$
+      # Files with kubebuilder scaffold markers in import blocks (gci would strip them)
+      - cmd/main\.go
+      - suite_test\.go
 output:
   sort-order:
     - linter

--- a/admin/Makefile
+++ b/admin/Makefile
@@ -143,11 +143,6 @@ ENVTEST_VERSION ?= $(shell v='$(call gomodver,sigs.k8s.io/controller-runtime)'; 
   [ -n "$$v" ] || { echo "Set ENVTEST_VERSION manually (controller-runtime replace has no tag)" >&2; exit 1; }; \
   printf '%s\n' "$$v" | sed -E 's/^v?([0-9]+)\.([0-9]+).*/release-\1.\2/')
 
-#ENVTEST_K8S_VERSION is the version of Kubernetes to use for setting up ENVTEST binaries (i.e. 1.31)
-ENVTEST_K8S_VERSION ?= $(shell v='$(call gomodver,k8s.io/api)'; \
-  [ -n "$$v" ] || { echo "Set ENVTEST_K8S_VERSION manually (k8s.io/api replace has no tag)" >&2; exit 1; }; \
-  printf '%s\n' "$$v" | sed -E 's/^v?[0-9]+\.([0-9]+).*/1.\1/')
-
 GOLANGCI_LINT_VERSION ?= v2.11.4
 
 .PHONY: kustomize

--- a/admin/Makefile
+++ b/admin/Makefile
@@ -135,10 +135,20 @@ ENVTEST ?= $(LOCALBIN)/setup-envtest
 GOLANGCI_LINT = $(LOCALBIN)/golangci-lint
 
 ## Tool Versions
-KUSTOMIZE_VERSION ?= v5.4.3
+KUSTOMIZE_VERSION ?= v5.7.1
 CONTROLLER_TOOLS_VERSION ?= v0.20.1
-ENVTEST_VERSION ?= release-0.19
-GOLANGCI_LINT_VERSION ?= v2.11.2
+
+#ENVTEST_VERSION is the version of controller-runtime release branch to fetch the envtest setup script (i.e. release-0.20)
+ENVTEST_VERSION ?= $(shell v='$(call gomodver,sigs.k8s.io/controller-runtime)'; \
+  [ -n "$$v" ] || { echo "Set ENVTEST_VERSION manually (controller-runtime replace has no tag)" >&2; exit 1; }; \
+  printf '%s\n' "$$v" | sed -E 's/^v?([0-9]+)\.([0-9]+).*/release-\1.\2/')
+
+#ENVTEST_K8S_VERSION is the version of Kubernetes to use for setting up ENVTEST binaries (i.e. 1.31)
+ENVTEST_K8S_VERSION ?= $(shell v='$(call gomodver,k8s.io/api)'; \
+  [ -n "$$v" ] || { echo "Set ENVTEST_K8S_VERSION manually (k8s.io/api replace has no tag)" >&2; exit 1; }; \
+  printf '%s\n' "$$v" | sed -E 's/^v?[0-9]+\.([0-9]+).*/1.\1/')
+
+GOLANGCI_LINT_VERSION ?= v2.5.0
 
 .PHONY: kustomize
 kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary.
@@ -150,6 +160,14 @@ controller-gen: $(CONTROLLER_GEN) ## Download controller-gen locally if necessar
 $(CONTROLLER_GEN): $(LOCALBIN)
 	$(call go-install-tool,$(CONTROLLER_GEN),sigs.k8s.io/controller-tools/cmd/controller-gen,$(CONTROLLER_TOOLS_VERSION))
 
+.PHONY: setup-envtest
+setup-envtest: envtest ## Download the binaries required for ENVTEST in the local bin directory.
+	@echo "Setting up envtest binaries for Kubernetes version $(ENVTEST_K8S_VERSION)..."
+	@"$(ENVTEST)" use $(ENVTEST_K8S_VERSION) --bin-dir "$(LOCALBIN)" -p path || { \
+		echo "Error: Failed to set up envtest binaries for version $(ENVTEST_K8S_VERSION)."; \
+		exit 1; \
+	}
+
 .PHONY: envtest
 envtest: $(ENVTEST) ## Download setup-envtest locally if necessary.
 $(ENVTEST): $(LOCALBIN)
@@ -158,20 +176,24 @@ $(ENVTEST): $(LOCALBIN)
 .PHONY: golangci-lint
 golangci-lint: $(GOLANGCI_LINT) ## Download golangci-lint locally if necessary.
 $(GOLANGCI_LINT): $(LOCALBIN)
-	$(call go-install-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/cmd/golangci-lint,$(GOLANGCI_LINT_VERSION))
+	$(call go-install-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/v2/cmd/golangci-lint,$(GOLANGCI_LINT_VERSION))
 
 # go-install-tool will 'go install' any package with custom target and name of binary, if it doesn't exist
 # $1 - target path with name of binary
 # $2 - package url which can be installed
 # $3 - specific version of package
 define go-install-tool
-@[ -f "$(1)-$(3)" ] || { \
+@[ -f "$(1)-$(3)" ] && [ "$$(readlink -- "$(1)" 2>/dev/null)" = "$(1)-$(3)" ] || { \
 set -e; \
 package=$(2)@$(3) ;\
 echo "Downloading $${package}" ;\
-rm -f $(1) || true ;\
-GOBIN=$(LOCALBIN) go install $${package} ;\
-mv $(1) $(1)-$(3) ;\
+rm -f "$(1)" ;\
+GOBIN="$(LOCALBIN)" go install $${package} ;\
+mv "$(LOCALBIN)/$$(basename "$(1)")" "$(1)-$(3)" ;\
 } ;\
-ln -sf $(1)-$(3) $(1)
+ln -sf "$$(realpath "$(1)-$(3)")" "$(1)"
+endef
+
+define gomodver
+$(shell go list -m -f '{{if .Replace}}{{.Replace.Version}}{{else}}{{.Version}}{{end}}' $(1) 2>/dev/null)
 endef

--- a/admin/Makefile
+++ b/admin/Makefile
@@ -135,14 +135,9 @@ ENVTEST ?= $(LOCALBIN)/setup-envtest
 GOLANGCI_LINT = $(LOCALBIN)/golangci-lint
 
 ## Tool Versions
-KUSTOMIZE_VERSION ?= v5.7.1
+KUSTOMIZE_VERSION ?= v5.4.3
 CONTROLLER_TOOLS_VERSION ?= v0.20.1
-
-#ENVTEST_VERSION is the version of controller-runtime release branch to fetch the envtest setup script (i.e. release-0.20)
-ENVTEST_VERSION ?= $(shell v='$(call gomodver,sigs.k8s.io/controller-runtime)'; \
-  [ -n "$$v" ] || { echo "Set ENVTEST_VERSION manually (controller-runtime replace has no tag)" >&2; exit 1; }; \
-  printf '%s\n' "$$v" | sed -E 's/^v?([0-9]+)\.([0-9]+).*/release-\1.\2/')
-
+ENVTEST_VERSION ?= release-0.19
 GOLANGCI_LINT_VERSION ?= v2.11.4
 
 .PHONY: kustomize
@@ -154,14 +149,6 @@ $(KUSTOMIZE): $(LOCALBIN)
 controller-gen: $(CONTROLLER_GEN) ## Download controller-gen locally if necessary.
 $(CONTROLLER_GEN): $(LOCALBIN)
 	$(call go-install-tool,$(CONTROLLER_GEN),sigs.k8s.io/controller-tools/cmd/controller-gen,$(CONTROLLER_TOOLS_VERSION))
-
-.PHONY: setup-envtest
-setup-envtest: envtest ## Download the binaries required for ENVTEST in the local bin directory.
-	@echo "Setting up envtest binaries for Kubernetes version $(ENVTEST_K8S_VERSION)..."
-	@"$(ENVTEST)" use $(ENVTEST_K8S_VERSION) --bin-dir "$(LOCALBIN)" -p path || { \
-		echo "Error: Failed to set up envtest binaries for version $(ENVTEST_K8S_VERSION)."; \
-		exit 1; \
-	}
 
 .PHONY: envtest
 envtest: $(ENVTEST) ## Download setup-envtest locally if necessary.
@@ -178,17 +165,13 @@ $(GOLANGCI_LINT): $(LOCALBIN)
 # $2 - package url which can be installed
 # $3 - specific version of package
 define go-install-tool
-@[ -f "$(1)-$(3)" ] && [ "$$(readlink -- "$(1)" 2>/dev/null)" = "$(1)-$(3)" ] || { \
+@[ -f "$(1)-$(3)" ] || { \
 set -e; \
 package=$(2)@$(3) ;\
 echo "Downloading $${package}" ;\
-rm -f "$(1)" ;\
-GOBIN="$(LOCALBIN)" go install $${package} ;\
-mv "$(LOCALBIN)/$$(basename "$(1)")" "$(1)-$(3)" ;\
+rm -f $(1) || true ;\
+GOBIN=$(LOCALBIN) go install $${package} ;\
+mv $(1) $(1)-$(3) ;\
 } ;\
-ln -sf "$$(realpath "$(1)-$(3)")" "$(1)"
-endef
-
-define gomodver
-$(shell go list -m -f '{{if .Replace}}{{.Replace.Version}}{{else}}{{.Version}}{{end}}' $(1) 2>/dev/null)
+ln -sf $(1)-$(3) $(1)
 endef

--- a/admin/Makefile
+++ b/admin/Makefile
@@ -148,7 +148,7 @@ ENVTEST_K8S_VERSION ?= $(shell v='$(call gomodver,k8s.io/api)'; \
   [ -n "$$v" ] || { echo "Set ENVTEST_K8S_VERSION manually (k8s.io/api replace has no tag)" >&2; exit 1; }; \
   printf '%s\n' "$$v" | sed -E 's/^v?[0-9]+\.([0-9]+).*/1.\1/')
 
-GOLANGCI_LINT_VERSION ?= v2.5.0
+GOLANGCI_LINT_VERSION ?= v2.11.4
 
 .PHONY: kustomize
 kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary.

--- a/admin/cmd/main.go
+++ b/admin/cmd/main.go
@@ -22,11 +22,8 @@ import (
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
+	// +kubebuilder:scaffold:imports
 )
-
-// NOTE: the +kubebuilder:scaffold:imports marker was removed because gci (import formatting)
-// does not allow non-import comments inside the import block. If you need to scaffold new
-// CRD types with kubebuilder, re-add it as the last line inside the import parentheses.
 
 var (
 	scheme   = runtime.NewScheme()

--- a/admin/cmd/main.go
+++ b/admin/cmd/main.go
@@ -22,8 +22,11 @@ import (
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
-	// +kubebuilder:scaffold:imports
 )
+
+// NOTE: the +kubebuilder:scaffold:imports marker was removed because gci (import formatting)
+// does not allow non-import comments inside the import block. If you need to scaffold new
+// CRD types with kubebuilder, re-add it as the last line inside the import parentheses.
 
 var (
 	scheme   = runtime.NewScheme()

--- a/admin/cmd/main.go
+++ b/admin/cmd/main.go
@@ -9,10 +9,6 @@ import (
 	"flag"
 	"os"
 
-	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
-	// to ensure that exec-entrypoint and run can make use of them.
-	_ "k8s.io/client-go/plugin/pkg/client/auth"
-
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
@@ -22,6 +18,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
 	"github.com/telekom/controlplane/admin/internal/controller"
+
+	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
+	// to ensure that exec-entrypoint and run can make use of them.
+	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	// +kubebuilder:scaffold:imports
 )
 

--- a/admin/internal/controller/environment_controller.go
+++ b/admin/internal/controller/environment_controller.go
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+//nolint:dupl // kubebuilder controller scaffolding is structurally identical across CRD types
 package controller
 
 import (

--- a/admin/internal/controller/environment_controller.go
+++ b/admin/internal/controller/environment_controller.go
@@ -7,8 +7,6 @@ package controller
 import (
 	"context"
 
-	cconfig "github.com/telekom/controlplane/common/pkg/config"
-	cc "github.com/telekom/controlplane/common/pkg/controller"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -17,6 +15,8 @@ import (
 
 	adminv1 "github.com/telekom/controlplane/admin/api/v1"
 	environment_handler "github.com/telekom/controlplane/admin/internal/handler/environment"
+	cconfig "github.com/telekom/controlplane/common/pkg/config"
+	cc "github.com/telekom/controlplane/common/pkg/controller"
 )
 
 // EnvironmentReconciler reconciles a Environment object

--- a/admin/internal/controller/environment_controller_test.go
+++ b/admin/internal/controller/environment_controller_test.go
@@ -7,17 +7,17 @@ package controller
 import (
 	"context"
 
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
-	"github.com/telekom/controlplane/common/pkg/condition"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	adminv1 "github.com/telekom/controlplane/admin/api/v1"
+	"github.com/telekom/controlplane/common/pkg/condition"
 	"github.com/telekom/controlplane/common/pkg/config"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("Environment Controller", func() {

--- a/admin/internal/controller/remoteorganization_controller.go
+++ b/admin/internal/controller/remoteorganization_controller.go
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+//nolint:dupl // kubebuilder controller scaffolding is structurally identical across CRD types
 package controller
 
 import (

--- a/admin/internal/controller/remoteorganization_controller.go
+++ b/admin/internal/controller/remoteorganization_controller.go
@@ -7,8 +7,6 @@ package controller
 import (
 	"context"
 
-	cconfig "github.com/telekom/controlplane/common/pkg/config"
-	cc "github.com/telekom/controlplane/common/pkg/controller"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -17,6 +15,8 @@ import (
 
 	adminv1 "github.com/telekom/controlplane/admin/api/v1"
 	remoteorg_handler "github.com/telekom/controlplane/admin/internal/handler/remoteorganization"
+	cconfig "github.com/telekom/controlplane/common/pkg/config"
+	cc "github.com/telekom/controlplane/common/pkg/controller"
 )
 
 // RemoteOrganizationReconciler reconciles a RemoteOrganization object

--- a/admin/internal/controller/remoteorganization_controller_test.go
+++ b/admin/internal/controller/remoteorganization_controller_test.go
@@ -7,20 +7,18 @@ package controller
 import (
 	"context"
 
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	adminv1 "github.com/telekom/controlplane/admin/api/v1"
 	"github.com/telekom/controlplane/common/pkg/condition"
+	"github.com/telekom/controlplane/common/pkg/config"
+	"github.com/telekom/controlplane/common/pkg/types"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/api/meta"
-
-	"sigs.k8s.io/controller-runtime/pkg/client"
-
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	adminv1 "github.com/telekom/controlplane/admin/api/v1"
-	"github.com/telekom/controlplane/common/pkg/config"
-	"github.com/telekom/controlplane/common/pkg/types"
 )
 
 var _ = Describe("RemoteOrganization Controller", func() {
@@ -75,7 +73,6 @@ var _ = Describe("RemoteOrganization Controller", func() {
 
 				expectedNamespaceName := "test--test-id"
 				VerifyNamespace(ctx, g, expectedNamespaceName)
-
 			}, timeout, interval).Should(Succeed())
 		})
 	})

--- a/admin/internal/controller/schema.go
+++ b/admin/internal/controller/schema.go
@@ -5,12 +5,13 @@
 package controller
 
 import (
-	adminv1 "github.com/telekom/controlplane/admin/api/v1"
-	gatewayv1 "github.com/telekom/controlplane/gateway/api/v1"
-	identityv1 "github.com/telekom/controlplane/identity/api/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+
+	adminv1 "github.com/telekom/controlplane/admin/api/v1"
+	gatewayv1 "github.com/telekom/controlplane/gateway/api/v1"
+	identityv1 "github.com/telekom/controlplane/identity/api/v1"
 )
 
 func RegisterSchemesOrDie(scheme *runtime.Scheme) {

--- a/admin/internal/controller/suite_test.go
+++ b/admin/internal/controller/suite_test.go
@@ -13,9 +13,6 @@ import (
 	"testing"
 	"time"
 
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
-
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -26,7 +23,9 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
-	// +kubebuilder:scaffold:imports
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 )
 
 // These tests use Ginkgo (BDD-style Go testing framework). Refer to
@@ -39,11 +38,13 @@ const (
 	testEnvironment = "test"
 )
 
-var cfg *rest.Config
-var k8sClient client.Client
-var testEnv *envtest.Environment
-var ctx context.Context
-var cancel context.CancelFunc
+var (
+	cfg       *rest.Config
+	k8sClient client.Client
+	testEnv   *envtest.Environment
+	ctx       context.Context
+	cancel    context.CancelFunc
+)
 
 func TestControllers(t *testing.T) {
 	RegisterFailHandler(Fail)

--- a/admin/internal/controller/suite_test.go
+++ b/admin/internal/controller/suite_test.go
@@ -26,6 +26,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	// +kubebuilder:scaffold:imports
 )
 
 // These tests use Ginkgo (BDD-style Go testing framework). Refer to

--- a/admin/internal/controller/zone_controller.go
+++ b/admin/internal/controller/zone_controller.go
@@ -7,8 +7,7 @@ package controller
 import (
 	"context"
 
-	cconfig "github.com/telekom/controlplane/common/pkg/config"
-	cc "github.com/telekom/controlplane/common/pkg/controller"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -21,7 +20,8 @@ import (
 
 	adminv1 "github.com/telekom/controlplane/admin/api/v1"
 	zone_handler "github.com/telekom/controlplane/admin/internal/handler/zone"
-	corev1 "k8s.io/api/core/v1"
+	cconfig "github.com/telekom/controlplane/common/pkg/config"
+	cc "github.com/telekom/controlplane/common/pkg/controller"
 )
 
 // ZoneReconciler reconciles a Zone object

--- a/admin/internal/controller/zone_controller.go
+++ b/admin/internal/controller/zone_controller.go
@@ -86,8 +86,8 @@ func (r *ZoneReconciler) mapEnvironmentToZone(ctx context.Context, obj client.Ob
 	}
 
 	requests := make([]reconcile.Request, 0, len(list.Items))
-	for _, zone := range list.Items {
-		requests = append(requests, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(&zone)})
+	for i := range list.Items {
+		requests = append(requests, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(&list.Items[i])})
 	}
 
 	return requests

--- a/admin/internal/controller/zone_controller_test.go
+++ b/admin/internal/controller/zone_controller_test.go
@@ -7,24 +7,23 @@ package controller
 import (
 	"context"
 
-	gatewayapi "github.com/telekom/controlplane/gateway/api/v1"
-
-	"github.com/telekom/controlplane/common/pkg/types"
-	identityapi "github.com/telekom/controlplane/identity/api/v1"
-
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	adminv1 "github.com/telekom/controlplane/admin/api/v1"
 	"github.com/telekom/controlplane/common/pkg/condition"
 	"github.com/telekom/controlplane/common/pkg/config"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"github.com/telekom/controlplane/common/pkg/types"
+	gatewayapi "github.com/telekom/controlplane/gateway/api/v1"
+	identityapi "github.com/telekom/controlplane/identity/api/v1"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 )
 
-func NewZone(name string, namespace string) *adminv1.Zone {
+func NewZone(name, namespace string) *adminv1.Zone {
 	idpAdminUrl := "https://test-iris.de/auth/admin/realms"
 	gatewayAdminUrl := "https://test-stargate.de/admin-api"
 
@@ -128,7 +127,6 @@ var _ = Describe("Zone Controller", func() {
 
 				expectedNamespaceName := "test--test-zone"
 				VerifyNamespace(ctx, g, expectedNamespaceName)
-
 			}, timeout, interval).Should(Succeed())
 		})
 	})

--- a/admin/internal/handler/remoteorganization/handler.go
+++ b/admin/internal/handler/remoteorganization/handler.go
@@ -10,14 +10,15 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	adminv1 "github.com/telekom/controlplane/admin/api/v1"
 	cclient "github.com/telekom/controlplane/common/pkg/client"
 	"github.com/telekom/controlplane/common/pkg/condition"
 	"github.com/telekom/controlplane/common/pkg/config"
 	"github.com/telekom/controlplane/common/pkg/util/contextutil"
-	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 type RemoteOrganizationHandler struct{}

--- a/admin/internal/handler/util/urls/urls.go
+++ b/admin/internal/handler/util/urls/urls.go
@@ -13,11 +13,11 @@ import (
 	adminv1 "github.com/telekom/controlplane/admin/api/v1"
 )
 
-func ensureSuffix(url string) string {
-	if !strings.HasSuffix(url, "/") {
-		return url + "/"
+func ensureSuffix(rawURL string) string {
+	if !strings.HasSuffix(rawURL, "/") {
+		return rawURL + "/"
 	}
-	return url
+	return rawURL
 }
 
 func ForIdentityProviderAdminUrl(baseUrl string) string {

--- a/admin/internal/handler/util/urls/urls.go
+++ b/admin/internal/handler/util/urls/urls.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
+
 	adminv1 "github.com/telekom/controlplane/admin/api/v1"
 )
 
@@ -28,7 +29,6 @@ func ForIdentityProviderAdminUrl(baseUrl string) string {
 func ForGatewayAdminUrl(baseUrl string) string {
 	adminUrl := ensureSuffix(baseUrl)
 	return adminUrl + "admin-api"
-
 }
 
 func ForGatewayAdminIssuerUrl(baseUrl string) string {
@@ -37,7 +37,7 @@ func ForGatewayAdminIssuerUrl(baseUrl string) string {
 	return adminIssuerUrl + "auth/realms/rover"
 }
 
-func ForGatewayRealm(identityProviderBaseUrl string, realmName string) string {
+func ForGatewayRealm(identityProviderBaseUrl, realmName string) string {
 	realmIssuerUrl := ensureSuffix(identityProviderBaseUrl)
 
 	return realmIssuerUrl + "auth/realms/" + realmName
@@ -51,6 +51,6 @@ func ForRouteDownstream(gatewayBaseUrl string, config adminv1.ApiConfig) (*url.U
 	return url.Parse(raw)
 }
 
-func ForStargateLmsIssuer(gatewayBaseUrl string, realmName string) string {
+func ForStargateLmsIssuer(gatewayBaseUrl, realmName string) string {
 	return strings.TrimSuffix(gatewayBaseUrl, "/") + ":443" + "/auth/realms/" + realmName
 }

--- a/admin/internal/handler/zone/handler.go
+++ b/admin/internal/handler/zone/handler.go
@@ -11,25 +11,24 @@ import (
 	"strings"
 
 	"github.com/google/uuid"
+	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	adminv1 "github.com/telekom/controlplane/admin/api/v1"
 	"github.com/telekom/controlplane/admin/internal/handler/util/naming"
 	"github.com/telekom/controlplane/admin/internal/handler/util/urls"
-	"github.com/telekom/controlplane/common/pkg/types"
-	"github.com/telekom/controlplane/common/pkg/util/labelutil"
-
-	"github.com/pkg/errors"
-	adminv1 "github.com/telekom/controlplane/admin/api/v1"
 	cclient "github.com/telekom/controlplane/common/pkg/client"
 	"github.com/telekom/controlplane/common/pkg/condition"
 	"github.com/telekom/controlplane/common/pkg/config"
 	cconfig "github.com/telekom/controlplane/common/pkg/config"
 	"github.com/telekom/controlplane/common/pkg/handler"
+	"github.com/telekom/controlplane/common/pkg/types"
 	"github.com/telekom/controlplane/common/pkg/util/contextutil"
+	"github.com/telekom/controlplane/common/pkg/util/labelutil"
 	gatewayapi "github.com/telekom/controlplane/gateway/api/v1"
 	identityapi "github.com/telekom/controlplane/identity/api/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-
-	corev1 "k8s.io/api/core/v1"
 )
 
 const (
@@ -349,7 +348,6 @@ func createGateway(ctx context.Context, handlingContext HandlingContext) (*gatew
 		return nil, errors.Wrapf(err, "failed to create or update Gateway: %s in zone: %s", gateway.Name, handlingContext.Zone.Name)
 	}
 	return gateway, nil
-
 }
 
 func createIdentityClient(ctx context.Context, handlingContext HandlingContext, identityRealm *identityapi.Realm) (*identityapi.Client, error) {

--- a/admin/internal/handler/zone/handler.go
+++ b/admin/internal/handler/zone/handler.go
@@ -130,33 +130,9 @@ func (h *ZoneHandler) CreateOrUpdate(ctx context.Context, obj *adminv1.Zone) err
 
 	// Team apis configuration
 	if obj.Spec.TeamApis != nil {
-		// Team apis identity realm
-		teamApiIdentityRealm, err := createIdentityRealm(ctx, handlingContext, identityProvider, naming.ForTeamApiIdentityRealm(handlingContext.Environment))
-		if err != nil {
+		if err := reconcileTeamApis(ctx, obj, handlingContext, identityProvider, gateway); err != nil {
 			return err
 		}
-		obj.Status.TeamApiIdentityRealm = types.ObjectRefFromObject(teamApiIdentityRealm)
-
-		// Team apis gateway realm
-		teamApisGatewayRealm, err := createGatewayRealm(ctx, handlingContext, gateway, naming.ForTeamApiGatewayRealm(handlingContext.Environment))
-		if err != nil {
-			return err
-		}
-		obj.Status.TeamApiGatewayRealm = types.ObjectRefFromObject(teamApisGatewayRealm)
-		if len(teamApisGatewayRealm.Spec.IssuerUrls) > 0 {
-			obj.Status.Links.TeamIssuer = teamApisGatewayRealm.Spec.IssuerUrls[0]
-		}
-
-		// Team api routes
-		var teamApiRouteRefs []types.ObjectRef
-		for _, teamApiRoute := range obj.Spec.TeamApis.Apis {
-			route, err := createTeamApiRoute(ctx, handlingContext, teamApiRoute, *teamApisGatewayRealm)
-			if err != nil {
-				return err
-			}
-			teamApiRouteRefs = append(teamApiRouteRefs, *types.ObjectRefFromObject(route))
-		}
-		obj.Status.TeamApiRoutes = teamApiRouteRefs
 	} else {
 		obj.Status.TeamApiIdentityRealm = nil
 		obj.Status.TeamApiGatewayRealm = nil
@@ -182,7 +158,35 @@ func (h *ZoneHandler) CreateOrUpdate(ctx context.Context, obj *adminv1.Zone) err
 	return nil
 }
 
-func createTeamApiRoute(ctx context.Context, handlingContext HandlingContext, teamRouteConfig adminv1.ApiConfig, gatewayRealm gatewayapi.Realm) (*gatewayapi.Route, error) {
+func reconcileTeamApis(ctx context.Context, obj *adminv1.Zone, handlingContext HandlingContext, identityProvider *identityapi.IdentityProvider, gateway *gatewayapi.Gateway) error {
+	teamApiIdentityRealm, err := createIdentityRealm(ctx, handlingContext, identityProvider, naming.ForTeamApiIdentityRealm(handlingContext.Environment))
+	if err != nil {
+		return err
+	}
+	obj.Status.TeamApiIdentityRealm = types.ObjectRefFromObject(teamApiIdentityRealm)
+
+	teamApisGatewayRealm, err := createGatewayRealm(ctx, handlingContext, gateway, naming.ForTeamApiGatewayRealm(handlingContext.Environment))
+	if err != nil {
+		return err
+	}
+	obj.Status.TeamApiGatewayRealm = types.ObjectRefFromObject(teamApisGatewayRealm)
+	if len(teamApisGatewayRealm.Spec.IssuerUrls) > 0 {
+		obj.Status.Links.TeamIssuer = teamApisGatewayRealm.Spec.IssuerUrls[0]
+	}
+
+	teamApiRouteRefs := make([]types.ObjectRef, 0, len(obj.Spec.TeamApis.Apis))
+	for _, teamApiRoute := range obj.Spec.TeamApis.Apis {
+		route, err := createTeamApiRoute(ctx, handlingContext, teamApiRoute, teamApisGatewayRealm)
+		if err != nil {
+			return err
+		}
+		teamApiRouteRefs = append(teamApiRouteRefs, *types.ObjectRefFromObject(route))
+	}
+	obj.Status.TeamApiRoutes = teamApiRouteRefs
+	return nil
+}
+
+func createTeamApiRoute(ctx context.Context, handlingContext HandlingContext, teamRouteConfig adminv1.ApiConfig, gatewayRealm *gatewayapi.Realm) (*gatewayapi.Route, error) {
 	scopedClient := cclient.ClientFromContextOrDie(ctx)
 	teamRoute := &gatewayapi.Route{
 		ObjectMeta: metav1.ObjectMeta{
@@ -224,7 +228,7 @@ func createTeamApiRoute(ctx context.Context, handlingContext HandlingContext, te
 		}
 
 		teamRoute.Spec = gatewayapi.RouteSpec{
-			Realm:       *types.ObjectRefFromObject(&gatewayRealm),
+			Realm:       *types.ObjectRefFromObject(gatewayRealm),
 			PassThrough: false,
 			Upstreams:   []gatewayapi.Upstream{upstream},
 			Downstreams: []gatewayapi.Downstream{downstream},

--- a/admin/internal/handler/zone/handler.go
+++ b/admin/internal/handler/zone/handler.go
@@ -21,7 +21,7 @@ import (
 	"github.com/telekom/controlplane/admin/internal/handler/util/urls"
 	cclient "github.com/telekom/controlplane/common/pkg/client"
 	"github.com/telekom/controlplane/common/pkg/condition"
-	"github.com/telekom/controlplane/common/pkg/config"
+	cconfig "github.com/telekom/controlplane/common/pkg/config"
 	"github.com/telekom/controlplane/common/pkg/handler"
 	"github.com/telekom/controlplane/common/pkg/types"
 	"github.com/telekom/controlplane/common/pkg/util/contextutil"
@@ -57,8 +57,8 @@ func (h *ZoneHandler) CreateOrUpdate(ctx context.Context, obj *adminv1.Zone) err
 
 	mutator := func() error {
 		namespace.Labels = map[string]string{
-			config.EnvironmentLabelKey:          environment.Name,
-			config.BuildLabelKey(zoneLabelName): obj.Name,
+			cconfig.EnvironmentLabelKey:          environment.Name,
+			cconfig.BuildLabelKey(zoneLabelName): obj.Name,
 		}
 		return nil
 	}
@@ -129,7 +129,7 @@ func (h *ZoneHandler) CreateOrUpdate(ctx context.Context, obj *adminv1.Zone) err
 
 	// Team apis configuration
 	if obj.Spec.TeamApis != nil {
-		if err := reconcileTeamApis(ctx, obj, handlingContext, identityProvider, gateway); err != nil {
+		if err := reconcileTeamApis(ctx, handlingContext, obj, identityProvider, gateway); err != nil {
 			return err
 		}
 	} else {
@@ -140,7 +140,7 @@ func (h *ZoneHandler) CreateOrUpdate(ctx context.Context, obj *adminv1.Zone) err
 	}
 
 	// Populate Permissions URL if configured and feature enabled
-	if config.FeaturePermission.IsEnabled() && obj.Spec.Permissions != nil {
+	if cconfig.FeaturePermission.IsEnabled() && obj.Spec.Permissions != nil {
 		// Use url.JoinPath to properly handle slashes when combining gateway URL with ApiBasePath
 		permissionsUrl, err := url.JoinPath(obj.Status.Links.Url, obj.Spec.Permissions.ApiBasePath)
 		if err != nil {
@@ -157,31 +157,31 @@ func (h *ZoneHandler) CreateOrUpdate(ctx context.Context, obj *adminv1.Zone) err
 	return nil
 }
 
-func reconcileTeamApis(ctx context.Context, obj *adminv1.Zone, handlingContext HandlingContext, identityProvider *identityapi.IdentityProvider, gateway *gatewayapi.Gateway) error {
+func reconcileTeamApis(ctx context.Context, handlingContext HandlingContext, zone *adminv1.Zone, identityProvider *identityapi.IdentityProvider, gateway *gatewayapi.Gateway) error {
 	teamApiIdentityRealm, err := createIdentityRealm(ctx, handlingContext, identityProvider, naming.ForTeamApiIdentityRealm(handlingContext.Environment))
 	if err != nil {
 		return err
 	}
-	obj.Status.TeamApiIdentityRealm = types.ObjectRefFromObject(teamApiIdentityRealm)
+	zone.Status.TeamApiIdentityRealm = types.ObjectRefFromObject(teamApiIdentityRealm)
 
 	teamApisGatewayRealm, err := createGatewayRealm(ctx, handlingContext, gateway, naming.ForTeamApiGatewayRealm(handlingContext.Environment))
 	if err != nil {
 		return err
 	}
-	obj.Status.TeamApiGatewayRealm = types.ObjectRefFromObject(teamApisGatewayRealm)
+	zone.Status.TeamApiGatewayRealm = types.ObjectRefFromObject(teamApisGatewayRealm)
 	if len(teamApisGatewayRealm.Spec.IssuerUrls) > 0 {
-		obj.Status.Links.TeamIssuer = teamApisGatewayRealm.Spec.IssuerUrls[0]
+		zone.Status.Links.TeamIssuer = teamApisGatewayRealm.Spec.IssuerUrls[0]
 	}
 
-	teamApiRouteRefs := make([]types.ObjectRef, 0, len(obj.Spec.TeamApis.Apis))
-	for _, teamApiRoute := range obj.Spec.TeamApis.Apis {
+	teamApiRouteRefs := make([]types.ObjectRef, 0, len(zone.Spec.TeamApis.Apis))
+	for _, teamApiRoute := range zone.Spec.TeamApis.Apis {
 		route, err := createTeamApiRoute(ctx, handlingContext, teamApiRoute, teamApisGatewayRealm)
 		if err != nil {
 			return err
 		}
 		teamApiRouteRefs = append(teamApiRouteRefs, *types.ObjectRefFromObject(route))
 	}
-	obj.Status.TeamApiRoutes = teamApiRouteRefs
+	zone.Status.TeamApiRoutes = teamApiRouteRefs
 	return nil
 }
 
@@ -196,8 +196,8 @@ func createTeamApiRoute(ctx context.Context, handlingContext HandlingContext, te
 
 	mutator := func() error {
 		teamRoute.Labels = map[string]string{
-			config.EnvironmentLabelKey:          handlingContext.Environment.Name,
-			config.BuildLabelKey(zoneLabelName): handlingContext.Zone.Name,
+			cconfig.EnvironmentLabelKey:          handlingContext.Environment.Name,
+			cconfig.BuildLabelKey(zoneLabelName): handlingContext.Zone.Name,
 		}
 
 		upstreamUrl, err := url.Parse(teamRouteConfig.Url)
@@ -258,8 +258,8 @@ func createGatewayConsumer(ctx context.Context, handlingContext HandlingContext,
 
 	mutator := func() error {
 		gatewayConsumer.Labels = map[string]string{
-			config.EnvironmentLabelKey:          handlingContext.Environment.Name,
-			config.BuildLabelKey(zoneLabelName): handlingContext.Zone.Name,
+			cconfig.EnvironmentLabelKey:          handlingContext.Environment.Name,
+			cconfig.BuildLabelKey(zoneLabelName): handlingContext.Zone.Name,
 		}
 
 		gatewayConsumer.Spec = gatewayapi.ConsumerSpec{
@@ -287,8 +287,8 @@ func createGatewayRealm(ctx context.Context, handlingContext HandlingContext, ga
 
 	mutator := func() error {
 		gatewayRealm.Labels = map[string]string{
-			config.EnvironmentLabelKey:          handlingContext.Environment.Name,
-			config.BuildLabelKey(zoneLabelName): handlingContext.Zone.Name,
+			cconfig.EnvironmentLabelKey:          handlingContext.Environment.Name,
+			cconfig.BuildLabelKey(zoneLabelName): handlingContext.Zone.Name,
 		}
 
 		gatewayRealm.Spec = gatewayapi.RealmSpec{
@@ -318,8 +318,8 @@ func createGateway(ctx context.Context, handlingContext HandlingContext) (*gatew
 
 	mutator := func() error {
 		gateway.Labels = map[string]string{
-			config.EnvironmentLabelKey:          handlingContext.Environment.Name,
-			config.BuildLabelKey(zoneLabelName): handlingContext.Zone.Name,
+			cconfig.EnvironmentLabelKey:          handlingContext.Environment.Name,
+			cconfig.BuildLabelKey(zoneLabelName): handlingContext.Zone.Name,
 		}
 
 		var adminUrl string
@@ -365,8 +365,8 @@ func createIdentityClient(ctx context.Context, handlingContext HandlingContext, 
 
 	mutator := func() error {
 		identityClient.Labels = map[string]string{
-			config.EnvironmentLabelKey:          handlingContext.Environment.Name,
-			config.BuildLabelKey(zoneLabelName): handlingContext.Zone.Name,
+			cconfig.EnvironmentLabelKey:          handlingContext.Environment.Name,
+			cconfig.BuildLabelKey(zoneLabelName): handlingContext.Zone.Name,
 		}
 
 		var clientSecret string
@@ -415,8 +415,8 @@ func createIdentityRealm(ctx context.Context, handlingContext HandlingContext, i
 
 	mutator := func() error {
 		identityRealm.Labels = map[string]string{
-			config.EnvironmentLabelKey:          handlingContext.Environment.Name,
-			config.BuildLabelKey(zoneLabelName): handlingContext.Zone.Name,
+			cconfig.EnvironmentLabelKey:          handlingContext.Environment.Name,
+			cconfig.BuildLabelKey(zoneLabelName): handlingContext.Zone.Name,
 		}
 
 		identityRealm.Spec = identityapi.RealmSpec{
@@ -446,8 +446,8 @@ func createIdentityProvider(ctx context.Context, handlingContext HandlingContext
 
 	mutator := func() error {
 		identityProvider.Labels = map[string]string{
-			config.EnvironmentLabelKey:          handlingContext.Environment.Name,
-			config.BuildLabelKey(zoneLabelName): handlingContext.Zone.Name,
+			cconfig.EnvironmentLabelKey:          handlingContext.Environment.Name,
+			cconfig.BuildLabelKey(zoneLabelName): handlingContext.Zone.Name,
 		}
 
 		var adminUrl string

--- a/admin/internal/handler/zone/handler.go
+++ b/admin/internal/handler/zone/handler.go
@@ -22,7 +22,6 @@ import (
 	cclient "github.com/telekom/controlplane/common/pkg/client"
 	"github.com/telekom/controlplane/common/pkg/condition"
 	"github.com/telekom/controlplane/common/pkg/config"
-	cconfig "github.com/telekom/controlplane/common/pkg/config"
 	"github.com/telekom/controlplane/common/pkg/handler"
 	"github.com/telekom/controlplane/common/pkg/types"
 	"github.com/telekom/controlplane/common/pkg/util/contextutil"
@@ -141,7 +140,7 @@ func (h *ZoneHandler) CreateOrUpdate(ctx context.Context, obj *adminv1.Zone) err
 	}
 
 	// Populate Permissions URL if configured and feature enabled
-	if cconfig.FeaturePermission.IsEnabled() && obj.Spec.Permissions != nil {
+	if config.FeaturePermission.IsEnabled() && obj.Spec.Permissions != nil {
 		// Use url.JoinPath to properly handle slashes when combining gateway URL with ApiBasePath
 		permissionsUrl, err := url.JoinPath(obj.Status.Links.Url, obj.Spec.Permissions.ApiBasePath)
 		if err != nil {

--- a/admin/internal/handler/zone/handlingContext.go
+++ b/admin/internal/handler/zone/handlingContext.go
@@ -5,8 +5,9 @@
 package zone
 
 import (
-	adminv1 "github.com/telekom/controlplane/admin/api/v1"
 	corev1 "k8s.io/api/core/v1"
+
+	adminv1 "github.com/telekom/controlplane/admin/api/v1"
 )
 
 type HandlingContext struct {


### PR DESCRIPTION
 ## Update Makefile
 Update tool versions and golangci-lint target in Makefile.

 ## Autofixes for `admin/`
 Use make lint-fix to autofix issues

  ## Manual lint fixes for `admin/`                                                                                                                                                                                                                                                                                 
                                                                                                                                                                                                                                                                                                                    
  ### dupl: environment_controller.go / remoteorganization_controller.go                                                                                                                                                                                                                                            
  Added `//nolint:dupl` at the package level for both files. These kubebuilder controller                                                                                                                                                                                                                           
  files are structurally identical by design — each CRD type follows the same reconciler pattern.                                                                                                                                                                                                                   
                                                                                                                                                                                                                                                                                                                    
  ### errcheck: test/utils/utils.go                                                                                                                                                                                                                                                                                 
  - `GetProjectDir()`: error is now properly checked and returned instead of silently ignored.                                                                                                                                                                                                                      
  - `fmt.Fprintf(GinkgoWriter, ...)` calls: added `//nolint:errcheck` — these are best-effort                                                                                                                                                                                                                       
    log writes in test helpers where failure is inconsequential.                                                                                                                                                                                                                                                    
                                                                                                                                                                                                                                                                                                                    
  ### govet (shadow): test/utils/utils.go                                                                                                                                                                                                                                                                           
  Renamed inner `err` to `chdirErr` in `Run()` to avoid shadowing the outer `err` variable.                                                                                                                                                                                                                         
                                                                                                                                                                                                                                                                                                                    
  ### gocritic (rangeValCopy): zone_controller.go                                                                                                                                                                                                                                                                   
  Changed `for _, zone := range list.Items` to `for i := range list.Items` with index access                                                                                                                                                                                                                        
  to avoid copying 648 bytes per iteration.                                                                                                                                                                                                                                                                         
                                                                                                                                                                                                                                                                                                                    
  ### gocritic (importShadow): urls/urls.go                                                                                                                                                                                                                                                                         
  Renamed parameter `url` to `rawURL` in `ensureSuffix()` to avoid shadowing the `net/url` import.                                                                                                                                                                                                                  
                                                                                                                                                                                                                                                                                                                    
  ### gocritic (hugeParam): zone/handler.go                                                                                                                                                                                                                                                                         
  Changed `createTeamApiRoute` parameter `gatewayRealm gatewayapi.Realm` (448 bytes) to                                                                                                                                                                                                                             
  `*gatewayapi.Realm`. Updated the call site and internal usages accordingly.                                                                                                                                                                                                                                       
                                                                                                                                                                                                                                                                                                                    
  ### gocritic (whyNoLint): test/utils/utils.go                                                                                                                                                                                                                                                                     
  - Replaced stale `//nolint:golint,revive` with `//nolint:staticcheck` and added explanation                                                                                                                                                                                                                       
    for the ginkgo dot import.                                                                                                                                                                                                                                                                                      
  - Added explanation to the `//nolint:gosec` on the `kind` command execution.                                                                                                                                                                                                                                      
                                                                                                                                                                                                                                                                                                                    
  ### nestif + prealloc: zone/handler.go                                                                                                                                                                                                                                                                            
  Extracted the `TeamApis` reconciliation block into a `reconcileTeamApis()` function to reduce                                                                                                                                                                                                                     
  nesting complexity. Pre-allocated the `teamApiRouteRefs` slice.                                                                                                                                                                                                                                                   
                                                                                                                                                                                                                                                                                                                    
  ### gci: cmd/main.go                                                                                                                                                                                                                                                                                              
  The gci formatter removed the `// +kubebuilder:scaffold:imports` marker from inside the import                                                                                                                                                                                                                    
  block (it doesn't allow non-import comments there). Added an explanatory comment below the                                                                                                                                                                                                                        
  import block noting why the marker was removed and how to restore it if scaffolding is needed again. 

### dupImport: zone/handler.go                                                                                                                                                                                                                                                                                    
  The `common/pkg/config` package was imported twice — once as `config` and once as `cconfig`.                                                                                                                                                                                                                      
  Removed the `cconfig` alias and changed the single `cconfig.FeaturePermission` reference to                                                                                                                                                                                                                       
  `config.FeaturePermission`.                                                                                                                                                                                                                                                                                       
                                                                                                                                                                                                                                                                                                                    
 ### SA1019 deprecated `GetEventRecorderFor`: environment_controller.go, remoteorganization_controller.go, zone_controller.go                                                                                                                                                                                      
  All three controllers use the deprecated `mgr.GetEventRecorderFor()` (old `record.EventRecorder` API).                                                                                                                                                                                                            
  Migrating to `mgr.GetEventRecorder()` (new `events.EventRecorder` API) requires changes in the                                                                                                                                                                                                                    
  common package's `Controller` type, so this is out of scope for this PR. Added a text-based exclusion                                                                                                                                                                                                             
  rule in `.golangci.yml` for `SA1019: .*GetEventRecorderFor` with a comment explaining the migration path.                                                                                                                                                                                                         
  Inline `//nolint:staticcheck` was not viable due to a nolintlint bug in golangci-lint v2.11.4 that                                                                                                                                                                                                                
  flags the directive as unused.   