### PR TITLE
fix(application): Fix golangci-lint issues

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -140,6 +140,7 @@ jobs:
       module: application
       run_check_generated_files: true
       ko_build_path: "cmd/main.go"
+      lint_fail_on_issues: true
 
   api:
     name: Api

--- a/admin/cmd/main.go
+++ b/admin/cmd/main.go
@@ -22,11 +22,8 @@ import (
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
+	// +kubebuilder:scaffold:imports
 )
-
-// NOTE: the +kubebuilder:scaffold:imports marker was removed because gci (import formatting)
-// does not allow non-import comments inside the import block. If you need to scaffold new
-// CRD types with kubebuilder, re-add it as the last line inside the import parentheses.
 
 var (
 	scheme   = runtime.NewScheme()

--- a/admin/cmd/main.go
+++ b/admin/cmd/main.go
@@ -22,8 +22,11 @@ import (
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
-	// +kubebuilder:scaffold:imports
 )
+
+// NOTE: the +kubebuilder:scaffold:imports marker was removed because gci (import formatting)
+// does not allow non-import comments inside the import block. If you need to scaffold new
+// CRD types with kubebuilder, re-add it as the last line inside the import parentheses.
 
 var (
 	scheme   = runtime.NewScheme()

--- a/application/Makefile
+++ b/application/Makefile
@@ -138,7 +138,7 @@ GOLANGCI_LINT = $(LOCALBIN)/golangci-lint
 KUSTOMIZE_VERSION ?= v5.4.3
 CONTROLLER_TOOLS_VERSION ?= v0.20.1
 ENVTEST_VERSION ?= release-0.19
-GOLANGCI_LINT_VERSION ?= v2.11.2
+GOLANGCI_LINT_VERSION ?= v2.11.4
 
 .PHONY: kustomize
 kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary.
@@ -158,7 +158,7 @@ $(ENVTEST): $(LOCALBIN)
 .PHONY: golangci-lint
 golangci-lint: $(GOLANGCI_LINT) ## Download golangci-lint locally if necessary.
 $(GOLANGCI_LINT): $(LOCALBIN)
-	$(call go-install-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/cmd/golangci-lint,$(GOLANGCI_LINT_VERSION))
+	$(call go-install-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/v2/cmd/golangci-lint,$(GOLANGCI_LINT_VERSION))
 
 # go-install-tool will 'go install' any package with custom target and name of binary, if it doesn't exist
 # $1 - target path with name of binary

--- a/application/cmd/main.go
+++ b/application/cmd/main.go
@@ -99,7 +99,7 @@ func main() {
 	// Initial webhook TLS options
 	webhookTLSOpts := tlsOpts
 
-	if len(webhookCertPath) > 0 {
+	if webhookCertPath != "" {
 		setupLog.Info("Initializing webhook certificate watcher using provided certificates",
 			"webhook-cert-path", webhookCertPath, "webhook-cert-name", webhookCertName, "webhook-cert-key", webhookCertKey)
 

--- a/application/cmd/main.go
+++ b/application/cmd/main.go
@@ -10,10 +10,6 @@ import (
 	"os"
 	"path/filepath"
 
-	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
-	// to ensure that exec-entrypoint and run can make use of them.
-	_ "k8s.io/client-go/plugin/pkg/client/auth"
-
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
@@ -31,6 +27,10 @@ import (
 	webhookv1 "github.com/telekom/controlplane/application/internal/webhook/v1"
 	gateway "github.com/telekom/controlplane/gateway/api/v1"
 	identity "github.com/telekom/controlplane/identity/api/v1"
+
+	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
+	// to ensure that exec-entrypoint and run can make use of them.
+	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	// +kubebuilder:scaffold:imports
 )
 

--- a/application/internal/controller/application_controller_test.go
+++ b/application/internal/controller/application_controller_test.go
@@ -7,19 +7,19 @@ package controller
 import (
 	"context"
 
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
-	"github.com/telekom/controlplane/common/pkg/config"
 	corev1 "k8s.io/api/core/v1"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	adminv1 "github.com/telekom/controlplane/admin/api/v1"
 	applicationv1 "github.com/telekom/controlplane/application/api/v1"
+	"github.com/telekom/controlplane/common/pkg/config"
 	ctypes "github.com/telekom/controlplane/common/pkg/types"
 	gatewayv1 "github.com/telekom/controlplane/gateway/api/v1"
 	identityv1 "github.com/telekom/controlplane/identity/api/v1"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("Application Controller", func() {
@@ -65,7 +65,6 @@ var _ = Describe("Application Controller", func() {
 				},
 			}
 			Expect(k8sClient.Create(ctx, zoneB)).To(Succeed())
-
 		})
 
 		AfterEach(func() {
@@ -121,7 +120,6 @@ var _ = Describe("Application Controller", func() {
 
 				By("Checking if the Gateway-Consumer is created")
 				CheckStatusOfConsumer(ctx, g, expectedClientId, expectedResourceName, testNamespace)
-
 			}, timeout, interval).Should(Succeed())
 		})
 
@@ -182,10 +180,8 @@ var _ = Describe("Application Controller", func() {
 
 				By("Checking if the failover Gateway-Consumer is created")
 				CheckStatusOfConsumer(ctx, g, expectedClientId, expectedResourceName, testNamespace)
-
 			}, timeout, interval).Should(Succeed())
 		})
-
 	})
 })
 
@@ -199,7 +195,7 @@ func CheckStatusOfClient(ctx context.Context, g Gomega, clientId, name, namespac
 	g.Expect(idpClient.Spec.ClientId).To(Equal(clientId))
 }
 
-func CheckStatusOfConsumer(ctx context.Context, g Gomega, clientId, name string, namespace string) {
+func CheckStatusOfConsumer(ctx context.Context, g Gomega, clientId, name, namespace string) {
 	consumer := &gatewayv1.Consumer{}
 	err := k8sClient.Get(ctx, client.ObjectKey{
 		Name:      name,

--- a/application/internal/controller/suite_test.go
+++ b/application/internal/controller/suite_test.go
@@ -13,9 +13,6 @@ import (
 	"testing"
 	"time"
 
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
-
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -30,6 +27,9 @@ import (
 	"github.com/telekom/controlplane/common/pkg/test/mock"
 	gatewayv1 "github.com/telekom/controlplane/gateway/api/v1"
 	identityv1 "github.com/telekom/controlplane/identity/api/v1"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 	// +kubebuilder:scaffold:imports
 )
 
@@ -44,11 +44,13 @@ const (
 	mockKeycloak    = true
 )
 
-var cfg *rest.Config
-var k8sClient client.Client
-var testEnv *envtest.Environment
-var ctx context.Context
-var cancel context.CancelFunc
+var (
+	cfg       *rest.Config
+	k8sClient client.Client
+	testEnv   *envtest.Environment
+	ctx       context.Context
+	cancel    context.CancelFunc
+)
 
 func TestControllers(t *testing.T) {
 	RegisterFailHandler(Fail)
@@ -122,7 +124,6 @@ var _ = BeforeSuite(func() {
 		err = k8sManager.Start(ctx)
 		Expect(err).ToNot(HaveOccurred(), "failed to run manager")
 	}()
-
 })
 
 var _ = AfterSuite(func() {

--- a/application/internal/handler/application/handler.go
+++ b/application/internal/handler/application/handler.go
@@ -8,6 +8,10 @@ import (
 	"context"
 
 	"github.com/pkg/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+
 	admin "github.com/telekom/controlplane/admin/api/v1"
 	application "github.com/telekom/controlplane/application/api/v1"
 	"github.com/telekom/controlplane/common/pkg/client"
@@ -19,9 +23,6 @@ import (
 	"github.com/telekom/controlplane/common/pkg/util/contextutil"
 	gateway "github.com/telekom/controlplane/gateway/api/v1"
 	identity "github.com/telekom/controlplane/identity/api/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	ctrl "sigs.k8s.io/controller-runtime"
 )
 
 var _ handler.Handler[*application.Application] = &ApplicationHandler{}
@@ -47,7 +48,8 @@ func (h *ApplicationHandler) CreateOrUpdate(ctx context.Context, app *applicatio
 	failoverZones := make([]*admin.Zone, 0, len(app.Spec.FailoverZones))
 	if app.Spec.NeedsClient || app.Spec.NeedsConsumer {
 		for _, zoneRef := range app.Spec.FailoverZones {
-			zone, err := GetZone(ctx, c, zoneRef)
+			var foZone *admin.Zone
+			foZone, err = GetZone(ctx, c, zoneRef)
 			if err != nil {
 				if apierrors.IsNotFound(errors.Cause(err)) {
 					return ctrlerrors.BlockedErrorf("Zone %s not found", zoneRef.Name)
@@ -55,7 +57,7 @@ func (h *ApplicationHandler) CreateOrUpdate(ctx context.Context, app *applicatio
 					return ctrlerrors.RetryableErrorf("failed to get Zone when creating application: %s", err.Error())
 				}
 			}
-			failoverZones = append(failoverZones, zone)
+			failoverZones = append(failoverZones, foZone)
 		}
 	}
 
@@ -133,7 +135,7 @@ func CreateIdentityClient(ctx context.Context, zone *admin.Zone, owner *applicat
 		opt(options)
 	}
 
-	client := client.ClientFromContextOrDie(ctx)
+	c := client.ClientFromContextOrDie(ctx)
 	clientId := MakeClientName(owner)
 	resourceName := clientId + "--" + zone.Name
 	realmName := contextutil.EnvFromContextOrDie(ctx)
@@ -165,7 +167,7 @@ func CreateIdentityClient(ctx context.Context, zone *admin.Zone, owner *applicat
 			idpClient.Labels[config.BuildLabelKey("failover")] = "true"
 		}
 
-		err := ctrl.SetControllerReference(owner, idpClient, client.Scheme())
+		err := ctrl.SetControllerReference(owner, idpClient, c.Scheme())
 		if err != nil {
 			return errors.Wrapf(err, "failed to set controller reference for identity client %s", resourceName)
 		}
@@ -179,7 +181,7 @@ func CreateIdentityClient(ctx context.Context, zone *admin.Zone, owner *applicat
 		return nil
 	}
 
-	_, err := client.CreateOrUpdate(ctx, idpClient, mutator)
+	_, err := c.CreateOrUpdate(ctx, idpClient, mutator)
 	if err != nil {
 		return errors.Wrapf(err, "failed to create or update Identity Client %s", resourceName)
 	}
@@ -195,7 +197,7 @@ func CreateGatewayConsumer(ctx context.Context, zone *admin.Zone, owner *applica
 		opt(options)
 	}
 
-	client := client.ClientFromContextOrDie(ctx)
+	c := client.ClientFromContextOrDie(ctx)
 	clientId := MakeClientName(owner)
 	resourceName := clientId + "--" + zone.Name
 	realmName := contextutil.EnvFromContextOrDie(ctx)
@@ -223,7 +225,7 @@ func CreateGatewayConsumer(ctx context.Context, zone *admin.Zone, owner *applica
 			consumer.Labels[config.BuildLabelKey("failover")] = "true"
 		}
 
-		err := ctrl.SetControllerReference(owner, consumer, client.Scheme())
+		err := ctrl.SetControllerReference(owner, consumer, c.Scheme())
 		if err != nil {
 			return errors.Wrapf(err, "failed to set controller reference for gateway consumer %s", resourceName)
 		}
@@ -244,7 +246,7 @@ func CreateGatewayConsumer(ctx context.Context, zone *admin.Zone, owner *applica
 		return nil
 	}
 
-	_, err := client.CreateOrUpdate(ctx, consumer, mutator)
+	_, err := c.CreateOrUpdate(ctx, consumer, mutator)
 	if err != nil {
 		return errors.Wrapf(err, "failed to create or update Gateway Consumer %s", resourceName)
 	}

--- a/application/internal/handler/application/util.go
+++ b/application/internal/handler/application/util.go
@@ -8,6 +8,7 @@ import (
 	"context"
 
 	"github.com/pkg/errors"
+
 	admin "github.com/telekom/controlplane/admin/api/v1"
 	application "github.com/telekom/controlplane/application/api/v1"
 	"github.com/telekom/controlplane/common/pkg/client"
@@ -19,18 +20,16 @@ func MakeClientName(obj *application.Application) string {
 	return obj.Spec.Team + "--" + obj.Name
 }
 
-func GetZone(ctx context.Context, client client.ScopedClient, zoneRef types.ObjectRef) (*admin.Zone, error) {
+func GetZone(ctx context.Context, c client.ScopedClient, zoneRef types.ObjectRef) (*admin.Zone, error) {
 	zone := &admin.Zone{}
-	err := client.Get(ctx, zoneRef.K8s(), zone)
+	err := c.Get(ctx, zoneRef.K8s(), zone)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to get zone %s", zoneRef.Name)
 	}
 	return zone, nil
-
 }
 
-func GetIdpClient(ctx context.Context, client client.ScopedClient, obj *application.Application, clientName string, namespace string) (*identity.Client, error) {
-
+func GetIdpClient(ctx context.Context, c client.ScopedClient, obj *application.Application, clientName, namespace string) (*identity.Client, error) {
 	clientRef := &types.ObjectRef{
 		Name:      clientName,
 		Namespace: namespace,
@@ -38,10 +37,9 @@ func GetIdpClient(ctx context.Context, client client.ScopedClient, obj *applicat
 
 	idpClient := &identity.Client{}
 
-	err := client.Get(ctx, clientRef.K8s(), idpClient)
+	err := c.Get(ctx, clientRef.K8s(), idpClient)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get zone")
 	}
 	return idpClient, nil
-
 }

--- a/application/internal/secret/secret.go
+++ b/application/internal/secret/secret.go
@@ -22,9 +22,7 @@ var GetSecretManager = func() api.SecretManager {
 	return secretManager
 }
 
-var WithSecretValue = func(name string, value any) api.OnboardingOption {
-	return api.WithSecretValue(name, value)
-}
+var WithSecretValue = api.WithSecretValue
 
 const (
 	ClientSecret = "clientSecret"

--- a/application/internal/webhook/v1/application_webhook.go
+++ b/application/internal/webhook/v1/application_webhook.go
@@ -9,14 +9,15 @@ import (
 	"fmt"
 
 	"github.com/go-logr/logr"
-	applicationv1 "github.com/telekom/controlplane/application/api/v1"
-	"github.com/telekom/controlplane/application/internal/webhook/v1/mutator"
-	"github.com/telekom/controlplane/application/internal/webhook/v1/validator"
-	"github.com/telekom/controlplane/common/pkg/controller"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	applicationv1 "github.com/telekom/controlplane/application/api/v1"
+	"github.com/telekom/controlplane/application/internal/webhook/v1/mutator"
+	"github.com/telekom/controlplane/application/internal/webhook/v1/validator"
+	"github.com/telekom/controlplane/common/pkg/controller"
 )
 
 var applicationLog = logf.Log.WithName("application-resource").WithValues("apiVersion", "application.cp.ei.telekom.de/v1", "kind", "Application")
@@ -62,7 +63,7 @@ func (v *ApplicationCustomValidator) ValidateCreate(ctx context.Context, app *ap
 	return v.validateCreateOrUpdate(ctx, app)
 }
 
-func (v *ApplicationCustomValidator) ValidateUpdate(ctx context.Context, _ *applicationv1.Application, app *applicationv1.Application) (admission.Warnings, error) {
+func (v *ApplicationCustomValidator) ValidateUpdate(ctx context.Context, _, app *applicationv1.Application) (admission.Warnings, error) {
 	return v.validateCreateOrUpdate(ctx, app)
 }
 

--- a/application/internal/webhook/v1/mutator/mutate.go
+++ b/application/internal/webhook/v1/mutator/mutate.go
@@ -10,10 +10,11 @@ import (
 	"strings"
 
 	"github.com/go-logr/logr"
+	"k8s.io/apimachinery/pkg/api/errors"
+
 	applicationv1 "github.com/telekom/controlplane/application/api/v1"
 	"github.com/telekom/controlplane/application/internal/secret"
 	secretsapi "github.com/telekom/controlplane/secret-manager/api"
-	"k8s.io/apimachinery/pkg/api/errors"
 )
 
 func wrapCommunicationError(err error, purposeOfCommunication string) error {

--- a/application/internal/webhook/v1/mutator/mutate_test.go
+++ b/application/internal/webhook/v1/mutator/mutate_test.go
@@ -11,11 +11,12 @@ import (
 
 	"github.com/stretchr/testify/mock"
 
-	. "github.com/onsi/gomega"
 	applicationv1 "github.com/telekom/controlplane/application/api/v1"
 	"github.com/telekom/controlplane/application/internal/secret"
 	"github.com/telekom/controlplane/secret-manager/api"
 	"github.com/telekom/controlplane/secret-manager/api/fake"
+
+	. "github.com/onsi/gomega"
 )
 
 func TestMutateSecret(t *testing.T) {

--- a/application/internal/webhook/v1/validator/validate.go
+++ b/application/internal/webhook/v1/validator/validate.go
@@ -5,12 +5,13 @@
 package validator
 
 import (
-	applicationv1 "github.com/telekom/controlplane/application/api/v1"
-	"github.com/telekom/controlplane/common/pkg/controller"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	applicationv1 "github.com/telekom/controlplane/application/api/v1"
+	"github.com/telekom/controlplane/common/pkg/controller"
 )
 
 // ValidateAndGetEnv verifies that the object carries an environment label


### PR DESCRIPTION
 ## Update Makefile
 Update tool versions and golangci-lint target in Makefile.

 ## Autofixes for `application/`
 Use make lint-fix to autofix issues

  ## Manual lint fixes for `application/`
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       
 ### Variable shadowing & naming (predeclared, revive)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   
  - internal/handler/application/handler.go — Renamed local client variables to c to avoid shadowing the imported client package.                                                                                                                                                                                   
  - internal/handler/application/handler.go — Renamed shadowed zone→foZone inside the failover loop (:= was shadowing the outer err).                                                                                                                                                                               
  - internal/handler/application/util.go — Same client→c rename for function parameters.                                                                                                                                                                                                                            
                                                                                                                                                                                                                                                                                                                    
 ### Code style (gocritic)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 
  - cmd/main.go — emptyStringTest: replaced len(webhookCertPath) > 0 with webhookCertPath != "".                                                                                                                                                                                                                    
  - internal/secret/secret.go — unlambda: replaced redundant lambda wrapper with direct function value api.WithSecretValue.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             

  ### Formatting & declarations (gofumpt, gocritic)

  - internal/controller/suite_test.go — Grouped package-level var declarations into a single block.
  - internal/webhook/v1/application_webhook.go — Combined identical-type unnamed params: ValidateUpdate(ctx, _ *App, app *App) → ValidateUpdate(ctx, _, app *App).
  - internal/handler/application/util.go — Combined identical-type params: clientName string, namespace string → clientName, namespace string.
  - internal/controller/application_controller_test.go — Same param combining for CheckStatusOfConsumer.
  - Removed unnecessary blank lines flagged by whitespace / gofumpt in tests and utility functions.


