### PR TITLE
fix(file-manager): Fix golangci-lint issues

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -94,6 +94,7 @@ jobs:
       run_check_generated_files: false
       ko_build_path: "cmd/server/server.go"
       coverage_threshold: 61
+      lint_fail_on_issues: true
 
   gateway:
     name: Gateway

--- a/file-manager/Makefile
+++ b/file-manager/Makefile
@@ -26,3 +26,51 @@ COVER_PACKAGES = ./internal/handler/...,./pkg/...
 .PHONY: test
 test: fmt vet ## Run tests.
 	gotestsum --format pkgname --junitfile junit.xml --jsonfile gotest.log -- $(TEST_PACKAGES) -coverprofile cover.out --coverpkg $(COVER_PACKAGES) -mod=readonly -race
+
+##@ Lint
+
+.PHONY: lint
+lint: golangci-lint ## Run golangci-lint linter
+	"$(GOLANGCI_LINT)" run
+
+.PHONY: lint-fix
+lint-fix: golangci-lint ## Run golangci-lint linter and perform fixes
+	"$(GOLANGCI_LINT)" run --fix
+
+.PHONY: lint-config
+lint-config: golangci-lint ## Verify golangci-lint linter configuration
+	"$(GOLANGCI_LINT)" config verify
+
+##@ Dependencies
+
+## Location to install dependencies to
+LOCALBIN ?= $(shell pwd)/bin
+$(LOCALBIN):
+	mkdir -p $(LOCALBIN)
+
+## Tool Binaries
+GOLANGCI_LINT = $(LOCALBIN)/golangci-lint
+
+## Tool Versions
+GOLANGCI_LINT_VERSION ?= v2.11.4
+
+.PHONY: golangci-lint
+golangci-lint: $(GOLANGCI_LINT) ## Download golangci-lint locally if necessary.
+$(GOLANGCI_LINT): $(LOCALBIN)
+	$(call go-install-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/v2/cmd/golangci-lint,$(GOLANGCI_LINT_VERSION))
+
+# go-install-tool will 'go install' any package with custom target and name of binary, if it doesn't exist
+# $1 - target path with name of binary
+# $2 - package url which can be installed
+# $3 - specific version of package
+define go-install-tool
+@[ -f "$(1)-$(3)" ] && [ "$$(readlink -- "$(1)" 2>/dev/null)" = "$(1)-$(3)" ] || { \
+set -e; \
+package=$(2)@$(3) ;\
+echo "Downloading $${package}" ;\
+rm -f "$(1)" ;\
+GOBIN="$(LOCALBIN)" go install $${package} ;\
+mv "$(LOCALBIN)/$$(basename "$(1)")" "$(1)-$(3)" ;\
+} ;\
+ln -sf "$$(realpath "$(1)-$(3)")" "$(1)"
+endef

--- a/file-manager/api/api.go
+++ b/file-manager/api/api.go
@@ -29,7 +29,7 @@ import (
 const (
 	localhost                = "http://localhost:8443/api"
 	inCluster                = "https://file-manager.controlplane-system.svc.cluster.local/api"
-	TokenFilePath            = "/var/run/secrets/filemgr/token"
+	TokenFilePath            = "/var/run/secrets/filemgr/token" //nolint:gosec // G101: path constant, not a credential
 	uploadRequestContentType = "application/octet-stream"
 
 	CaFilePath = "/var/run/secrets/trust-bundle/trust-bundle.pem"
@@ -46,7 +46,7 @@ type DownloadApi interface {
 }
 
 type UploadApi interface {
-	UploadFile(ctx context.Context, fileId string, fileContentType string, r io.Reader) (*FileUploadResponse, error)
+	UploadFile(ctx context.Context, fileId, fileContentType string, r io.Reader) (*FileUploadResponse, error)
 }
 
 type DeleteApi interface {
@@ -106,6 +106,7 @@ func WithURL(url string) Option {
 		o.URL = url
 	}
 }
+
 func WithAccessToken(token accesstoken.AccessToken) Option {
 	return func(o *Options) {
 		o.Token = token
@@ -143,7 +144,6 @@ func New(opts ...Option) FileManager {
 			client.WithCaFilepath(CaFilePath),
 		)),
 		gen.WithRequestEditorFn(options.accessTokenReqEditor))
-
 	if err != nil {
 		log.Fatalf("Failed to create file manager client: %v", err)
 	}
@@ -162,15 +162,15 @@ func GetFileManager(opts ...Option) FileManager {
 	return api
 }
 
-func (f *FileManagerAPI) UploadFile(ctx context.Context, fileId string, fileContentType string, r io.Reader) (*FileUploadResponse, error) {
-	log := logr.FromContextOrDiscard(ctx)
+func (f *FileManagerAPI) UploadFile(ctx context.Context, fileId, fileContentType string, r io.Reader) (*FileUploadResponse, error) {
+	logger := logr.FromContextOrDiscard(ctx)
 
 	buf := bytes.NewBuffer(nil)
 	size, hash, err := copyAndHash(buf, r)
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to copy content")
 	}
-	log.V(1).Info("Uploading file ", "fileId", fileId, "fileContentType", fileContentType, "size", size, "hash", hash)
+	logger.V(1).Info("Uploading file ", "fileId", fileId, "fileContentType", fileContentType, "size", size, "hash", hash)
 
 	params := &gen.UploadFileParams{
 		XFileContentType: &fileContentType,
@@ -180,11 +180,10 @@ func (f *FileManagerAPI) UploadFile(ctx context.Context, fileId string, fileCont
 	}
 	// use generated client code to call the file manager server
 	response, err := f.Client.UploadFileWithBody(ctx, fileId, params, uploadRequestContentType, buf)
-
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to upload file")
 	}
-	defer response.Body.Close() //nolint:errcheck
+	defer response.Body.Close() //nolint:errcheck // best-effort close
 
 	// evaluate the response
 	switch response.StatusCode {
@@ -215,12 +214,12 @@ func (f *FileManagerAPI) UploadFile(ctx context.Context, fileId string, fileCont
 }
 
 func (f *FileManagerAPI) DownloadFile(ctx context.Context, fileId string, w io.Writer) (*FileDownloadResponse, error) {
-	log := logr.FromContextOrDiscard(ctx)
+	logger := logr.FromContextOrDiscard(ctx)
 	response, err := f.Client.DownloadFile(ctx, fileId)
 	if err != nil {
 		return nil, err
 	}
-	defer response.Body.Close() //nolint:errcheck
+	defer response.Body.Close() //nolint:errcheck // best-effort close
 
 	switch response.StatusCode {
 	case http.StatusOK:
@@ -228,7 +227,7 @@ func (f *FileManagerAPI) DownloadFile(ctx context.Context, fileId string, w io.W
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to copy file content")
 		}
-		log.V(1).Info("Downloaded file", "fileId", fileId, "size", size, "hash", hash)
+		logger.V(1).Info("Downloaded file", "fileId", fileId, "size", size, "hash", hash)
 
 		expectedChecksum := extractHeader(response, constants.XFileChecksum)
 		if f.ValidateChecksum && hash != expectedChecksum {
@@ -255,7 +254,7 @@ func (f *FileManagerAPI) DeleteFile(ctx context.Context, fileId string) error {
 	if err != nil {
 		return err
 	}
-	defer response.Body.Close() //nolint:errcheck
+	defer response.Body.Close() //nolint:errcheck // best-effort close
 
 	switch response.StatusCode {
 	case http.StatusNoContent:

--- a/file-manager/api/api_test.go
+++ b/file-manager/api/api_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+
 	"github.com/telekom/controlplane/file-manager/api"
 	"github.com/telekom/controlplane/file-manager/api/constants"
 	gen_test "github.com/telekom/controlplane/file-manager/api/gen/mock"

--- a/file-manager/cmd/client/client.go
+++ b/file-manager/cmd/client/client.go
@@ -112,7 +112,7 @@ func main() {
 		return
 	}
 
-	if fileId != "" {
+	if fileId != "" { //nolint:nestif // CLI command flow with necessary nesting
 		// download file
 		w := os.Stdout
 		if outputFile != "" {
@@ -120,7 +120,11 @@ func main() {
 			if err != nil {
 				panic(err)
 			}
-			defer file.Close() //nolint:errcheck // best-effort close
+			defer func() {
+				if err := file.Close(); err != nil {
+					panic(err)
+				}
+			}()
 			w = file
 		}
 		fileInfo, err := fileManager.DownloadFile(ctx, fileId, w)

--- a/file-manager/cmd/client/client.go
+++ b/file-manager/cmd/client/client.go
@@ -91,12 +91,12 @@ func main() {
 
 	if filepath != "" && fileId != "" {
 		// upload file
-		file, err := os.Open(filepath)
+		file, err := os.Open(filepath) //nolint:gosec // G304: filepath comes from CLI argument
 		if err != nil {
 			fmt.Println("Error opening file:", err)
 			return
 		}
-		defer file.Close() //nolint:errcheck
+		defer file.Close() //nolint:errcheck // best-effort close
 
 		contentType, err := detectContentType(file)
 		if err != nil {
@@ -116,11 +116,11 @@ func main() {
 		// download file
 		w := os.Stdout
 		if outputFile != "" {
-			file, err := os.OpenFile(outputFile, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0644)
+			file, err := os.OpenFile(outputFile, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600) //nolint:gosec // G304: filepath comes from CLI argument
 			if err != nil {
 				panic(err)
 			}
-			defer file.Close() //nolint:errcheck
+			defer file.Close() //nolint:errcheck // best-effort close
 			w = file
 		}
 		fileInfo, err := fileManager.DownloadFile(ctx, fileId, w)
@@ -145,7 +145,7 @@ func detectContentType(file *os.File) (string, error) {
 	if err != nil && err != io.EOF {
 		return "", err
 	}
-	file.Seek(0, 0) //nolint:errcheck
+	file.Seek(0, 0) //nolint:errcheck,gosec // best-effort seek for retry
 
 	contentType = http.DetectContentType(buffer)
 	return contentType, nil

--- a/file-manager/cmd/server/config/config.go
+++ b/file-manager/cmd/server/config/config.go
@@ -25,7 +25,7 @@ func (c BackendConfig) Get(key string) string {
 	return c.Config[key]
 }
 
-func (c BackendConfig) GetDefault(key string, defaultValue string) string {
+func (c BackendConfig) GetDefault(key, defaultValue string) string {
 	if c.Config == nil {
 		return defaultValue
 	}
@@ -71,11 +71,11 @@ func GetConfigOrDie(filepath string) *ServerConfig {
 	if filepath == "" {
 		return DefaultConfig()
 	}
-	file, err := os.OpenFile(filepath, os.O_RDONLY, 0o644) //nolint:gosec
+	file, err := os.OpenFile(filepath, os.O_RDONLY, 0o644) //nolint:gosec // G302: config file needs standard permissions
 	if err != nil {
 		panic(err)
 	}
-	defer file.Close() //nolint:errcheck
+	defer file.Close() //nolint:errcheck // best-effort close
 	cfg, err := ReadConfig(file)
 	if err != nil {
 		panic(err)

--- a/file-manager/cmd/server/server.go
+++ b/file-manager/cmd/server/server.go
@@ -147,7 +147,7 @@ func main() {
 	probesCtrl.Register(app, cs.ControllerOpts{})
 
 	apiGroup := app.Group("/api")
-	handler := api.NewStrictHandler(handler.NewHandler(ctrl), nil)
+	h := api.NewStrictHandler(handler.NewHandler(ctrl), nil)
 
 	if cfg.Security.Enabled {
 		opts := []k8s.KubernetesAuthOption{
@@ -163,7 +163,7 @@ func main() {
 		apiGroup.Use(k8s.NewKubernetesAuthz(opts...))
 	}
 
-	api.RegisterHandlersWithOptions(apiGroup, handler, api.FiberServerOptions{})
+	api.RegisterHandlersWithOptions(apiGroup, h, api.FiberServerOptions{})
 
 	go func() {
 		if disableTls {

--- a/file-manager/internal/handler/error.go
+++ b/file-manager/internal/handler/error.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/gofiber/fiber/v2"
+
 	"github.com/telekom/controlplane/common-server/pkg/server"
 	"github.com/telekom/controlplane/file-manager/pkg/backend"
 )

--- a/file-manager/pkg/backend/buckets/config.go
+++ b/file-manager/pkg/backend/buckets/config.go
@@ -13,7 +13,7 @@ import (
 
 const (
 	// BucketsBackendTokenPath per convention - /var/run/secrets/:backendName/token
-	BucketsBackendTokenPath = "/var/run/secrets/buckets/token"
+	BucketsBackendTokenPath = "/var/run/secrets/buckets/token" //nolint:gosec // G101: path constant, not a credential
 )
 
 // BucketConfig holds all configuration needed for bucket operations

--- a/file-manager/pkg/backend/buckets/credentials.go
+++ b/file-manager/pkg/backend/buckets/credentials.go
@@ -9,11 +9,13 @@ import (
 
 	"github.com/minio/minio-go/v7/pkg/credentials"
 	"github.com/pkg/errors"
+
 	accesstoken "github.com/telekom/controlplane/common-server/pkg/client/token"
 )
 
 type CredentialProvider string
 
+//nolint:gosec // G101: path constants, not credentials
 const (
 	CredentialProviderEnvMinio       CredentialProvider = "env-minio"
 	CredentialProviderSTSWebIdentity CredentialProvider = "sts-web-identity"
@@ -21,13 +23,13 @@ const (
 )
 
 type Properties interface {
-	GetDefault(key string, defaultValue string) string
+	GetDefault(key, defaultValue string) string
 	Get(key string) string
 }
 
 type propertiesMap map[string]string
 
-func (p propertiesMap) GetDefault(key string, defaultValue string) string {
+func (p propertiesMap) GetDefault(key, defaultValue string) string {
 	value, exists := p[key]
 	if !exists {
 		return defaultValue
@@ -54,7 +56,11 @@ func WithProperty(key, value string) CredentialOption {
 		if o.properties == nil {
 			o.properties = propertiesMap{}
 		}
-		o.properties.(propertiesMap)[key] = value
+		pm, ok := o.properties.(propertiesMap)
+		if !ok {
+			return
+		}
+		pm[key] = value
 	}
 }
 

--- a/file-manager/pkg/backend/buckets/credentials_test.go
+++ b/file-manager/pkg/backend/buckets/credentials_test.go
@@ -18,7 +18,7 @@ func newMockProperties(props map[string]string) Properties {
 	return &mockProperties{props: props}
 }
 
-func (m *mockProperties) GetDefault(key string, defaultValue string) string {
+func (m *mockProperties) GetDefault(key, defaultValue string) string {
 	if val, ok := m.props[key]; ok {
 		return val
 	}

--- a/file-manager/pkg/backend/buckets/file_downloader.go
+++ b/file-manager/pkg/backend/buckets/file_downloader.go
@@ -12,6 +12,7 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/minio/minio-go/v7"
 	"github.com/pkg/errors"
+
 	"github.com/telekom/controlplane/file-manager/pkg/backend"
 )
 
@@ -41,7 +42,7 @@ func (s *BucketFileDownloader) downloadObject(ctx context.Context, path string) 
 		log.Error(err, "Failed to get file from bucket")
 		return nil, errors.Wrap(err, "failed to get file from bucket")
 	}
-	defer object.Close() //nolint:errcheck
+	defer object.Close() //nolint:errcheck // best-effort close
 
 	// Create a buffer to store the downloaded content
 	buf := new(bytes.Buffer)

--- a/file-manager/pkg/backend/buckets/file_uploader.go
+++ b/file-manager/pkg/backend/buckets/file_uploader.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/minio/minio-go/v7"
+
 	"github.com/telekom/controlplane/file-manager/api/constants"
 	"github.com/telekom/controlplane/file-manager/pkg/backend"
 	"github.com/telekom/controlplane/file-manager/pkg/backend/identifier"

--- a/file-manager/pkg/backend/buckets/file_uploader_test.go
+++ b/file-manager/pkg/backend/buckets/file_uploader_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/minio/minio-go/v7"
+
 	"github.com/telekom/controlplane/file-manager/pkg/backend"
 )
 

--- a/file-manager/pkg/backend/buckets/minio_wrapper.go
+++ b/file-manager/pkg/backend/buckets/minio_wrapper.go
@@ -40,6 +40,8 @@ func (w *MinioWrapper) GetObjectInfo(ctx context.Context, path string) (minio.Ob
 }
 
 // ExtractMetadata extracts relevant metadata from object info
+//
+//nolint:gocritic // hugeParam: minio API returns value type
 func (w *MinioWrapper) ExtractMetadata(ctx context.Context, objInfo minio.ObjectInfo) map[string]string {
 	log := logr.FromContextOrDiscard(ctx)
 	metadata := make(map[string]string)
@@ -75,7 +77,7 @@ var validator *ObjectMetadataValidator
 
 // ValidateObjectMetadata delegates to the ObjectMetadataValidator
 // This method maintains backwards compatibility with existing code
-func (w *MinioWrapper) ValidateObjectMetadata(ctx context.Context, path string, expectedContentType string, expectedChecksum string, uploadedCRC64 string) error {
+func (w *MinioWrapper) ValidateObjectMetadata(ctx context.Context, path, expectedContentType, expectedChecksum, uploadedCRC64 string) error {
 	// Create the validator if it doesn't exist yet
 	if validator == nil {
 		validator = NewObjectMetadataValidator(w)

--- a/file-manager/pkg/backend/buckets/minio_wrapper_test.go
+++ b/file-manager/pkg/backend/buckets/minio_wrapper_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/minio/minio-go/v7"
+
 	"github.com/telekom/controlplane/file-manager/api/constants"
 )
 

--- a/file-manager/pkg/backend/buckets/validation.go
+++ b/file-manager/pkg/backend/buckets/validation.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/minio/minio-go/v7"
+
 	"github.com/telekom/controlplane/file-manager/api/constants"
 	"github.com/telekom/controlplane/file-manager/pkg/backend"
 )
@@ -33,7 +34,7 @@ func NewObjectMetadataValidator(wrapper BucketClientValidator) *ObjectMetadataVa
 }
 
 // ValidateObjectMetadata validates that the uploaded object metadata matches expectations
-func (v *ObjectMetadataValidator) ValidateObjectMetadata(ctx context.Context, path string, expectedContentType string, expectedChecksum string, uploadedCRC64 string) error {
+func (v *ObjectMetadataValidator) ValidateObjectMetadata(ctx context.Context, path, expectedContentType, expectedChecksum, uploadedCRC64 string) error {
 	log := logr.FromContextOrDiscard(ctx)
 
 	// First validate the client
@@ -83,7 +84,7 @@ func (v *ObjectMetadataValidator) validateContentType(ctx context.Context, actua
 }
 
 // validateChecksum checks if the stored checksum matches the expected checksum
-func (v *ObjectMetadataValidator) validateChecksum(ctx context.Context, objInfo interface{}, expectedChecksum string, uploadedCRC64 string) error {
+func (v *ObjectMetadataValidator) validateChecksum(ctx context.Context, objInfo interface{}, expectedChecksum, uploadedCRC64 string) error {
 	log := logr.FromContextOrDiscard(ctx)
 
 	// Skip validation if no checksum was expected
@@ -99,31 +100,29 @@ func (v *ObjectMetadataValidator) validateChecksum(ctx context.Context, objInfo 
 
 	// Use uploadedCRC64 if provided, otherwise fall back to object info
 	var storedChecksum string
-	if uploadedCRC64 != "" {
+	var checksumSource string
+	switch {
+	case uploadedCRC64 != "":
 		storedChecksum = uploadedCRC64
+		checksumSource = "UploadedCRC64NVME"
 		log.V(1).Info("Using uploaded CRC64NVME checksum for validation", "checksum", storedChecksum)
-	} else if objInfoTyped.ChecksumCRC64NVME != "" {
+	case objInfoTyped.ChecksumCRC64NVME != "":
 		storedChecksum = objInfoTyped.ChecksumCRC64NVME
+		checksumSource = "CRC64NVME"
 		log.V(1).Info("Using CRC64NVME checksum from object info for validation", "checksum", storedChecksum)
-	} else if objInfoTyped.ETag != "" {
+	case objInfoTyped.ETag != "":
 		storedChecksum = objInfoTyped.ETag
+		checksumSource = "S3 ETag"
 		log.V(1).Info("Using generated checksum (ETag) for validation", "checksum", storedChecksum)
-	} else {
+	default:
 		// Fall back to UserMetadata if neither CRC64 nor ETag is available
 		storedChecksum = objInfoTyped.UserMetadata[constants.XFileChecksum]
+		checksumSource = "UserMetadata"
 		log.V(1).Info("Using UserMetadata checksum for validation", "userMetadataChecksum", storedChecksum)
 	}
 
 	// If checksum differs from what was expected, return an error
 	if storedChecksum != expectedChecksum {
-		checksumSource := "UserMetadata"
-		if uploadedCRC64 != "" {
-			checksumSource = "UploadedCRC64NVME"
-		} else if objInfoTyped.ChecksumCRC64NVME != "" {
-			checksumSource = "CRC64NVME"
-		} else if objInfoTyped.ETag != "" {
-			checksumSource = "S3 ETag"
-		}
 		log.Error(nil, "Checksum mismatch",
 			"expected", expectedChecksum,
 			"actual", storedChecksum,

--- a/file-manager/pkg/backend/buckets/validation_test.go
+++ b/file-manager/pkg/backend/buckets/validation_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/minio/minio-go/v7"
 	"github.com/pkg/errors"
+
 	"github.com/telekom/controlplane/file-manager/api/constants"
 )
 

--- a/file-manager/pkg/backend/errors.go
+++ b/file-manager/pkg/backend/errors.go
@@ -164,7 +164,7 @@ func IsTooManyRequestsErr(err error) bool {
 }
 
 // ErrInvalidChecksum creates a BackendError for a checksum mismatch
-func ErrInvalidChecksum(fileId string, expected, actual string) *BackendError {
+func ErrInvalidChecksum(fileId, expected, actual string) *BackendError {
 	err := fmt.Errorf("checksum mismatch for file '%s': expected %s, got %s", fileId, expected, actual)
 	return NewBackendError(fileId, err, TypeErrInvalidChecksum)
 }
@@ -182,7 +182,7 @@ func IsInvalidChecksumErr(err error) bool {
 }
 
 // ErrInvalidContentType creates a BackendError for a content type mismatch
-func ErrInvalidContentType(fileId string, expected, actual string) *BackendError {
+func ErrInvalidContentType(fileId, expected, actual string) *BackendError {
 	err := fmt.Errorf("content type mismatch for file '%s': expected %s, got %s", fileId, expected, actual)
 	return NewBackendError(fileId, err, TypeErrInvalidContentType)
 }
@@ -218,7 +218,7 @@ func IsClientInitializationErr(err error) bool {
 }
 
 // ErrUploadFailed creates a BackendError for file upload failures
-func ErrUploadFailed(fileId string, details string) *BackendError {
+func ErrUploadFailed(fileId, details string) *BackendError {
 	err := fmt.Errorf("failed to upload file '%s': %s", fileId, details)
 	return NewBackendError(fileId, err, TypeErrUploadFailed)
 }
@@ -236,7 +236,7 @@ func IsUploadFailedErr(err error) bool {
 }
 
 // ErrDownloadFailed creates a BackendError for file download failures
-func ErrDownloadFailed(fileId string, details string) *BackendError {
+func ErrDownloadFailed(fileId, details string) *BackendError {
 	err := fmt.Errorf("failed to download file '%s': %s", fileId, details)
 	return NewBackendError(fileId, err, TypeErrDownloadFailed)
 }

--- a/file-manager/pkg/controller/delete_controller_test.go
+++ b/file-manager/pkg/controller/delete_controller_test.go
@@ -7,20 +7,19 @@ package controller_test
 import (
 	"context"
 
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
 	"github.com/pkg/errors"
 
 	"github.com/telekom/controlplane/file-manager/pkg/backend"
 	"github.com/telekom/controlplane/file-manager/pkg/controller"
 	"github.com/telekom/controlplane/file-manager/test/mocks"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("DeleteController", func() {
-
 	Context("Delete controller", func() {
-
-		var mockedBackend = &mocks.MockFileDeleter{}
+		mockedBackend := &mocks.MockFileDeleter{}
 
 		It("Should delete files successfully", func() {
 			ctx := context.Background()
@@ -105,7 +104,5 @@ var _ = Describe("DeleteController", func() {
 			Expect(err.Error()).To(ContainSubstring("InvalidFileId"))
 			Expect(err.Error()).To(ContainSubstring("poc----file.txt"))
 		})
-
 	})
-
 })

--- a/file-manager/pkg/controller/download_controller_test.go
+++ b/file-manager/pkg/controller/download_controller_test.go
@@ -7,13 +7,13 @@ package controller_test
 import (
 	"bytes"
 	"context"
+	"io"
 
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
 	"github.com/telekom/controlplane/file-manager/pkg/controller"
 	"github.com/telekom/controlplane/file-manager/test/mocks"
 
-	"io"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 )
 
 const (
@@ -22,10 +22,8 @@ const (
 )
 
 var _ = Describe("DownloadController", func() {
-
 	Context("Download controller", func() {
-
-		var mockedBackend = &mocks.MockFileDownloader{}
+		mockedBackend := &mocks.MockFileDownloader{}
 
 		It("Should download files", func() {
 			ctx := context.Background()
@@ -33,7 +31,7 @@ var _ = Describe("DownloadController", func() {
 
 			writer := getMockWriterWithContent("this is a test file content")
 
-			var headers = make(map[string]string)
+			headers := make(map[string]string)
 			headers[XFileContentType] = "application/yaml"
 			headers[XFileChecksum] = "thisIsATestChecksum"
 
@@ -76,9 +74,7 @@ var _ = Describe("DownloadController", func() {
 			Expect(m).To(BeNil())
 			Expect(file).To(BeNil())
 		})
-
 	})
-
 })
 
 func getMockWriterWithContent(content string) io.ReadWriter {

--- a/file-manager/pkg/controller/upload_controller.go
+++ b/file-manager/pkg/controller/upload_controller.go
@@ -7,13 +7,13 @@ package controller
 import (
 	"context"
 	"io"
+	"maps"
 	"mime"
 	"path/filepath"
 	"strings"
 
-	"maps"
-
 	"github.com/go-logr/logr"
+
 	"github.com/telekom/controlplane/file-manager/api/constants"
 	"github.com/telekom/controlplane/file-manager/pkg/backend"
 	"github.com/telekom/controlplane/file-manager/pkg/backend/identifier"

--- a/file-manager/pkg/controller/upload_controller_test.go
+++ b/file-manager/pkg/controller/upload_controller_test.go
@@ -6,21 +6,20 @@ package controller_test
 
 import (
 	"context"
+	"io"
 	"strings"
 
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
 	"github.com/pkg/errors"
+
 	"github.com/telekom/controlplane/file-manager/pkg/controller"
 	"github.com/telekom/controlplane/file-manager/test/mocks"
 
-	"io"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("UploadController", func() {
-
 	Context("Upload controller", func() {
-
 		var mockedBackend *mocks.MockFileUploader
 		BeforeEach(func() {
 			mockedBackend = &mocks.MockFileUploader{}
@@ -31,13 +30,13 @@ var _ = Describe("UploadController", func() {
 			ctrl := controller.NewUploadController(mockedBackend)
 
 			var reader io.Reader = strings.NewReader("test content")
-			var backendMetadata = make(map[string]string)
+			backendMetadata := make(map[string]string)
 			backendMetadata["X-File-Content-Type"] = "application/octet-stream"
 			backendMetadata["X-File-Checksum"] = "test-checksum"
 
 			mockedBackend.EXPECT().UploadFile(any(ctx), "poc--eni--hyperion--my-test-file", reader, backendMetadata).Return("poc--eni--hyperion--my-test-file", nil)
 
-			var callMetadata = make(map[string]string)
+			callMetadata := make(map[string]string)
 			callMetadata["X-File-Content-Type"] = "application/octet-stream"
 			callMetadata["X-File-Checksum"] = "test-checksum"
 
@@ -52,14 +51,14 @@ var _ = Describe("UploadController", func() {
 			ctrl := controller.NewUploadController(mockedBackend)
 
 			var reader io.Reader = strings.NewReader("test content")
-			var backendMetadata = make(map[string]string)
+			backendMetadata := make(map[string]string)
 			backendMetadata["X-File-Checksum"] = "test-checksum"
 			backendMetadata["X-File-Content-Type"] = "application/octet-stream"
 			backendMetadata["X-File-Content-Type-Source"] = "auto-detected"
 
 			mockedBackend.EXPECT().UploadFile(any(ctx), "poc--eni--hyperion--my-test-file", reader, backendMetadata).Return("poc--eni--hyperion--my-test-file", nil)
 
-			var callMetadata = make(map[string]string)
+			callMetadata := make(map[string]string)
 			callMetadata["X-File-Checksum"] = "test-checksum"
 
 			file, err := ctrl.UploadFile(ctx, "poc--eni--hyperion--my-test-file", reader, callMetadata)
@@ -73,14 +72,14 @@ var _ = Describe("UploadController", func() {
 			ctrl := controller.NewUploadController(mockedBackend)
 
 			var reader io.Reader = strings.NewReader("test content")
-			var backendMetadata = make(map[string]string)
+			backendMetadata := make(map[string]string)
 			backendMetadata["X-File-Checksum"] = "test-checksum"
 			backendMetadata["X-File-Content-Type"] = "text/plain; charset=utf-8"
 			backendMetadata["X-File-Content-Type-Source"] = "auto-detected"
 
 			mockedBackend.EXPECT().UploadFile(any(ctx), "poc--eni--hyperion--my-test-file.txt", reader, backendMetadata).Return("poc--eni--hyperion--my-test-file.txt", nil)
 
-			var callMetadata = make(map[string]string)
+			callMetadata := make(map[string]string)
 			callMetadata["X-File-Checksum"] = "test-checksum"
 
 			file, err := ctrl.UploadFile(ctx, "poc--eni--hyperion--my-test-file.txt", reader, callMetadata)
@@ -95,7 +94,7 @@ var _ = Describe("UploadController", func() {
 
 			var reader io.Reader = strings.NewReader("test content")
 
-			var callMetadata = make(map[string]string)
+			callMetadata := make(map[string]string)
 			callMetadata["X-File-Checksum"] = "test-checksum"
 
 			file, err := ctrl.UploadFile(ctx, "i-dont-need-coffee", reader, callMetadata)
@@ -111,7 +110,7 @@ var _ = Describe("UploadController", func() {
 
 			var reader io.Reader = nil
 
-			var callMetadata = make(map[string]string)
+			callMetadata := make(map[string]string)
 			callMetadata["X-File-Checksum"] = "test-checksum"
 
 			file, err := ctrl.UploadFile(ctx, "poc--eni--hyperion--my-test-file", reader, callMetadata)
@@ -126,14 +125,14 @@ var _ = Describe("UploadController", func() {
 			ctrl := controller.NewUploadController(mockedBackend)
 
 			var reader io.Reader = strings.NewReader("test content")
-			var backendMetadata = make(map[string]string)
+			backendMetadata := make(map[string]string)
 			backendMetadata["X-File-Checksum"] = "test-checksum"
 			backendMetadata["X-File-Content-Type"] = "application/octet-stream"
 			backendMetadata["X-File-Content-Type-Source"] = "auto-detected"
 
 			mockedBackend.EXPECT().UploadFile(any(ctx), "poc--eni--hyperion--my-test-file", reader, backendMetadata).Return("", errors.New("this is a test error message"))
 
-			var callMetadata = make(map[string]string)
+			callMetadata := make(map[string]string)
 			callMetadata["X-File-Checksum"] = "test-checksum"
 
 			file, err := ctrl.UploadFile(ctx, "poc--eni--hyperion--my-test-file", reader, callMetadata)
@@ -142,7 +141,5 @@ var _ = Describe("UploadController", func() {
 			Expect(err.Error()).To(Equal("this is a test error message"))
 			Expect(file).To(BeEmpty())
 		})
-
 	})
-
 })


### PR DESCRIPTION
 ## Update Makefile
 Update tool versions and golangci-lint target in Makefile.

 ## Autofixes for `file-manager/`
 Use make lint-fix to autofix issues

  ## Manual lint fixes for `file-manager/`