### PR TITLE
fix(notification): Fix golangci-lint issues

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -201,6 +201,7 @@ jobs:
       module: notification
       run_check_generated_files: true
       ko_build_path: "cmd/main.go"
+      lint_fail_on_issues: true
 
   event:
     name: Event

--- a/notification/Makefile
+++ b/notification/Makefile
@@ -137,7 +137,7 @@ GOLANGCI_LINT = $(LOCALBIN)/golangci-lint
 KUSTOMIZE_VERSION ?= v5.4.3
 CONTROLLER_TOOLS_VERSION ?= v0.20.1
 ENVTEST_VERSION ?= release-0.19
-GOLANGCI_LINT_VERSION ?= v2.11.2
+GOLANGCI_LINT_VERSION ?= v2.11.4
 
 .PHONY: kustomize
 kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary.
@@ -157,7 +157,7 @@ $(ENVTEST): $(LOCALBIN)
 .PHONY: golangci-lint
 golangci-lint: $(GOLANGCI_LINT) ## Download golangci-lint locally if necessary.
 $(GOLANGCI_LINT): $(LOCALBIN)
-	$(call go-install-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/cmd/golangci-lint,$(GOLANGCI_LINT_VERSION))
+	$(call go-install-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/v2/cmd/golangci-lint,$(GOLANGCI_LINT_VERSION))
 
 # go-install-tool will 'go install' any package with custom target and name of binary, if it doesn't exist
 # $1 - target path with name of binary

--- a/notification/cmd/main.go
+++ b/notification/cmd/main.go
@@ -7,15 +7,10 @@ package main
 import (
 	"crypto/tls"
 	"flag"
-	"github.com/pkg/errors"
-	"github.com/telekom/controlplane/notification/internal/templatecache"
 	"os"
 	"path/filepath"
 
-	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
-	// to ensure that exec-entrypoint and run can make use of them.
-	_ "k8s.io/client-go/plugin/pkg/client/auth"
-
+	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
@@ -27,10 +22,14 @@ import (
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
-	notificationsconfig "github.com/telekom/controlplane/notification/internal/config"
-
 	notificationv1 "github.com/telekom/controlplane/notification/api/v1"
+	notificationsconfig "github.com/telekom/controlplane/notification/internal/config"
 	"github.com/telekom/controlplane/notification/internal/controller"
+	"github.com/telekom/controlplane/notification/internal/templatecache"
+
+	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
+	// to ensure that exec-entrypoint and run can make use of them.
+	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	// +kubebuilder:scaffold:imports
 )
 
@@ -46,7 +45,6 @@ func init() {
 	// +kubebuilder:scaffold:scheme
 }
 
-// nolint:gocyclo
 func main() {
 	var metricsAddr string
 	var metricsCertPath, metricsCertName, metricsCertKey string
@@ -114,17 +112,17 @@ func main() {
 	// Initial webhook TLS options
 	webhookTLSOpts := tlsOpts
 
-	if len(webhookCertPath) > 0 {
+	if webhookCertPath != "" {
 		setupLog.Info("Initializing webhook certificate watcher using provided certificates",
 			"webhook-cert-path", webhookCertPath, "webhook-cert-name", webhookCertName, "webhook-cert-key", webhookCertKey)
 
-		var err error
-		webhookCertWatcher, err = certwatcher.New(
+		var certErr error
+		webhookCertWatcher, certErr = certwatcher.New(
 			filepath.Join(webhookCertPath, webhookCertName),
 			filepath.Join(webhookCertPath, webhookCertKey),
 		)
-		if err != nil {
-			setupLog.Error(err, "Failed to initialize webhook certificate watcher")
+		if certErr != nil {
+			setupLog.Error(certErr, "Failed to initialize webhook certificate watcher")
 			os.Exit(1)
 		}
 
@@ -163,17 +161,17 @@ func main() {
 	// - [METRICS-WITH-CERTS] at config/default/kustomization.yaml to generate and use certificates
 	// managed by cert-manager for the metrics server.
 	// - [PROMETHEUS-WITH-CERTS] at config/prometheus/kustomization.yaml for TLS certification.
-	if len(metricsCertPath) > 0 {
+	if metricsCertPath != "" {
 		setupLog.Info("Initializing metrics certificate watcher using provided certificates",
 			"metrics-cert-path", metricsCertPath, "metrics-cert-name", metricsCertName, "metrics-cert-key", metricsCertKey)
 
-		var err error
-		metricsCertWatcher, err = certwatcher.New(
+		var certErr error
+		metricsCertWatcher, certErr = certwatcher.New(
 			filepath.Join(metricsCertPath, metricsCertName),
 			filepath.Join(metricsCertPath, metricsCertKey),
 		)
-		if err != nil {
-			setupLog.Error(err, "to initialize metrics certificate watcher", "error", err)
+		if certErr != nil {
+			setupLog.Error(certErr, "failed to initialize metrics certificate watcher")
 			os.Exit(1)
 		}
 

--- a/notification/internal/config/config.go
+++ b/notification/internal/config/config.go
@@ -5,14 +5,14 @@
 package config
 
 import (
-	"github.com/pkg/errors"
-	"github.com/spf13/viper"
 	"strings"
 	"time"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/viper"
 )
 
 type NotificationHousekeepingConfig struct {
-
 	// TTLMonthsAfterFinished specifies how many months should the notification be kept in the system if it was successfully handled (all channels sent without error)
 	TTLMonthsAfterFinished int32 `json:"ttlMonthsAfterFinished,omitempty"`
 }

--- a/notification/internal/controller/index.go
+++ b/notification/internal/controller/index.go
@@ -38,6 +38,7 @@ func RegisterIndecesOrDie(ctx context.Context, mgr ctrl.Manager) {
 			// index key is "namespace/name"
 			keys := make([]string, 0, len(n.Spec.Channels))
 			for _, ch := range n.Spec.Channels {
+				// We'll use "namespace/name" as the key
 				keys = append(keys, fmt.Sprintf("%s/%s", ch.Namespace, ch.Name))
 			}
 			return keys
@@ -62,6 +63,7 @@ func RegisterIndecesOrDie(ctx context.Context, mgr ctrl.Manager) {
 			for _, ch := range n.Spec.Channels {
 				parts := strings.Split(ch.Name, "--")
 				channelType := parts[len(parts)-1]
+				// We'll construct the template name as the key
 				keys = append(keys, fmt.Sprintf("%s--%s", n.Spec.Purpose, channelType))
 			}
 			return keys

--- a/notification/internal/controller/index.go
+++ b/notification/internal/controller/index.go
@@ -29,12 +29,13 @@ func RegisterIndecesOrDie(ctx context.Context, mgr ctrl.Manager) {
 	if err := mgr.GetFieldIndexer().IndexField(
 		ctx,
 		&notificationv1.Notification{},
-		IndexFieldSpecChannelRefs,
+		IndexFieldSpecChannelRefs, // virtual field name for the index
 		func(obj client.Object) []string {
 			n, ok := obj.(*notificationv1.Notification)
 			if !ok {
 				return nil
 			}
+			// index key is "namespace/name"
 			keys := make([]string, 0, len(n.Spec.Channels))
 			for _, ch := range n.Spec.Channels {
 				keys = append(keys, fmt.Sprintf("%s/%s", ch.Namespace, ch.Name))
@@ -50,12 +51,13 @@ func RegisterIndecesOrDie(ctx context.Context, mgr ctrl.Manager) {
 	if err := mgr.GetFieldIndexer().IndexField(
 		ctx,
 		&notificationv1.Notification{},
-		IndexFieldSpecTemplateNames,
+		IndexFieldSpecTemplateNames, // virtual field name for the index
 		func(obj client.Object) []string {
 			n, ok := obj.(*notificationv1.Notification)
 			if !ok {
 				return nil
 			}
+			// index key is the constructed template name: "<purpose>--<channelType>"
 			keys := make([]string, 0, len(n.Spec.Channels))
 			for _, ch := range n.Spec.Channels {
 				parts := strings.Split(ch.Name, "--")

--- a/notification/internal/controller/index.go
+++ b/notification/internal/controller/index.go
@@ -7,14 +7,16 @@ package controller
 import (
 	"context"
 	"fmt"
-	notificationv1 "github.com/telekom/controlplane/notification/api/v1"
-	"k8s.io/apimachinery/pkg/types"
 	"os"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
-	"strings"
+
+	notificationv1 "github.com/telekom/controlplane/notification/api/v1"
 )
 
 const (
@@ -23,17 +25,18 @@ const (
 )
 
 func RegisterIndecesOrDie(ctx context.Context, mgr ctrl.Manager) {
-
 	// Index Notifications by each channel reference
 	if err := mgr.GetFieldIndexer().IndexField(
 		ctx,
 		&notificationv1.Notification{},
-		IndexFieldSpecChannelRefs, // this is a *virtual* field name for your index
+		IndexFieldSpecChannelRefs,
 		func(obj client.Object) []string {
-			n := obj.(*notificationv1.Notification)
-			var keys []string
+			n, ok := obj.(*notificationv1.Notification)
+			if !ok {
+				return nil
+			}
+			keys := make([]string, 0, len(n.Spec.Channels))
 			for _, ch := range n.Spec.Channels {
-				// We'll use "namespace/name" as the key
 				keys = append(keys, fmt.Sprintf("%s/%s", ch.Namespace, ch.Name))
 			}
 			return keys
@@ -47,16 +50,16 @@ func RegisterIndecesOrDie(ctx context.Context, mgr ctrl.Manager) {
 	if err := mgr.GetFieldIndexer().IndexField(
 		ctx,
 		&notificationv1.Notification{},
-		IndexFieldSpecTemplateNames, // this is a *virtual* field name for your index
+		IndexFieldSpecTemplateNames,
 		func(obj client.Object) []string {
-			n := obj.(*notificationv1.Notification)
-			var keys []string
+			n, ok := obj.(*notificationv1.Notification)
+			if !ok {
+				return nil
+			}
+			keys := make([]string, 0, len(n.Spec.Channels))
 			for _, ch := range n.Spec.Channels {
-
 				parts := strings.Split(ch.Name, "--")
 				channelType := parts[len(parts)-1]
-
-				// We'll construct the template name as the key
 				keys = append(keys, fmt.Sprintf("%s--%s", n.Spec.Purpose, channelType))
 			}
 			return keys
@@ -68,23 +71,26 @@ func RegisterIndecesOrDie(ctx context.Context, mgr ctrl.Manager) {
 }
 
 func (r *NotificationReconciler) MapChannelToNotification(ctx context.Context, obj client.Object) []reconcile.Request {
-	log := log.FromContext(ctx)
+	logger := log.FromContext(ctx)
 
-	ch := obj.(*notificationv1.NotificationChannel)
+	ch, ok := obj.(*notificationv1.NotificationChannel)
+	if !ok {
+		return nil
+	}
 	channelKey := fmt.Sprintf("%s/%s", ch.Namespace, ch.Name)
 
 	var notifications notificationv1.NotificationList
-	if err := r.Client.List(ctx, &notifications, client.MatchingFields{IndexFieldSpecChannelRefs: channelKey}); err != nil {
-		log.Error(err, "Failed to list notification channels")
+	if err := r.List(ctx, &notifications, client.MatchingFields{IndexFieldSpecChannelRefs: channelKey}); err != nil {
+		logger.Error(err, "Failed to list notification channels")
 		return nil
 	}
 
 	requests := make([]reconcile.Request, 0, len(notifications.Items))
-	for _, n := range notifications.Items {
+	for i := range notifications.Items {
 		requests = append(requests, reconcile.Request{
 			NamespacedName: types.NamespacedName{
-				Namespace: n.Namespace,
-				Name:      n.Name,
+				Namespace: notifications.Items[i].Namespace,
+				Name:      notifications.Items[i].Name,
 			},
 		})
 	}
@@ -93,22 +99,25 @@ func (r *NotificationReconciler) MapChannelToNotification(ctx context.Context, o
 }
 
 func (r *NotificationReconciler) MapTemplateToNotification(ctx context.Context, obj client.Object) []reconcile.Request {
-	log := log.FromContext(ctx)
+	logger := log.FromContext(ctx)
 
-	template := obj.(*notificationv1.NotificationTemplate)
+	template, ok := obj.(*notificationv1.NotificationTemplate)
+	if !ok {
+		return nil
+	}
 
 	var notifications notificationv1.NotificationList
-	if err := r.Client.List(ctx, &notifications, client.MatchingFields{IndexFieldSpecTemplateNames: template.Name}); err != nil {
-		log.Error(err, "Failed to list notification templates")
+	if err := r.List(ctx, &notifications, client.MatchingFields{IndexFieldSpecTemplateNames: template.Name}); err != nil {
+		logger.Error(err, "Failed to list notification templates")
 		return nil
 	}
 
 	requests := make([]reconcile.Request, 0, len(notifications.Items))
-	for _, n := range notifications.Items {
+	for i := range notifications.Items {
 		requests = append(requests, reconcile.Request{
 			NamespacedName: types.NamespacedName{
-				Namespace: n.Namespace,
-				Name:      n.Name,
+				Namespace: notifications.Items[i].Namespace,
+				Name:      notifications.Items[i].Name,
 			},
 		})
 	}

--- a/notification/internal/controller/notification_controller.go
+++ b/notification/internal/controller/notification_controller.go
@@ -6,27 +6,26 @@ package controller
 
 import (
 	"context"
-	cconfig "github.com/telekom/controlplane/common/pkg/config"
-	cc "github.com/telekom/controlplane/common/pkg/controller"
-	notificationv1 "github.com/telekom/controlplane/notification/api/v1"
-	"github.com/telekom/controlplane/notification/internal/sender"
-	"github.com/telekom/controlplane/notification/internal/sender/adapter/mail"
-	"github.com/telekom/controlplane/notification/internal/sender/adapter/msteams"
-	"github.com/telekom/controlplane/notification/internal/sender/adapter/webhook"
-	"github.com/telekom/controlplane/notification/internal/templatecache"
+
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
-	"sigs.k8s.io/controller-runtime/pkg/handler"
-
-	notificationhandler "github.com/telekom/controlplane/notification/internal/handler"
-
+	cconfig "github.com/telekom/controlplane/common/pkg/config"
+	cc "github.com/telekom/controlplane/common/pkg/controller"
+	notificationv1 "github.com/telekom/controlplane/notification/api/v1"
 	notificationsconfig "github.com/telekom/controlplane/notification/internal/config"
+	notificationhandler "github.com/telekom/controlplane/notification/internal/handler"
+	"github.com/telekom/controlplane/notification/internal/sender"
+	"github.com/telekom/controlplane/notification/internal/sender/adapter/mail"
+	"github.com/telekom/controlplane/notification/internal/sender/adapter/msteams"
+	"github.com/telekom/controlplane/notification/internal/sender/adapter/webhook"
+	"github.com/telekom/controlplane/notification/internal/templatecache"
 )
 
 // NotificationReconciler reconciles a Notification object
@@ -43,12 +42,11 @@ type NotificationReconciler struct {
 }
 
 func NewNotificationReconcilerWithConfig(
-	client client.Client,
+	c client.Client,
 	scheme *runtime.Scheme,
 	emailConfig *notificationsconfig.EmailAdapterConfig,
-	TemplateCache *templatecache.TemplateCache,
+	tmplCache *templatecache.TemplateCache,
 ) *NotificationReconciler {
-
 	// initialize the notification sender with all adapters so they can be reused
 	notificationSender := &sender.AdapterSender{
 		MailAdapter: &mail.EmailAdapter{
@@ -59,10 +57,10 @@ func NewNotificationReconcilerWithConfig(
 	}
 
 	return &NotificationReconciler{
-		Client:             client,
+		Client:             c,
 		Scheme:             scheme,
 		NotificationSender: notificationSender,
-		TemplateCache:      TemplateCache,
+		TemplateCache:      tmplCache,
 	}
 }
 

--- a/notification/internal/controller/notification_controller_test.go
+++ b/notification/internal/controller/notification_controller_test.go
@@ -8,10 +8,18 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
+	"math/rand/v2"
+
 	"github.com/onsi/gomega/gstruct"
 	"github.com/stretchr/testify/mock"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
 	"github.com/telekom/controlplane/common/pkg/condition"
 	"github.com/telekom/controlplane/common/pkg/config"
 	commontypes "github.com/telekom/controlplane/common/pkg/types"
@@ -20,15 +28,9 @@ import (
 	"github.com/telekom/controlplane/notification/internal/sender/adapter"
 	mailsender "github.com/telekom/controlplane/notification/internal/sender/adapter/mail"
 	mailsendermock "github.com/telekom/controlplane/notification/internal/sender/adapter/mail/mock"
-	"k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/api/meta"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
-	"math/rand/v2"
-	ctrl "sigs.k8s.io/controller-runtime"
 
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 )
 
 const (
@@ -37,7 +39,6 @@ const (
 )
 
 var _ = Describe("Notification Controller", Ordered, func() {
-
 	Context("When reconciling a resource", func() {
 		var (
 			ctx              context.Context
@@ -101,7 +102,7 @@ var _ = Describe("Notification Controller", Ordered, func() {
 					Name:      notificationName,
 					Namespace: defaultNamespace,
 				}, notification)
-				g.Expect(err).To(BeNil())
+				g.Expect(err).ToNot(HaveOccurred())
 
 				g.Expect(notification.Spec.Purpose).To(Equal(purposeName))
 				g.Expect(notification.Spec.Sender.Type).To(Equal(notificationv1.SenderTypeUser))
@@ -126,12 +127,10 @@ var _ = Describe("Notification Controller", Ordered, func() {
 				g.Expect(notification.Status.States[channelMapKey].Sent).To(BeTrue())
 				g.Expect(notification.Status.States[channelMapKey].ErrorMessage).To(BeEquivalentTo("Successfully sent"))
 			}, timeout, interval).Should(Succeed())
-
 		})
 	})
 
 	Context("When reconciling a resource and some resources are missing", func() {
-
 		var (
 			ctx              context.Context
 			notificationName string
@@ -147,7 +146,6 @@ var _ = Describe("Notification Controller", Ordered, func() {
 			notificationName = randName("notif")
 			templateName = randName(notificationPurpose + "--mail")
 			channelName = randName("eni--hyperion--mail")
-
 		})
 
 		AfterEach(func() {
@@ -175,7 +173,7 @@ var _ = Describe("Notification Controller", Ordered, func() {
 					Name:      notif.Name,
 					Namespace: defaultNamespace,
 				}, notification)
-				g.Expect(err).To(BeNil())
+				g.Expect(err).ToNot(HaveOccurred())
 
 				g.Expect(notification.Spec.Purpose).To(Equal("test-purpose"))
 				g.Expect(notification.Spec.Sender.Type).To(Equal(notificationv1.SenderTypeUser))
@@ -216,7 +214,6 @@ var _ = Describe("Notification Controller", Ordered, func() {
 				g.Expect(notification.Status.States[channelMapKey].Sent).To(BeFalse())
 				g.Expect(notification.Status.States[channelMapKey].ErrorMessage).To(BeEquivalentTo(errorMessage))
 			}, timeout, interval).Should(Succeed())
-
 		})
 	})
 
@@ -405,7 +402,7 @@ var _ = Describe("Notification Controller", Ordered, func() {
 					Name:      notificationName,
 					Namespace: defaultNamespace,
 				}, notification)
-				g.Expect(err).To(BeNil())
+				g.Expect(err).ToNot(HaveOccurred())
 
 				g.Expect(notification.Spec.Purpose).To(Equal(purposeName))
 				g.Expect(notification.Spec.Sender.Type).To(Equal(notificationv1.SenderTypeUser))
@@ -447,7 +444,7 @@ var _ = Describe("Notification Controller", Ordered, func() {
 					Name:      otherNotificatioName,
 					Namespace: defaultNamespace,
 				}, notification)
-				g.Expect(err).To(BeNil())
+				g.Expect(err).ToNot(HaveOccurred())
 
 				g.Expect(notification.Spec.Purpose).To(Equal(purposeName))
 				g.Expect(notification.Spec.Sender.Type).To(Equal(notificationv1.SenderTypeUser))
@@ -513,6 +510,7 @@ func newTestNotificationTemplate(ctx context.Context, name, namespace string) *n
 	return template
 }
 
+//nolint:unparam // namespace kept as parameter for test clarity
 func newTestNotificationChannel(ctx context.Context, name, namespace string) *notificationv1.NotificationChannel {
 	fromString := "test.from@somewhere.test"
 	channel := &notificationv1.NotificationChannel{
@@ -538,6 +536,7 @@ func newTestNotificationChannel(ctx context.Context, name, namespace string) *no
 	return channel
 }
 
+//nolint:unparam // namespace kept as parameter for test clarity
 func newTestNotification(ctx context.Context, name, namespace string, opts ...NotificationOption) *notificationv1.Notification {
 	notification := &notificationv1.Notification{
 		ObjectMeta: metav1.ObjectMeta{
@@ -553,12 +552,7 @@ func newTestNotification(ctx context.Context, name, namespace string, opts ...No
 				Type: notificationv1.SenderTypeUser,
 				Name: "John Snow",
 			},
-			Channels: []commontypes.ObjectRef{
-				//{
-				//	Name:      channelName,
-				//	Namespace: "default",
-				//},
-			},
+			Channels: []commontypes.ObjectRef{},
 			Properties: runtime.RawExtension{
 				Raw: []byte(`{"subjectValue":"awesomeSubject", "bodyValue":"awesomeBody"}`),
 			},
@@ -573,7 +567,8 @@ func newTestNotification(ctx context.Context, name, namespace string, opts ...No
 	return notification
 }
 
-func withChannel(name string, namespace string) NotificationOption {
+//nolint:unparam // namespace kept as parameter for test clarity
+func withChannel(name, namespace string) NotificationOption {
 	return func(notification *notificationv1.Notification) {
 		if notification.Spec.Channels == nil {
 			notification.Spec.Channels = []commontypes.ObjectRef{}

--- a/notification/internal/controller/notificationchannel_controller.go
+++ b/notification/internal/controller/notificationchannel_controller.go
@@ -6,7 +6,6 @@ package controller
 
 import (
 	"context"
-	"github.com/telekom/controlplane/notification/internal/config"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/record"
@@ -17,6 +16,7 @@ import (
 	cconfig "github.com/telekom/controlplane/common/pkg/config"
 	cc "github.com/telekom/controlplane/common/pkg/controller"
 	notificationv1 "github.com/telekom/controlplane/notification/api/v1"
+	"github.com/telekom/controlplane/notification/internal/config"
 	"github.com/telekom/controlplane/notification/internal/handler"
 )
 

--- a/notification/internal/controller/notificationchannel_controller_test.go
+++ b/notification/internal/controller/notificationchannel_controller_test.go
@@ -6,17 +6,18 @@ package controller
 
 import (
 	"context"
-	"github.com/telekom/controlplane/common/pkg/condition"
-	"github.com/telekom/controlplane/common/pkg/config"
-	"k8s.io/apimachinery/pkg/api/meta"
 
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
+	"github.com/telekom/controlplane/common/pkg/condition"
+	"github.com/telekom/controlplane/common/pkg/config"
 	notificationv1 "github.com/telekom/controlplane/notification/api/v1"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("NotificationChannel Controller", func() {
@@ -44,7 +45,6 @@ var _ = Describe("NotificationChannel Controller", func() {
 						},
 					},
 					Spec: notificationv1.NotificationChannelSpec{
-
 						Email: &notificationv1.EmailConfig{
 							Recipients:     []string{"test@test.com"},
 							Authentication: nil,
@@ -70,7 +70,7 @@ var _ = Describe("NotificationChannel Controller", func() {
 			Eventually(func(g Gomega) {
 				channel := &notificationv1.NotificationChannel{}
 				err := k8sClient.Get(ctx, typeNamespacedName, channel)
-				g.Expect(err).To(BeNil())
+				g.Expect(err).ToNot(HaveOccurred())
 
 				g.Expect(channel.Spec.Email).ToNot(BeNil())
 				g.Expect(channel.Spec.Ignore).To(ContainElement("thisPurpose"))

--- a/notification/internal/controller/notificationtemplate_controller.go
+++ b/notification/internal/controller/notificationtemplate_controller.go
@@ -6,7 +6,6 @@ package controller
 
 import (
 	"context"
-	"github.com/telekom/controlplane/notification/internal/templatecache"
 	texttemplate "text/template"
 
 	"k8s.io/apimachinery/pkg/runtime"
@@ -19,6 +18,7 @@ import (
 	cc "github.com/telekom/controlplane/common/pkg/controller"
 	notificationv1 "github.com/telekom/controlplane/notification/api/v1"
 	"github.com/telekom/controlplane/notification/internal/handler"
+	"github.com/telekom/controlplane/notification/internal/templatecache"
 )
 
 // NotificationTemplateReconciler reconciles a NotificationTemplate object

--- a/notification/internal/controller/notificationtemplate_controller_test.go
+++ b/notification/internal/controller/notificationtemplate_controller_test.go
@@ -6,18 +6,19 @@ package controller
 
 import (
 	"context"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+
 	"github.com/telekom/controlplane/common/pkg/condition"
 	"github.com/telekom/controlplane/common/pkg/config"
-	"k8s.io/apimachinery/pkg/api/meta"
-	"k8s.io/apimachinery/pkg/runtime"
+	notificationv1 "github.com/telekom/controlplane/notification/api/v1"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
-
-	notificationv1 "github.com/telekom/controlplane/notification/api/v1"
 )
 
 var _ = Describe("NotificationTemplate Controller", func() {
@@ -72,7 +73,7 @@ var _ = Describe("NotificationTemplate Controller", func() {
 			Eventually(func(g Gomega) {
 				template := &notificationv1.NotificationTemplate{}
 				err := k8sClient.Get(ctx, typeNamespacedName, template)
-				g.Expect(err).To(BeNil())
+				g.Expect(err).ToNot(HaveOccurred())
 
 				g.Expect(template.Spec.Purpose).To(Equal("ApiSubscriptionApproved"))
 				g.Expect(template.Spec.ChannelType).To(Equal("Email"))

--- a/notification/internal/controller/suite_test.go
+++ b/notification/internal/controller/suite_test.go
@@ -7,30 +7,30 @@ package controller
 import (
 	"context"
 	"fmt"
-	notificationsconfig "github.com/telekom/controlplane/notification/internal/config"
-	"github.com/telekom/controlplane/notification/internal/templatecache"
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"os"
 	"path/filepath"
 	"runtime"
-	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/manager"
-	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"testing"
 	"time"
 
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
-
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
 	notificationv1 "github.com/telekom/controlplane/notification/api/v1"
+	notificationsconfig "github.com/telekom/controlplane/notification/internal/config"
+	"github.com/telekom/controlplane/notification/internal/templatecache"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 	// +kubebuilder:scaffold:imports
 )
 

--- a/notification/internal/handler/notification_handler.go
+++ b/notification/internal/handler/notification_handler.go
@@ -7,8 +7,15 @@ package handler
 import (
 	"context"
 	"fmt"
+	"strings"
+
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
 	"github.com/telekom/controlplane/common/pkg/client"
 	"github.com/telekom/controlplane/common/pkg/condition"
 	"github.com/telekom/controlplane/common/pkg/handler"
@@ -19,11 +26,6 @@ import (
 	"github.com/telekom/controlplane/notification/internal/sender"
 	"github.com/telekom/controlplane/notification/internal/sender/adapter"
 	"github.com/telekom/controlplane/notification/internal/templatecache"
-	"k8s.io/apimachinery/pkg/api/meta"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/log"
-	"strings"
 )
 
 var _ handler.Handler[*notificationv1.Notification] = &NotificationHandler{}
@@ -35,12 +37,12 @@ type NotificationHandler struct {
 }
 
 func (n *NotificationHandler) CreateOrUpdate(ctx context.Context, notification *notificationv1.Notification) error {
-	var shouldBlock = false
+	shouldBlock := false
 
-	var channels = notification.Spec.Channels
+	channels := notification.Spec.Channels
 	// if there are no channels in the notification, we will use all channels form the notifications namespace
 	// this handles the case when a team is onboarded and channels are not yet cached, thus not listed by the client
-	if channels == nil || len(channels) == 0 {
+	if len(channels) == 0 {
 		channels = findChannelsForNotification(ctx, notification)
 	}
 
@@ -125,28 +127,28 @@ func (n *NotificationHandler) CreateOrUpdate(ctx context.Context, notification *
 }
 
 func findChannelsForNotification(ctx context.Context, notification *notificationv1.Notification) []types.ObjectRef {
-	log := logr.FromContextOrDiscard(ctx)
+	logger := logr.FromContextOrDiscard(ctx)
 	cclient, _ := client.ClientFromContext(ctx)
 
-	var notificationChannels = &notificationv1.NotificationChannelList{}
+	notificationChannels := &notificationv1.NotificationChannelList{}
 	var channelRefs []types.ObjectRef
 
 	err := cclient.List(ctx, notificationChannels, k8sclient.InNamespace(notification.Namespace))
 	if err != nil {
-		log.Error(err, "Failed to list channels in namespace", "namespace", notification.Namespace)
+		logger.Error(err, "Failed to list channels in namespace", "namespace", notification.Namespace)
 		return nil
 	}
 
-	for _, channel := range notificationChannels.Items {
-		channelRefs = append(channelRefs, *types.ObjectRefFromObject(&channel))
+	for i := range notificationChannels.Items {
+		channelRefs = append(channelRefs, *types.ObjectRefFromObject(&notificationChannels.Items[i]))
 	}
 
-	log.V(1).Info("Found channels in namespace. Returning refs", "namespace", notification.Namespace, "channels", channelRefs)
+	logger.V(1).Info("Found channels in namespace. Returning refs", "namespace", notification.Namespace, "channels", channelRefs)
 	return channelRefs
 }
 
 func alreadySent(key string, notification *notificationv1.Notification) bool {
-	if notification.Status.States == nil || len(notification.Status.States) == 0 {
+	if len(notification.Status.States) == 0 {
 		return false
 	}
 
@@ -181,7 +183,7 @@ func (n *NotificationHandler) resolveTemplate(ctx context.Context, channel *noti
 	// channel name - <teamname>--<type> - example: eni--hyperion--mail
 	// template name - <purpose>--<type> - example: api-subscription-approved--chat
 
-	log := log.FromContext(ctx)
+	logger := log.FromContext(ctx)
 
 	// build the template name first
 	templateName := buildTemplateName(channel, purpose)
@@ -189,7 +191,7 @@ func (n *NotificationHandler) resolveTemplate(ctx context.Context, channel *noti
 	// look for a cached value
 	parsedTemplateWrapper, ok := n.TemplateCache.Get(templateName)
 	if !ok {
-		log.V(1).Info("No template found in cache for channel and purpose", "channel", channel, "purpose", purpose)
+		logger.V(1).Info("No template found in cache for channel and purpose", "channel", channel, "purpose", purpose)
 		return nil, errors.New(fmt.Sprintf("No template found in cache for channel %q and purpose %q", purpose, channel.Name))
 	} else {
 
@@ -225,7 +227,7 @@ func (n *NotificationHandler) resolveTemplate(ctx context.Context, channel *noti
 		n.TemplateCache.Set(templateName, parsedTemplate)
 	}
 
-	log.V(1).Info("Resolved template found in cache", "channel", channel, "purpose", purpose)
+	logger.V(1).Info("Resolved template found in cache", "channel", channel, "purpose", purpose)
 	return parsedTemplateWrapper, nil
 }
 
@@ -252,7 +254,6 @@ func getChannelByRef(ctx context.Context, ref types.ObjectRef) (*notificationv1.
 		return nil, errors.Wrapf(err, "Channel %q found but its not ready", ref)
 	}
 	return &channel, nil
-
 }
 
 func (n *NotificationHandler) Delete(ctx context.Context, notification *notificationv1.Notification) error {

--- a/notification/internal/handler/notification_handler.go
+++ b/notification/internal/handler/notification_handler.go
@@ -192,7 +192,7 @@ func (n *NotificationHandler) resolveTemplate(ctx context.Context, channel *noti
 	parsedTemplateWrapper, ok := n.TemplateCache.Get(templateName)
 	if !ok {
 		logger.V(1).Info("No template found in cache for channel and purpose", "channel", channel, "purpose", purpose)
-		return nil, errors.New(fmt.Sprintf("No template found in cache for channel %q and purpose %q", purpose, channel.Name))
+		return nil, errors.New(fmt.Sprintf("No template found in cache for channel %q and purpose %q", channel.Name, purpose))
 	} else {
 
 		// there is a chance that when the operator starts, the templates will not be ready before the

--- a/notification/internal/handler/notification_handler_test.go
+++ b/notification/internal/handler/notification_handler_test.go
@@ -6,8 +6,12 @@ package handler_test
 
 import (
 	"context"
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
+	"time"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
 	cclient "github.com/telekom/controlplane/common/pkg/client"
 	fakeclient "github.com/telekom/controlplane/common/pkg/client/fake"
 	"github.com/telekom/controlplane/common/pkg/condition"
@@ -16,16 +20,13 @@ import (
 	commontypes "github.com/telekom/controlplane/common/pkg/types"
 	notificationv1 "github.com/telekom/controlplane/notification/api/v1"
 	handlers "github.com/telekom/controlplane/notification/internal/handler"
-	"k8s.io/apimachinery/pkg/api/meta"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("Notification Handler", func() {
-
 	Context("Reconciling a partially processed resource", func() {
-
 		const notificationPurpose = "test-purpose"
 
 		const notificationName = "test-notification"

--- a/notification/internal/handler/notification_handler_unit_test.go
+++ b/notification/internal/handler/notification_handler_unit_test.go
@@ -9,9 +9,13 @@ import (
 	"fmt"
 	texttemplate "text/template"
 
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
 	"github.com/stretchr/testify/mock"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	k8stypes "k8s.io/apimachinery/pkg/types"
+	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
+
 	cclient "github.com/telekom/controlplane/common/pkg/client"
 	fakeclient "github.com/telekom/controlplane/common/pkg/client/fake"
 	"github.com/telekom/controlplane/common/pkg/condition"
@@ -21,11 +25,9 @@ import (
 	handlers "github.com/telekom/controlplane/notification/internal/handler"
 	"github.com/telekom/controlplane/notification/internal/sender/adapter"
 	"github.com/telekom/controlplane/notification/internal/templatecache"
-	"k8s.io/apimachinery/pkg/api/meta"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-	k8stypes "k8s.io/apimachinery/pkg/types"
-	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 )
 
 // mockSender implements sender.NotificationSender for testing.
@@ -164,7 +166,6 @@ func expectGetTemplateError(fc *fakeclient.MockJanitorClient, templateName strin
 }
 
 var _ = Describe("Notification Handler - Unit Tests", func() {
-
 	var (
 		fakeClient *fakeclient.MockJanitorClient
 		ctx        context.Context

--- a/notification/internal/handler/notificationchannel_handler.go
+++ b/notification/internal/handler/notificationchannel_handler.go
@@ -55,6 +55,7 @@ func doNotificationsHousekeeping(ctx context.Context, channel *notificationv1.No
 	}
 
 	for i := range notifications.Items {
+		// let's check if the notification is eligible for housekeeping
 		if eligibleForHousekeeping(ctx, &notifications.Items[i], housekeepingConfig.TTLMonthsAfterFinished) {
 			err := scopedClient.Delete(ctx, &notifications.Items[i])
 			if err != nil {

--- a/notification/internal/handler/notificationchannel_handler.go
+++ b/notification/internal/handler/notificationchannel_handler.go
@@ -7,15 +7,17 @@ package handler
 import (
 	"context"
 	"fmt"
+	"time"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
 	cclient "github.com/telekom/controlplane/common/pkg/client"
 	"github.com/telekom/controlplane/common/pkg/condition"
 	"github.com/telekom/controlplane/common/pkg/handler"
 	notificationv1 "github.com/telekom/controlplane/notification/api/v1"
 	"github.com/telekom/controlplane/notification/internal/config"
-	"k8s.io/apimachinery/pkg/api/meta"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/log"
-	"time"
 )
 
 const (
@@ -29,7 +31,6 @@ type NotificationChannelHandler struct {
 }
 
 func (n *NotificationChannelHandler) CreateOrUpdate(ctx context.Context, channel *notificationv1.NotificationChannel) error {
-
 	doNotificationsHousekeeping(ctx, channel, n.HousekeepingConfig)
 
 	channel.SetCondition(condition.NewReadyCondition("Provisioned", "Notification channel is provisioned"))
@@ -42,33 +43,31 @@ func (n *NotificationChannelHandler) Delete(ctx context.Context, channel *notifi
 }
 
 func doNotificationsHousekeeping(ctx context.Context, channel *notificationv1.NotificationChannel, housekeepingConfig *config.NotificationHousekeepingConfig) {
-	log := log.FromContext(ctx)
+	logger := log.FromContext(ctx)
 
 	var notifications notificationv1.NotificationList
 	channelKey := fmt.Sprintf("%s/%s", channel.Namespace, channel.Name)
 
 	scopedClient := cclient.ClientFromContextOrDie(ctx)
 	if err := scopedClient.List(ctx, &notifications, client.MatchingFields{IndexFieldSpecChannelRefs: channelKey}); err != nil {
-		log.Error(err, fmt.Sprintf("Failed to list notifications for channel %q ", channelKey))
+		logger.Error(err, fmt.Sprintf("Failed to list notifications for channel %q ", channelKey))
 		return
 	}
 
-	for _, notification := range notifications.Items {
-
-		// let's check if the notification is eligible for housekeeping
-		if eligibleForHousekeeping(ctx, &notification, housekeepingConfig.TTLMonthsAfterFinished) {
-			err := scopedClient.Delete(ctx, &notification)
+	for i := range notifications.Items {
+		if eligibleForHousekeeping(ctx, &notifications.Items[i], housekeepingConfig.TTLMonthsAfterFinished) {
+			err := scopedClient.Delete(ctx, &notifications.Items[i])
 			if err != nil {
-				log.V(0).Error(err, "Failed to delete expired notification", "name", notification.Name)
+				logger.V(0).Error(err, "Failed to delete expired notification", "name", notifications.Items[i].Name)
 			} else {
-				log.V(0).Info("Deleted expired notification", "name", notification.Name)
+				logger.V(0).Info("Deleted expired notification", "name", notifications.Items[i].Name)
 			}
 		}
 	}
 }
 
 func eligibleForHousekeeping(ctx context.Context, notification *notificationv1.Notification, ttlMonthsAfterFinished int32) bool {
-	log := log.FromContext(ctx)
+	logger := log.FromContext(ctx)
 
 	// check if it's ready
 	ready := meta.IsStatusConditionTrue(notification.GetConditions(), condition.ConditionTypeReady)
@@ -93,7 +92,7 @@ func eligibleForHousekeeping(ctx context.Context, notification *notificationv1.N
 	ttl := time.Duration(ttlMonthsAfterFinished) * time.Hour * 24 * 7 * 4
 	expiry := readyTimestamp.Add(ttl)
 	if time.Now().After(expiry) {
-		log.V(1).Info("Notification is expired and eligible for housekeeping")
+		logger.V(1).Info("Notification is expired and eligible for housekeeping")
 		return true
 	} else {
 		return false

--- a/notification/internal/handler/notificationtemplate_handler.go
+++ b/notification/internal/handler/notificationtemplate_handler.go
@@ -9,14 +9,14 @@ import (
 	"encoding/json"
 
 	"github.com/pkg/errors"
-	"github.com/telekom/controlplane/common/pkg/errors/ctrlerrors"
-	"github.com/telekom/controlplane/notification/internal/rendering"
-	"github.com/telekom/controlplane/notification/internal/templatecache"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/telekom/controlplane/common/pkg/condition"
+	"github.com/telekom/controlplane/common/pkg/errors/ctrlerrors"
 	"github.com/telekom/controlplane/common/pkg/handler"
 	notificationv1 "github.com/telekom/controlplane/notification/api/v1"
+	"github.com/telekom/controlplane/notification/internal/rendering"
+	"github.com/telekom/controlplane/notification/internal/templatecache"
 )
 
 var _ handler.Handler[*notificationv1.NotificationTemplate] = &NotificationTemplateHandler{}
@@ -79,8 +79,8 @@ func (n *NotificationTemplateHandler) validateTemplate(template *notificationv1.
 }
 
 func (n *NotificationTemplateHandler) Delete(ctx context.Context, template *notificationv1.NotificationTemplate) error {
-	log := log.FromContext(ctx)
-	log.V(1).Info("Deleting template from cache", "name", template.Name)
+	logger := log.FromContext(ctx)
+	logger.V(1).Info("Deleting template from cache", "name", template.Name)
 
 	n.Cache.Delete(template.Name)
 	return nil

--- a/notification/internal/rendering/renderer.go
+++ b/notification/internal/rendering/renderer.go
@@ -12,13 +12,13 @@ import (
 	"time"
 
 	sprig "github.com/go-task/slim-sprig/v3"
+
 	notificationv1 "github.com/telekom/controlplane/notification/api/v1"
 	"github.com/telekom/controlplane/notification/internal/templatecache"
 )
 
 // parseTemplate parses both the subject and body templates, returns an error if the attempt fails
 func ParseTemplate(template *notificationv1.NotificationTemplate) (*templatecache.TemplateWrapper, error) {
-
 	// merge sprig + custom funcs
 	funcs := sprig.FuncMap()
 	for k, v := range getCustomTemplateFunctions() {

--- a/notification/internal/rendering/template_renderer_test.go
+++ b/notification/internal/rendering/template_renderer_test.go
@@ -9,9 +9,11 @@ import (
 	texttemplate "text/template"
 
 	sprig "github.com/go-task/slim-sprig/v3"
+
+	"github.com/telekom/controlplane/notification/internal/templatecache"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/telekom/controlplane/notification/internal/templatecache"
 )
 
 func TestRendering(t *testing.T) {
@@ -28,7 +30,6 @@ func mustUnmarshal(raw string) map[string]interface{} {
 }
 
 var _ = Describe("Template Rendering", func() {
-
 	Describe("Custom template functions", func() {
 		It("should render a template with a custom greeter function", func() {
 			funcs := sprig.FuncMap()

--- a/notification/internal/sender/adapter/adapter.go
+++ b/notification/internal/sender/adapter/adapter.go
@@ -20,7 +20,7 @@ type Attachment struct {
 }
 
 type NotificationAdapter[C NotificationConfig] interface {
-	Send(ctx context.Context, config C, title string, body string, attachments []Attachment) error
+	Send(ctx context.Context, config C, title, body string, attachments []Attachment) error
 }
 
 type MailChannelConfiguration interface {

--- a/notification/internal/sender/adapter/mail/email_mail_adapter.go
+++ b/notification/internal/sender/adapter/mail/email_mail_adapter.go
@@ -6,8 +6,10 @@ package mail
 
 import (
 	"context"
+
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
+
 	"github.com/telekom/controlplane/notification/internal/config"
 	"github.com/telekom/controlplane/notification/internal/sender/adapter"
 )

--- a/notification/internal/sender/adapter/mail/smtp_email_sender.go
+++ b/notification/internal/sender/adapter/mail/smtp_email_sender.go
@@ -14,9 +14,10 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
+	"gopkg.in/gomail.v2"
+
 	"github.com/telekom/controlplane/notification/internal/config"
 	"github.com/telekom/controlplane/notification/internal/sender/adapter"
-	"gopkg.in/gomail.v2"
 )
 
 var _ EmailSender = SMTPEmailSender{}
@@ -37,13 +38,13 @@ var NewSMTPSender = func(config *config.EmailAdapterConfig) EmailSender {
 func (s SMTPEmailSender) Send(ctx context.Context, from, senderName string, bcc []string, subject, body string, attachments []adapter.Attachment) error {
 	log := logr.FromContextOrDiscard(ctx)
 
-	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	_, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 
 	d := gomail.NewDialer(s.config.SMTPConnection.Host, s.config.SMTPConnection.Port, s.config.SMTPConnection.User, s.config.SMTPConnection.Password)
 
 	// we are aware that the InsecureSkipVerify is set to true. communication is within cluster and this is currently acceptable
-	d.TLSConfig = &tls.Config{ServerName: s.config.SMTPConnection.Host, InsecureSkipVerify: true}
+	d.TLSConfig = &tls.Config{ServerName: s.config.SMTPConnection.Host, InsecureSkipVerify: true} //nolint:gosec // G402: intra-cluster communication, acceptable risk
 
 	m := gomail.NewMessage()
 	m.SetHeader("From", fmt.Sprintf("%s <%s>", senderName, from))

--- a/notification/internal/sender/adapter/msteams/http_client.go
+++ b/notification/internal/sender/adapter/msteams/http_client.go
@@ -86,7 +86,7 @@ func NewRestyClient(config *HTTPClientConfig) *resty.Client {
 
 	// Configure custom transport with connection pooling and timeouts
 	// Start with http.DefaultTransport settings to preserve proxy and TLS config
-	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport := http.DefaultTransport.(*http.Transport).Clone() //nolint:errcheck // DefaultTransport is always *http.Transport
 
 	// Override with custom settings
 	transport.MaxIdleConns = config.MaxIdleConns

--- a/notification/internal/sender/adapter/msteams/http_client.go
+++ b/notification/internal/sender/adapter/msteams/http_client.go
@@ -86,7 +86,11 @@ func NewRestyClient(config *HTTPClientConfig) *resty.Client {
 
 	// Configure custom transport with connection pooling and timeouts
 	// Start with http.DefaultTransport settings to preserve proxy and TLS config
-	transport := http.DefaultTransport.(*http.Transport).Clone() //nolint:errcheck // DefaultTransport is always *http.Transport
+	defaultTransport, ok := http.DefaultTransport.(*http.Transport)
+	if !ok {
+		defaultTransport = &http.Transport{}
+	}
+	transport := defaultTransport.Clone()
 
 	// Override with custom settings
 	transport.MaxIdleConns = config.MaxIdleConns

--- a/notification/internal/sender/adapter/msteams/http_client_helpers_test.go
+++ b/notification/internal/sender/adapter/msteams/http_client_helpers_test.go
@@ -28,13 +28,10 @@ func newSuccessServer(t *testing.T, statusCode int, responseBody string) *httpte
 	}))
 }
 
-// newRetryServer creates a test server that fails N times before succeeding
-// Returns the server and the attempt counter (use .Load() to read)
+// newRetryServer creates a test server that fails N times before succeeding.
+// Returns the server and the attempt counter (use .Load() to read).
 //
-// successCode is always http.StatusOK in current tests, but kept as parameter
-// for flexibility and to make test intent explicit
-//
-//nolint:unparam
+//nolint:unparam // successCode kept as parameter for test flexibility even though currently always http.StatusOK
 func newRetryServer(t *testing.T, failureCode, successCode, failuresBeforeSuccess int) (*httptest.Server, *atomic.Int32) {
 	t.Helper()
 	var attemptCount atomic.Int32
@@ -50,12 +47,9 @@ func newRetryServer(t *testing.T, failureCode, successCode, failuresBeforeSucces
 	return server, &attemptCount
 }
 
-// newDelayedServer creates a test server that delays response by the given duration
+// newDelayedServer creates a test server that delays response by the given duration.
 //
-// statusCode is currently always http.StatusOK, but kept as parameter for flexibility
-// in testing different response scenarios
-//
-//nolint:unparam
+//nolint:unparam // statusCode kept as parameter for test flexibility even though currently always http.StatusOK
 func newDelayedServer(t *testing.T, delay time.Duration, statusCode int) *httptest.Server {
 	t.Helper()
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/notification/internal/sender/adapter/msteams/msteams_chat_adapter.go
+++ b/notification/internal/sender/adapter/msteams/msteams_chat_adapter.go
@@ -12,11 +12,12 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/pkg/errors"
-	"github.com/telekom/controlplane/notification/internal/sender/adapter"
 
 	"github.com/go-logr/logr"
 	"github.com/go-resty/resty/v2"
+	"github.com/pkg/errors"
+
+	"github.com/telekom/controlplane/notification/internal/sender/adapter"
 )
 
 const (
@@ -113,7 +114,6 @@ func (e MsTeamsAdapter) Send(ctx context.Context, config adapter.ChatChannelConf
 		SetContext(ctx).
 		SetBody(body).
 		Post(webhookURL)
-
 	if err != nil {
 		log.Error(err, "HTTP request failed",
 			"webhook", webhookURL,

--- a/notification/internal/sender/adapter/msteams/msteams_chat_adapter_test.go
+++ b/notification/internal/sender/adapter/msteams/msteams_chat_adapter_test.go
@@ -7,12 +7,13 @@ package msteams
 import (
 	"context"
 	"encoding/json"
-	adapter2 "github.com/telekom/controlplane/notification/internal/sender/adapter"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
+
+	adapter2 "github.com/telekom/controlplane/notification/internal/sender/adapter"
 )
 
 // mockChatConfig is a test implementation of ChatConfiguration

--- a/notification/internal/sender/adapter/webhook/webhook_callback_adapter.go
+++ b/notification/internal/sender/adapter/webhook/webhook_callback_adapter.go
@@ -6,14 +6,15 @@ package webhook
 
 import (
 	"context"
+
 	"github.com/go-logr/logr"
+
 	"github.com/telekom/controlplane/notification/internal/sender/adapter"
 )
 
 var _ adapter.NotificationAdapter[adapter.CallbackChannelConfiguration] = &WebhookAdapter{}
 
-type WebhookAdapter struct {
-}
+type WebhookAdapter struct{}
 
 // Send delivers a notification via the configured webhook callback URL.
 func (e WebhookAdapter) Send(ctx context.Context, config adapter.CallbackChannelConfiguration, title, body string, _ []adapter.Attachment) error {

--- a/notification/internal/sender/notification_sender.go
+++ b/notification/internal/sender/notification_sender.go
@@ -6,13 +6,15 @@ package sender
 
 import (
 	"context"
+
 	"github.com/pkg/errors"
+
 	notificationv1 "github.com/telekom/controlplane/notification/api/v1"
 	"github.com/telekom/controlplane/notification/internal/sender/adapter"
 )
 
 type NotificationSender interface {
-	ProcessNotification(ctx context.Context, channel *notificationv1.NotificationChannel, subject string, body string, attachments []adapter.Attachment) error
+	ProcessNotification(ctx context.Context, channel *notificationv1.NotificationChannel, subject, body string, attachments []adapter.Attachment) error
 }
 
 var _ NotificationSender = AdapterSender{}
@@ -25,7 +27,6 @@ type AdapterSender struct {
 
 // ProcessNotification routes a rendered notification to the appropriate channel adapter.
 func (a AdapterSender) ProcessNotification(ctx context.Context, channel *notificationv1.NotificationChannel, subject, body string, attachments []adapter.Attachment) error {
-
 	var err error
 	switch nType := channel.NotificationType(); nType {
 	case notificationv1.NotificationTypeMail:


### PR DESCRIPTION
 ## Update Makefile
 Update tool versions and golangci-lint target in Makefile.

 ## Autofixes for `notification/`
 Use make lint-fix to autofix issues

  ## Manual lint fixes for `notification/`
- Apply gofmt/goimports-style formatting and minor refactors (imports, variable naming, loop patterns).