### PR TITLE
fix(common): Fix golangci-lint issues

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,6 +37,7 @@ jobs:
       run_check_generated_files: false
       run_build_image: false
       coverage_threshold: 55
+      lint_fail_on_issues: true
 
   common-server:
     name: Common Server
@@ -94,7 +95,6 @@ jobs:
       run_check_generated_files: false
       ko_build_path: "cmd/server/server.go"
       coverage_threshold: 61
-      lint_fail_on_issues: true
 
   gateway:
     name: Gateway

--- a/common/Makefile
+++ b/common/Makefile
@@ -16,6 +16,20 @@ fmt: ## Run go fmt against code.
 vet: ## Run go vet against code.
 	go vet ./...
 
+##@ Lint
+
+.PHONY: lint
+lint: golangci-lint ## Run golangci-lint linter
+	"$(GOLANGCI_LINT)" run
+
+.PHONY: lint-fix
+lint-fix: golangci-lint ## Run golangci-lint linter and perform fixes
+	"$(GOLANGCI_LINT)" run --fix
+
+.PHONY: lint-config
+lint-config: golangci-lint ## Verify golangci-lint linter configuration
+	"$(GOLANGCI_LINT)" config verify
+
 ##@ Build
 
 .PHONY: build
@@ -37,27 +51,36 @@ $(LOCALBIN):
 	mkdir -p $(LOCALBIN)
 
 
+## Tool Binaries
 ENVTEST ?= $(LOCALBIN)/setup-envtest
-ENVTEST_VERSION ?= release-0.19
+GOLANGCI_LINT = $(LOCALBIN)/golangci-lint
 
+## Tool Versions
+ENVTEST_VERSION ?= release-0.19
+GOLANGCI_LINT_VERSION ?= v2.11.4
 
 .PHONY: envtest
 envtest: $(ENVTEST) ## Download setup-envtest locally if necessary.
 $(ENVTEST): $(LOCALBIN)
 	$(call go-install-tool,$(ENVTEST),sigs.k8s.io/controller-runtime/tools/setup-envtest,$(ENVTEST_VERSION))
 
+.PHONY: golangci-lint
+golangci-lint: $(GOLANGCI_LINT) ## Download golangci-lint locally if necessary.
+$(GOLANGCI_LINT): $(LOCALBIN)
+	$(call go-install-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/v2/cmd/golangci-lint,$(GOLANGCI_LINT_VERSION))
+
 # go-install-tool will 'go install' any package with custom target and name of binary, if it doesn't exist
 # $1 - target path with name of binary
 # $2 - package url which can be installed
 # $3 - specific version of package
 define go-install-tool
-@[ -f "$(1)-$(3)" ] || { \
+@[ -f "$(1)-$(3)" ] && [ "$$(readlink -- "$(1)" 2>/dev/null)" = "$(1)-$(3)" ] || { \
 set -e; \
 package=$(2)@$(3) ;\
 echo "Downloading $${package}" ;\
-rm -f $(1) || true ;\
-GOBIN=$(LOCALBIN) go install $${package} ;\
-mv $(1) $(1)-$(3) ;\
+rm -f "$(1)" ;\
+GOBIN="$(LOCALBIN)" go install $${package} ;\
+mv "$(LOCALBIN)/$$(basename "$(1)")" "$(1)-$(3)" ;\
 } ;\
-ln -sf $(1)-$(3) $(1)
+ln -sf "$$(realpath "$(1)-$(3)")" "$(1)"
 endef

--- a/common/pkg/client/cleanup.go
+++ b/common/pkg/client/cleanup.go
@@ -9,11 +9,12 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
-	"github.com/telekom/controlplane/common/pkg/types"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/telekom/controlplane/common/pkg/types"
 )
 
 func cleanupState(ctx context.Context, c ScopedClient, listOpts []client.ListOption, objectList types.ObjectList, desiredStateSet map[client.ObjectKey]bool) (int, error) {
@@ -22,20 +23,19 @@ func cleanupState(ctx context.Context, c ScopedClient, listOpts []client.ListOpt
 	if err != nil {
 		return deleted, errors.Wrap(err, "failed to list objects")
 	}
-	log := log.FromContext(ctx)
-	log.V(1).Info("cleanup state", "found", len(objectList.GetItems()), "desired", len(desiredStateSet))
+	logger := log.FromContext(ctx)
+	logger.V(1).Info("cleanup state", "found", len(objectList.GetItems()), "desired", len(desiredStateSet))
 
 	for _, object := range objectList.GetItems() {
-		if _, ok := desiredStateSet[client.ObjectKey{Name: object.GetName(), Namespace: object.GetNamespace()}]; !ok {
-			log.V(1).Info("deleting object", "name", object.GetName(), "namespace", object.GetNamespace())
-			err := c.Delete(ctx, object, &client.DeleteOptions{})
-			if err != nil && !apierrors.IsNotFound(err) {
-				// If we have some internal error, we return the error and the result
-				return deleted, errors.Wrapf(err, "failed to delete object %s", object.GetName())
-			}
-			deleted++
+		if _, ok := desiredStateSet[client.ObjectKey{Name: object.GetName(), Namespace: object.GetNamespace()}]; ok {
 			continue
 		}
+		logger.V(1).Info("deleting object", "name", object.GetName(), "namespace", object.GetNamespace())
+		delErr := c.Delete(ctx, object, &client.DeleteOptions{})
+		if delErr != nil && !apierrors.IsNotFound(delErr) {
+			return deleted, errors.Wrapf(delErr, "failed to delete object %s", object.GetName())
+		}
+		deleted++
 	}
 	if deleted > 0 {
 		err = c.List(ctx, objectList, listOpts...)
@@ -48,11 +48,11 @@ func cleanupState(ctx context.Context, c ScopedClient, listOpts []client.ListOpt
 }
 
 func cleanupStateUnstructured(ctx context.Context, c ScopedClient, listOpts []client.ListOption, gvk schema.GroupVersionKind, desiredStateSet map[client.ObjectKey]bool) (int, types.ObjectList, error) {
-	log := log.FromContext(ctx)
+	logger := log.FromContext(ctx)
 
 	// Ensure that we have a GVK for a List type
 	if !strings.HasSuffix(gvk.Kind, "List") {
-		gvk.Kind = gvk.Kind + "List"
+		gvk.Kind += "List"
 	}
 
 	// Get an instance of the List type
@@ -73,19 +73,18 @@ func cleanupStateUnstructured(ctx context.Context, c ScopedClient, listOpts []cl
 		return deleted, objectList, errors.Wrap(err, "failed to list objects")
 	}
 
-	log.V(1).Info("cleanup state", "found", len(objectList.GetItems()), "desired", len(desiredStateSet))
+	logger.V(1).Info("cleanup state", "found", len(objectList.GetItems()), "desired", len(desiredStateSet))
 
 	for _, object := range objectList.GetItems() {
-		if _, ok := desiredStateSet[client.ObjectKey{Name: object.GetName(), Namespace: object.GetNamespace()}]; !ok {
-			log.V(1).Info("deleting object", "name", object.GetName(), "namespace", object.GetNamespace())
-			err := c.Delete(ctx, object, &client.DeleteOptions{})
-			if err != nil && !apierrors.IsNotFound(err) {
-				// If we have some internal error, we return the error and the result
-				return deleted, objectList, errors.Wrapf(err, "failed to delete object %s", object.GetName())
-			}
-			deleted++
+		if _, ok := desiredStateSet[client.ObjectKey{Name: object.GetName(), Namespace: object.GetNamespace()}]; ok {
 			continue
 		}
+		logger.V(1).Info("deleting object", "name", object.GetName(), "namespace", object.GetNamespace())
+		delErr := c.Delete(ctx, object, &client.DeleteOptions{})
+		if delErr != nil && !apierrors.IsNotFound(delErr) {
+			return deleted, objectList, errors.Wrapf(delErr, "failed to delete object %s", object.GetName())
+		}
+		deleted++
 	}
 	if deleted > 0 {
 		err = c.List(ctx, objectList, listOpts...)

--- a/common/pkg/client/client.go
+++ b/common/pkg/client/client.go
@@ -8,13 +8,14 @@ import (
 	"context"
 
 	"github.com/pkg/errors"
-	"github.com/telekom/controlplane/common/pkg/condition"
-	"github.com/telekom/controlplane/common/pkg/config"
-	"github.com/telekom/controlplane/common/pkg/types"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	"github.com/telekom/controlplane/common/pkg/condition"
+	"github.com/telekom/controlplane/common/pkg/config"
+	"github.com/telekom/controlplane/common/pkg/types"
 )
 
 type ScopedClient interface {
@@ -49,7 +50,7 @@ func NewScopedClient(c client.Client, environment string) ScopedClient {
 	}
 }
 
-func (e *scopedClientImpl) CreateOrUpdate(ctx context.Context, obj client.Object, mutate controllerutil.MutateFn) (controllerutil.OperationResult, error) {
+func (c *scopedClientImpl) CreateOrUpdate(ctx context.Context, obj client.Object, mutate controllerutil.MutateFn) (controllerutil.OperationResult, error) {
 	wrapMutate := func() error {
 		if err := mutate(); err != nil {
 			return err
@@ -57,16 +58,16 @@ func (e *scopedClientImpl) CreateOrUpdate(ctx context.Context, obj client.Object
 		if obj.GetLabels() == nil {
 			obj.SetLabels(map[string]string{})
 		}
-		obj.GetLabels()[config.EnvironmentLabelKey] = e.environment
+		obj.GetLabels()[config.EnvironmentLabelKey] = c.environment
 		return nil
 	}
 
-	res, err := controllerutil.CreateOrUpdate(ctx, e.Client, obj, wrapMutate)
+	res, err := controllerutil.CreateOrUpdate(ctx, c.Client, obj, wrapMutate)
 	if err != nil {
 		return res, errors.Wrapf(err, "failed to create or update object %s", obj.GetName())
 	}
-	e.setChanged(res)
-	e.setReady(obj)
+	c.setChanged(res)
+	c.setReady(obj)
 
 	return res, nil
 }

--- a/common/pkg/client/client_test.go
+++ b/common/pkg/client/client_test.go
@@ -8,23 +8,22 @@ import (
 	"context"
 	"fmt"
 
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
 	"github.com/pkg/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
 	"github.com/telekom/controlplane/common/pkg/condition"
 	"github.com/telekom/controlplane/common/pkg/config"
 	"github.com/telekom/controlplane/common/pkg/test"
 	"github.com/telekom/controlplane/common/pkg/util/contextutil"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("Client", func() {
-
-	var (
-		templ = test.NewObject(name, namespace)
-	)
+	templ := test.NewObject(name, namespace)
 
 	Context("NewScopedClient", func() {
 		It("should return a new ScopedClientImpl", func() {
@@ -73,7 +72,6 @@ var _ = Describe("Client", func() {
 				Expect(err).NotTo(HaveOccurred())
 				Expect(res).To(Equal(controllerutil.OperationResultCreated))
 				Expect(obj.GetLabels()).To(HaveKeyWithValue(config.EnvironmentLabelKey, "test"))
-
 			})
 
 			It("should update the object", func() {
@@ -94,11 +92,9 @@ var _ = Describe("Client", func() {
 				Expect(res).To(Equal(controllerutil.OperationResultUpdated))
 				Expect(obj.GetLabels()).To(HaveKeyWithValue(config.BuildLabelKey("test"), "test"))
 				Expect(scopedClient.AnyChanged()).To(BeTrue())
-
 			})
 
 			It("should return an error if CreateOrUpdate fails", func() {
-
 				obj := templ.DeepCopy()
 
 				mutator := func() error {
@@ -107,12 +103,10 @@ var _ = Describe("Client", func() {
 
 				_, err := scopedClient.CreateOrUpdate(ctx, obj, mutator)
 				Expect(err.Error()).To(Equal("failed to create or update object test: force error"))
-
 			})
 		})
 
 		Context("Get", func() {
-
 			AfterEach(func() {
 				Expect(k8sClient.Delete(ctx, templ.DeepCopy())).To(Succeed())
 			})
@@ -137,7 +131,6 @@ var _ = Describe("Client", func() {
 			})
 
 			It("should return the object", func() {
-
 				obj := templ.DeepCopy()
 				obj.GetLabels()[config.EnvironmentLabelKey] = environment
 
@@ -146,12 +139,10 @@ var _ = Describe("Client", func() {
 				err := scopedClient.Get(ctx, client.ObjectKey{Name: name, Namespace: namespace}, obj)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(obj).ToNot(BeNil())
-
 			})
 		})
 
 		Context("Delete", func() {
-
 			AfterEach(func() {
 				err := k8sClient.Delete(ctx, templ.DeepCopy())
 				Expect(client.IgnoreNotFound(err)).To(Succeed())
@@ -176,17 +167,14 @@ var _ = Describe("Client", func() {
 				err := scopedClient.Delete(ctx, obj)
 				Expect(err).NotTo(HaveOccurred())
 			})
-
 		})
 
 		Context("List", func() {
-
 			AfterEach(func() {
 				Expect(k8sClient.DeleteAllOf(ctx, &test.TestResource{}, client.InNamespace(namespace))).To(Succeed())
 			})
 
 			It("should only return objects that belong to the environment", func() {
-
 				obj := templ.DeepCopy()
 				obj.GetLabels()[config.EnvironmentLabelKey] = environment
 
@@ -202,7 +190,6 @@ var _ = Describe("Client", func() {
 				Expect(err).NotTo(HaveOccurred())
 				Expect(list.Items).To(HaveLen(1))
 				Expect(list.Items[0].Name).To(Equal("test"))
-
 			})
 		})
 	})
@@ -233,7 +220,6 @@ var _ = Describe("Client", func() {
 		})
 
 		It("should delete all objects that are not in the desired state", func() {
-
 			listOpts := []client.ListOption{}
 
 			list := &test.TestResourceList{}
@@ -253,7 +239,6 @@ var _ = Describe("Client", func() {
 	})
 
 	Context("StateInfo", func() {
-
 		var (
 			ctx          context.Context
 			scopedClient ScopedClient

--- a/common/pkg/client/clientutil.go
+++ b/common/pkg/client/clientutil.go
@@ -5,16 +5,16 @@
 package client
 
 import (
-	"github.com/telekom/controlplane/common/pkg/config"
-	"github.com/telekom/controlplane/common/pkg/controller/index"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	"github.com/telekom/controlplane/common/pkg/config"
+	"github.com/telekom/controlplane/common/pkg/controller/index"
 )
 
 // OwnedBy filters for resources owned by the given owner based on controller references.
 // It requires that the index ".metadata.controller" is registered
 func OwnedBy(owner client.Object) []client.ListOption {
-
 	ownerUID := string(owner.GetUID())
 
 	if ownerUID == "" {
@@ -30,7 +30,6 @@ func OwnedBy(owner client.Object) []client.ListOption {
 
 // OwnedByLabel should only be used when ownership could not be determined by controllerRef because of cross-namespace references
 func OwnedByLabel(owner client.Object) []client.ListOption {
-
 	ownerUID := string(owner.GetUID())
 
 	if ownerUID == "" {

--- a/common/pkg/client/clientutil_test.go
+++ b/common/pkg/client/clientutil_test.go
@@ -5,15 +5,14 @@
 package client
 
 import (
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("Client Util Tests", func() {
-
 	// my faked clientObject which only contains the necessary UID field
 	fakeClientObject := &unstructured.Unstructured{
 		Object: map[string]interface{}{
@@ -25,7 +24,6 @@ var _ = Describe("Client Util Tests", func() {
 
 	Context("OwnedBy function", func() {
 		It("should return correct listOptions", func() {
-
 			listOptions := OwnedBy(fakeClientObject)
 			Expect(listOptions).To(HaveLen(1))
 			Expect(listOptions[0].(client.MatchingFields)[".metadata.controller"]).To(Equal("12345"))
@@ -34,11 +32,9 @@ var _ = Describe("Client Util Tests", func() {
 
 	Context("OwnedByLabel function", func() {
 		It("should return correct listOptions", func() {
-
 			listOptions := OwnedByLabel(fakeClientObject)
 			Expect(listOptions).To(HaveLen(1))
 			Expect(listOptions[0].(client.MatchingLabels)["cp.ei.telekom.de/owner.uid"]).To(Equal("12345"))
 		})
 	})
-
 })

--- a/common/pkg/client/context_test.go
+++ b/common/pkg/client/context_test.go
@@ -12,7 +12,6 @@ import (
 )
 
 var _ = Describe("Context", func() {
-
 	It("should manage the client in the context", func() {
 		ctx := context.Background()
 

--- a/common/pkg/client/janitor.go
+++ b/common/pkg/client/janitor.go
@@ -9,12 +9,13 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
-	"github.com/telekom/controlplane/common/pkg/types"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/telekom/controlplane/common/pkg/types"
 )
 
 type JanitorClient interface {
@@ -123,10 +124,10 @@ func (c *janitorClient) Delete(ctx context.Context, obj client.Object, opts ...c
 }
 
 func (c *janitorClient) CleanupAll(ctx context.Context, listOpts []client.ListOption) (int, error) {
-	log := log.FromContext(ctx)
+	logger := log.FromContext(ctx)
 	deleted := 0
 	for gvk, keys := range c.state {
-		log.V(1).Info("Cleaning up state", "gvk", gvk)
+		logger.V(1).Info("Cleaning up state", "gvk", gvk)
 
 		n, _, err := cleanupStateUnstructured(ctx, c, listOpts, gvk, keys)
 		if err != nil {

--- a/common/pkg/client/janitor_test.go
+++ b/common/pkg/client/janitor_test.go
@@ -7,19 +7,20 @@ package client
 import (
 	"context"
 
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
-	"github.com/telekom/controlplane/common/pkg/config"
-	"github.com/telekom/controlplane/common/pkg/test"
-	"github.com/telekom/controlplane/common/pkg/util/contextutil"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	"github.com/telekom/controlplane/common/pkg/config"
+	"github.com/telekom/controlplane/common/pkg/test"
+	"github.com/telekom/controlplane/common/pkg/util/contextutil"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("JanitorClient", func() {
-
 	var (
 		ctx   context.Context
 		jc    *janitorClient
@@ -44,18 +45,14 @@ var _ = Describe("JanitorClient", func() {
 	})
 
 	Context("NewClient", func() {
-
 		It("should return a new JanitorImpl", func() {
 			t := NewJanitorClient(NewScopedClient(k8sClient, environment))
 			Expect(t).To(BeAssignableToTypeOf(&janitorClient{}))
 		})
-
 	})
 
 	Context("Cleanup", func() {
-
 		It("should update the state", func() {
-
 			obj := templ.DeepCopy()
 
 			_, err := jc.CreateOrUpdate(ctx, obj, DoNothing())
@@ -67,7 +64,6 @@ var _ = Describe("JanitorClient", func() {
 			}, map[client.ObjectKey]bool{
 				{Namespace: "default", Name: "test"}: true,
 			}))
-
 		})
 
 		It("should create a resource and add it to the desired state", func() {
@@ -106,7 +102,6 @@ var _ = Describe("JanitorClient", func() {
 	})
 
 	Context("Wrap", func() {
-
 		It("should delete object that were not created in the Wrap function", func() {
 			undesiredObj := templ.DeepCopy()
 			undesiredObj.SetName("undesired")
@@ -117,7 +112,6 @@ var _ = Describe("JanitorClient", func() {
 			objList := test.NewObjectList()
 
 			deleted, err := jc.Wrap(ctx, objList, []client.ListOption{client.InNamespace(namespace)}, func(c ScopedClient) bool {
-
 				res, err := c.CreateOrUpdate(ctx, obj, DoNothing())
 				Expect(err).ToNot(HaveOccurred())
 				Expect(res).To(Equal(controllerutil.OperationResultCreated))
@@ -158,7 +152,6 @@ var _ = Describe("JanitorClient", func() {
 	})
 
 	Context("CleanupAll", func() {
-
 		It("should delete all objects", func() {
 			undesiredObj := templ.DeepCopy()
 			undesiredObj.SetName("undesired")
@@ -181,7 +174,6 @@ var _ = Describe("JanitorClient", func() {
 	})
 
 	Context("AddKnownTypeToState", func() {
-
 		It("should add a known type to the state", func() {
 			jc.Reset()
 			jc.AddKnownTypeToState(templ.DeepCopy())

--- a/common/pkg/condition/condition.go
+++ b/common/pkg/condition/condition.go
@@ -63,9 +63,9 @@ func NewNotReadyCondition(reason, message string) metav1.Condition {
 	return condition
 }
 
-func SetToUnknown(condition metav1.Condition) metav1.Condition {
-	condition.Status = metav1.ConditionUnknown
-	condition.Reason = "Unknown"
-	condition.Message = ""
-	return condition
+func SetToUnknown(cond metav1.Condition) metav1.Condition { //nolint:gocritic // hugeParam: intentional value copy for functional transformation
+	cond.Status = metav1.ConditionUnknown
+	cond.Reason = "Unknown"
+	cond.Message = ""
+	return cond
 }

--- a/common/pkg/condition/util.go
+++ b/common/pkg/condition/util.go
@@ -7,9 +7,9 @@ package condition
 import (
 	"fmt"
 
-	"github.com/telekom/controlplane/common/pkg/types"
-
 	"k8s.io/apimachinery/pkg/api/meta"
+
+	"github.com/telekom/controlplane/common/pkg/types"
 )
 
 // EnsureReady returns an error if the provided obj is not ready

--- a/common/pkg/config/config_test.go
+++ b/common/pkg/config/config_test.go
@@ -13,11 +13,9 @@ import (
 
 var _ = Describe("Config Test", func() {
 	BeforeEach(func() {
-
 	})
 
 	Context("RetryNWithJitterOnError", func() {
-
 		It("should return a time.Duration that jitters", func() {
 			var lastDelay time.Duration
 			for i := 0; i < 10; i++ {
@@ -30,7 +28,6 @@ var _ = Describe("Config Test", func() {
 	})
 
 	Context("RequestWithJitter", func() {
-
 		It("should return a time.Duration that jitters", func() {
 			var lastDelay time.Duration
 			for i := 0; i < 10; i++ {
@@ -41,5 +38,4 @@ var _ = Describe("Config Test", func() {
 			}
 		})
 	})
-
 })

--- a/common/pkg/config/env_test.go
+++ b/common/pkg/config/env_test.go
@@ -8,9 +8,10 @@ import (
 	"os"
 	"time"
 
+	"github.com/spf13/viper"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/spf13/viper"
 )
 
 var _ = Describe("Config Env Tests", func() {

--- a/common/pkg/controller/controller.go
+++ b/common/pkg/controller/controller.go
@@ -7,11 +7,6 @@ package controller
 import (
 	"context"
 
-	"github.com/telekom/controlplane/common/pkg/condition"
-	"github.com/telekom/controlplane/common/pkg/config"
-	"github.com/telekom/controlplane/common/pkg/errors/ctrlerrors"
-	"github.com/telekom/controlplane/common/pkg/handler"
-	"github.com/telekom/controlplane/common/pkg/util/contextutil"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -23,9 +18,13 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	common_types "github.com/telekom/controlplane/common/pkg/types"
-
 	cc "github.com/telekom/controlplane/common/pkg/client"
+	"github.com/telekom/controlplane/common/pkg/condition"
+	"github.com/telekom/controlplane/common/pkg/config"
+	"github.com/telekom/controlplane/common/pkg/errors/ctrlerrors"
+	"github.com/telekom/controlplane/common/pkg/handler"
+	common_types "github.com/telekom/controlplane/common/pkg/types"
+	"github.com/telekom/controlplane/common/pkg/util/contextutil"
 )
 
 type Controller[T common_types.Object] interface {
@@ -34,13 +33,13 @@ type Controller[T common_types.Object] interface {
 
 var _ Controller[common_types.Object] = &ControllerImpl[common_types.Object]{}
 
-func NewController[T common_types.Object](handler handler.Handler[T], client client.Client, recorder record.EventRecorder) Controller[T] {
+func NewController[T common_types.Object](h handler.Handler[T], c client.Client, recorder record.EventRecorder) Controller[T] {
 	return &ControllerImpl[T]{
-		Client: client,
-		Scheme: client.Scheme(),
+		Client: c,
+		Scheme: c.Scheme(),
 
 		Recorder: recorder,
-		Handler:  handler,
+		Handler:  h,
 	}
 }
 
@@ -53,33 +52,33 @@ type ControllerImpl[T common_types.Object] struct {
 }
 
 func (c *ControllerImpl[T]) Reconcile(ctx context.Context, req reconcile.Request, object T) (reconcile.Result, error) {
-	log := log.FromContext(ctx)
+	logger := log.FromContext(ctx)
 
 	err := Fetch(ctx, c.Client, req.NamespacedName, object)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
-			log.V(1).Info("Fetched object but it was not found")
+			logger.V(1).Info("Fetched object but it was not found")
 			return reconcile.Result{}, nil
 		}
 		return HandleError(ctx, err, object, c.Recorder), nil
 	}
 
-	if changed, err := FirstSetup(ctx, c.Client, object); err != nil {
-		return HandleError(ctx, err, object, c.Recorder), nil
+	if changed, setupErr := FirstSetup(ctx, c.Client, object); setupErr != nil {
+		return HandleError(ctx, setupErr, object, c.Recorder), nil
 	} else if changed {
 		return reconcile.Result{}, nil
 	}
 
-	log.V(1).Info("Fetched object")
+	logger.V(1).Info("Fetched object")
 
 	env, ok := GetEnvironment(object)
 	if !ok {
-		log.V(0).Info("Environment label is missing")
+		logger.V(0).Info("Environment label is missing")
 		c.Event(ctx, object, "Warning", "Processing", "Environment label is missing")
 		if object.SetCondition(condition.NewBlockedCondition("Environment label is missing")) {
 			StampObservedGeneration(object)
-			if err := c.Client.Status().Update(ctx, object); err != nil {
-				return HandleError(ctx, err, object, c.Recorder), nil
+			if updateErr := c.Client.Status().Update(ctx, object); updateErr != nil {
+				return HandleError(ctx, updateErr, object, c.Recorder), nil
 			}
 		}
 		return reconcile.Result{}, nil
@@ -89,67 +88,29 @@ func (c *ControllerImpl[T]) Reconcile(ctx context.Context, req reconcile.Request
 	ctx = cc.WithClient(ctx, cc.NewJanitorClient(cc.NewScopedClient(c.Client, env)))
 	ctx = contextutil.WithRecorder(ctx, c.Recorder)
 
-	// Handle the deletion
 	if IsBeingDeleted(object) {
-		c.Event(ctx, object, "Normal", "Processing", "Processing resource deletion")
-		if controllerutil.ContainsFinalizer(object, config.FinalizerName) {
-			log.V(0).Info("Deleting")
-
-			err := c.Handler.Delete(ctx, object)
-			if err != nil {
-				// Failed
-				EnsureNotReadyOnError(ctx, c.Client, object, err)
-				result := HandleError(ctx, err, object, c.Recorder)
-				StampObservedGeneration(object)
-				if err = c.Client.Status().Update(ctx, object); err != nil {
-					return HandleError(ctx, err, object, c.Recorder), nil
-				}
-				return result, nil
-			}
-
-			// Success
-
-			changed := controllerutil.RemoveFinalizer(object, config.FinalizerName)
-			if changed {
-				err = c.Client.Update(ctx, object)
-				if err != nil {
-					return HandleError(ctx, err, object, c.Recorder), nil
-				}
-			}
-
-			log.V(1).Info("Deleted", "resource", object)
-		}
-		return reconcile.Result{}, nil
+		return c.handleDeletion(ctx, object)
 	}
 
-	// Handle normal reconciliation
 	c.Event(ctx, object, "Normal", "Processing", "Processing resource")
 
-	log.V(1).Info("Creating or updating")
+	logger.V(1).Info("Creating or updating")
 	err = c.Handler.CreateOrUpdate(ctx, object)
 	if err != nil {
-		// Failed
 		EnsureNotReadyOnError(ctx, c.Client, object, err)
 		result := HandleError(ctx, err, object, c.Recorder)
-		// Always update the status after reconciliation to persist any changes made by the handler
-		// and to set any conditions related to the error.
 		StampObservedGeneration(object)
-		if err = c.Client.Status().Update(ctx, object); err != nil {
-			return HandleError(ctx, err, object, c.Recorder), nil
+		if statusErr := c.Client.Status().Update(ctx, object); statusErr != nil {
+			return HandleError(ctx, statusErr, object, c.Recorder), nil
 		}
 		return result, nil
 	}
 
-	// Success
-
-	log.V(1).Info("Created or updated", "resource", object)
-	// Enforce that atleast the processing condition is set in the handler. If not, log a warning.
+	logger.V(1).Info("Created or updated", "resource", object)
 	if meta.IsStatusConditionPresentAndEqual(object.GetConditions(), condition.ConditionTypeProcessing, metav1.ConditionUnknown) {
 		c.Event(ctx, object, "Warning", "Processing", "Resource has an unknown processing status")
 	}
 
-	// Always update the status after successful reconciliation to clear any error conditions
-	// and persist any changes made by the handler.
 	StampObservedGeneration(object)
 	if err = c.Client.Status().Update(ctx, object); err != nil {
 		return HandleError(ctx, err, object, c.Recorder), nil
@@ -160,17 +121,47 @@ func (c *ControllerImpl[T]) Reconcile(ctx context.Context, req reconcile.Request
 	}, nil
 }
 
+func (c *ControllerImpl[T]) handleDeletion(ctx context.Context, object T) (reconcile.Result, error) {
+	logger := log.FromContext(ctx)
+	c.Event(ctx, object, "Normal", "Processing", "Processing resource deletion")
+
+	if !controllerutil.ContainsFinalizer(object, config.FinalizerName) {
+		return reconcile.Result{}, nil
+	}
+
+	logger.V(0).Info("Deleting")
+	err := c.Handler.Delete(ctx, object)
+	if err != nil {
+		EnsureNotReadyOnError(ctx, c.Client, object, err)
+		result := HandleError(ctx, err, object, c.Recorder)
+		StampObservedGeneration(object)
+		if statusErr := c.Client.Status().Update(ctx, object); statusErr != nil {
+			return HandleError(ctx, statusErr, object, c.Recorder), nil
+		}
+		return result, nil
+	}
+
+	if controllerutil.RemoveFinalizer(object, config.FinalizerName) {
+		if updateErr := c.Client.Update(ctx, object); updateErr != nil {
+			return HandleError(ctx, updateErr, object, c.Recorder), nil
+		}
+	}
+
+	logger.V(1).Info("Deleted", "resource", object)
+	return reconcile.Result{}, nil
+}
+
 func (c *ControllerImpl[T]) Event(ctx context.Context, object common_types.Object, eventType, reason, message string) {
 	if c.Recorder != nil {
 		c.Recorder.Event(object, eventType, reason, message)
 	}
 }
 
-func Fetch(ctx context.Context, client client.Client, namespacedName types.NamespacedName, object client.Object) error {
-	log := log.FromContext(ctx)
-	log.V(1).Info("Fetching object")
+func Fetch(ctx context.Context, c client.Client, namespacedName types.NamespacedName, object client.Object) error {
+	logger := log.FromContext(ctx)
+	logger.V(1).Info("Fetching object")
 
-	if err := client.Get(ctx, namespacedName, object); err != nil {
+	if err := c.Get(ctx, namespacedName, object); err != nil {
 		return err
 	}
 	return nil
@@ -189,10 +180,10 @@ func GetEnvironment(object metav1.Object) (string, bool) {
 	return e, ok
 }
 
-func FirstSetup(ctx context.Context, client client.Client, object common_types.Object) (bool, error) {
+func FirstSetup(ctx context.Context, c client.Client, object common_types.Object) (bool, error) {
 	if !controllerutil.ContainsFinalizer(object, config.FinalizerName) {
 		controllerutil.AddFinalizer(object, config.FinalizerName)
-		if err := client.Update(ctx, object); err != nil {
+		if err := c.Update(ctx, object); err != nil {
 			return false, err
 		}
 		return true, nil
@@ -210,10 +201,9 @@ func FirstSetup(ctx context.Context, client client.Client, object common_types.O
 }
 
 func HandleError(ctx context.Context, err error, obj common_types.Object, recorder record.EventRecorder) reconcile.Result {
-	// handle Conflict - resource version can change during reconciliation, it causes conflict, simple requeue should solve it
 	if apierrors.IsConflict(err) {
-		log := log.FromContext(ctx).WithName("controller.error-handler")
-		log.V(0).Info("Conflict occurred during operation", "error", err)
+		logger := log.FromContext(ctx).WithName("controller.error-handler")
+		logger.V(0).Info("Conflict occurred during operation", "error", err)
 		if recorder != nil {
 			recorder.Event(obj, "Warning", "Conflict", err.Error())
 		}
@@ -222,15 +212,15 @@ func HandleError(ctx context.Context, err error, obj common_types.Object, record
 
 	conditionsUpdated, result := ctrlerrors.HandleError(ctx, obj, err, recorder)
 	if conditionsUpdated {
-		log := log.FromContext(ctx).WithName("controller.error-handler")
-		log.V(1).Info("Object conditions updated after error handling", "error", err)
+		logger := log.FromContext(ctx).WithName("controller.error-handler")
+		logger.V(1).Info("Object conditions updated after error handling", "error", err)
 	}
 	return result
 }
 
 // EnsureNotReadyOnError sets the Ready condition to false on the object if the error is not nil
 // and the Ready condition is not already set to false.
-func EnsureNotReadyOnError(ctx context.Context, client client.Client, obj common_types.Object, err error) bool {
+func EnsureNotReadyOnError(_ context.Context, _ client.Client, obj common_types.Object, err error) bool {
 	if err != nil && !meta.IsStatusConditionFalse(obj.GetConditions(), condition.ConditionTypeReady) {
 		return obj.SetCondition(condition.NewNotReadyCondition("ErrorOccurred", err.Error()))
 	}

--- a/common/pkg/controller/controller_test.go
+++ b/common/pkg/controller/controller_test.go
@@ -9,19 +9,21 @@ import (
 	"fmt"
 	"time"
 
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
-	"github.com/telekom/controlplane/common/pkg/condition"
-	"github.com/telekom/controlplane/common/pkg/config"
-	"github.com/telekom/controlplane/common/pkg/handler"
-	"github.com/telekom/controlplane/common/pkg/test"
-	"github.com/telekom/controlplane/common/pkg/test/mock"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/telekom/controlplane/common/pkg/condition"
+	"github.com/telekom/controlplane/common/pkg/config"
+	"github.com/telekom/controlplane/common/pkg/handler"
+	"github.com/telekom/controlplane/common/pkg/test"
+	"github.com/telekom/controlplane/common/pkg/test/mock"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("StampObservedGeneration", func() {
@@ -80,18 +82,15 @@ var _ = Describe("StampObservedGeneration", func() {
 })
 
 var _ = Describe("Controller", func() {
-
-	var (
-		templ = &test.TestResource{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      name,
-				Namespace: namespace,
-				Labels: map[string]string{
-					config.EnvironmentLabelKey: environment,
-				},
+	templ := &test.TestResource{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels: map[string]string{
+				config.EnvironmentLabelKey: environment,
 			},
-		}
-	)
+		},
+	}
 
 	Context("NewController", func() {
 		It("should return a new ControllerImpl", func() {
@@ -174,9 +173,8 @@ var _ = Describe("Controller", func() {
 	})
 
 	Context("Reconciler", func() {
-
-		var timeout = 2 * time.Second
-		var interval = 200 * time.Millisecond
+		timeout := 2 * time.Second
+		interval := 200 * time.Millisecond
 
 		AfterEach(func() {
 			obj := templ.DeepCopy()
@@ -189,7 +187,6 @@ var _ = Describe("Controller", func() {
 				}, obj)
 
 				g.Expect(apierrors.IsNotFound(err)).To(BeTrue())
-
 			}, timeout, interval).Should(Succeed())
 		})
 
@@ -205,9 +202,7 @@ var _ = Describe("Controller", func() {
 
 				g.Expect(err).ToNot(HaveOccurred())
 				g.Expect(obj.GetFinalizers()).To(ContainElement(config.FinalizerName))
-
 			}, timeout, interval).Should(Succeed())
-
 		})
 
 		It("should fail with missing environment", func() {
@@ -228,14 +223,12 @@ var _ = Describe("Controller", func() {
 				g.Expect(condition.Status).To(Equal(metav1.ConditionFalse))
 				g.Expect(condition.Reason).To(Equal("Blocked"))
 				g.Expect(condition.Message).To(Equal("Environment label is missing"))
-
 			}, timeout, interval).Should(Succeed())
 
 			obj.SetLabels(map[string]string{
 				config.EnvironmentLabelKey: environment,
 			})
 			Expect(k8sClient.Update(ctx, obj)).To(Succeed())
-
 		})
 
 		It("should successfully process", func() {
@@ -249,10 +242,7 @@ var _ = Describe("Controller", func() {
 				}, obj)
 
 				g.Expect(err).ToNot(HaveOccurred())
-
 			}, timeout, interval).Should(Succeed())
-
 		})
-
 	})
 })

--- a/common/pkg/controller/index/owner.go
+++ b/common/pkg/controller/index/owner.go
@@ -12,9 +12,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-var (
-	ControllerIndexKey = ".metadata.controller"
-)
+var ControllerIndexKey = ".metadata.controller"
 
 // SetOwnerIndex sets the owner index for the given object.
 func SetOwnerIndex(ctx context.Context, indexer client.FieldIndexer, ownedObj client.Object) error {

--- a/common/pkg/controller/index_test.go
+++ b/common/pkg/controller/index_test.go
@@ -7,20 +7,19 @@ package controller
 import (
 	"time"
 
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
-	"github.com/telekom/controlplane/common/pkg/controller/index"
-	"github.com/telekom/controlplane/common/pkg/test"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	"github.com/telekom/controlplane/common/pkg/controller/index"
+	"github.com/telekom/controlplane/common/pkg/test"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("Index", func() {
-
 	Context("OwnerIndex", func() {
-
 		It("should enable use to query using the owner-reference", func() {
-
 			ownerObj := test.NewObject("owner", "default")
 			Expect(k8sClient.Create(ctx, ownerObj)).To(Succeed())
 
@@ -33,13 +32,11 @@ var _ = Describe("Index", func() {
 				err := k8sManager.GetClient().List(ctx, objList, client.MatchingFields{index.ControllerIndexKey: string(ownerObj.GetUID())})
 				g.Expect(err).ToNot(HaveOccurred())
 				g.Expect(objList.Items).To(HaveLen(1))
-
 			}, 2*time.Second, 250*time.Millisecond).Should(Succeed())
 
 			// Cleanup
 			Expect(k8sClient.Delete(ctx, ownedObj)).To(Succeed())
 			Expect(k8sClient.Delete(ctx, ownerObj)).To(Succeed())
 		})
-
 	})
 })

--- a/common/pkg/controller/ratelimiter.go
+++ b/common/pkg/controller/ratelimiter.go
@@ -5,9 +5,10 @@
 package controller
 
 import (
-	"github.com/telekom/controlplane/common/pkg/config"
 	"k8s.io/client-go/util/workqueue"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/telekom/controlplane/common/pkg/config"
 )
 
 func NewRateLimiter[T reconcile.Request]() workqueue.TypedRateLimiter[T] {

--- a/common/pkg/errors/ctrlerrors/errors.go
+++ b/common/pkg/errors/ctrlerrors/errors.go
@@ -10,12 +10,13 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/telekom/controlplane/common/pkg/condition"
-	"github.com/telekom/controlplane/common/pkg/config"
-	"github.com/telekom/controlplane/common/pkg/types"
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/telekom/controlplane/common/pkg/condition"
+	"github.com/telekom/controlplane/common/pkg/config"
+	"github.com/telekom/controlplane/common/pkg/types"
 )
 
 type BlockedError interface {
@@ -80,11 +81,11 @@ func HandleError(ctx context.Context, obj types.Object, err error, recorder reco
 }
 
 func recordError(ctx context.Context, obj types.Object, err error, reason string, recorder record.EventRecorder) {
-	log := log.FromContext(ctx).WithName("controller.error-handler")
+	logger := log.FromContext(ctx).WithName("controller.error-handler")
 	if reason == "Unknown" {
-		log.Error(err, "Handling error", "reason", reason)
+		logger.Error(err, "Handling error", "reason", reason)
 	} else {
-		log.V(0).Info("Handling error", "reason", reason, "error", err.Error())
+		logger.V(0).Info("Handling error", "reason", reason, "error", err.Error())
 	}
 
 	if err != nil && recorder != nil {
@@ -92,10 +93,12 @@ func recordError(ctx context.Context, obj types.Object, err error, reason string
 	}
 }
 
-var _ error = &CtrlError{}
-var _ BlockedError = &CtrlError{}
-var _ RetryableError = &CtrlError{}
-var _ RetryableWithDelayError = &CtrlError{}
+var (
+	_ error                   = &CtrlError{}
+	_ BlockedError            = &CtrlError{}
+	_ RetryableError          = &CtrlError{}
+	_ RetryableWithDelayError = &CtrlError{}
+)
 
 type CtrlError struct {
 	msg        string

--- a/common/pkg/errors/ctrlerrors/suite_test.go
+++ b/common/pkg/errors/ctrlerrors/suite_test.go
@@ -10,13 +10,15 @@ import (
 	"testing"
 	"time"
 
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
 	"github.com/pkg/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"github.com/telekom/controlplane/common/pkg/errors/ctrlerrors"
 	"github.com/telekom/controlplane/common/pkg/test"
 	"github.com/telekom/controlplane/common/pkg/test/mock"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 )
 
 type MyBlockedError struct {
@@ -66,7 +68,6 @@ func TestCtrlerrors(t *testing.T) {
 }
 
 var _ = Describe("Test Suite", func() {
-
 	var recorder *mock.EventRecorder
 	var ctx context.Context
 	BeforeEach(func() {
@@ -97,7 +98,6 @@ var _ = Describe("Test Suite", func() {
 		})
 
 		It("should support custom blocked errors", func() {
-
 			myErr := &MyBlockedError{msg: "Custom blocked error"}
 			Expect(myErr.IsBlocked()).To(BeTrue())
 			Expect(myErr.Error()).To(Equal("Custom blocked error"))
@@ -189,7 +189,7 @@ var _ = Describe("Test Suite", func() {
 			Expect(condition.Message).To(Equal("This is a blocked error"))
 
 			events := recorder.GetEvents(obj)
-			Expect(len(events)).To(Equal(1))
+			Expect(events).To(HaveLen(1))
 			Expect(events[0].EventType).To(Equal("Warning"))
 			Expect(events[0].Reason).To(Equal("Blocked"))
 			Expect(events[0].Message).To(Equal("This is a blocked error"))
@@ -228,6 +228,5 @@ var _ = Describe("Test Suite", func() {
 			_, result := ctrlerrors.HandleError(ctx, obj, wrappedErr, recorder)
 			Expect(result.RequeueAfter).To(BeNumerically(">", specificDelay))
 		})
-
 	})
 })

--- a/common/pkg/errors/validation.go
+++ b/common/pkg/errors/validation.go
@@ -7,17 +7,16 @@ package errors
 import (
 	"fmt"
 
-	"github.com/telekom/controlplane/common/pkg/config"
-	"github.com/telekom/controlplane/common/pkg/types"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	"github.com/telekom/controlplane/common/pkg/config"
+	"github.com/telekom/controlplane/common/pkg/types"
 )
 
-var (
-	MetadataEnvPath = field.NewPath("metadata").Child("labels").Child(config.EnvironmentLabelKey)
-)
+var MetadataEnvPath = field.NewPath("metadata").Child("labels").Child(config.EnvironmentLabelKey)
 
 type ValidationError struct {
 	Errors   field.ErrorList

--- a/common/pkg/errors/validation_test.go
+++ b/common/pkg/errors/validation_test.go
@@ -110,13 +110,11 @@ var _ = Describe("ValidationError", func() {
 			valErr.AddInvalidError(field.NewPath("spec").Child("field1"), "invalid-value", "field1 is invalid")
 			valErr.AddInvalidError(field.NewPath("spec").Child("field2"), "/invalid", "field2 is invalid")
 
-			// Build the error
-			statusErr := func() *apierrors.StatusError {
-				target := &apierrors.StatusError{}
-				_ = errors.As(valErr.BuildError(), &target)
-				return target
-			}()
-			Expect(statusErr).To(HaveOccurred())
+			// Build the error and unwrap
+			err := valErr.BuildError()
+			Expect(err).To(HaveOccurred())
+			var statusErr *apierrors.StatusError
+			Expect(errors.As(err, &statusErr)).To(BeTrue())
 
 			// Verify error details
 			Expect(statusErr.ErrStatus.Status).To(Equal(metav1.StatusFailure))
@@ -145,13 +143,11 @@ var _ = Describe("ValidationError", func() {
 			path2 := field.NewPath("spec").Child("duplicate")
 			valErr.Errors = append(valErr.Errors, field.Duplicate(path2, "duplicate value"))
 
-			// Build the error
-			statusErr := func() *apierrors.StatusError {
-				target := &apierrors.StatusError{}
-				_ = errors.As(valErr.BuildError(), &target)
-				return target
-			}()
-			Expect(statusErr).To(HaveOccurred())
+			// Build the error and unwrap
+			err := valErr.BuildError()
+			Expect(err).To(HaveOccurred())
+			var statusErr *apierrors.StatusError
+			Expect(errors.As(err, &statusErr)).To(BeTrue())
 
 			// Verify types are preserved
 			Expect(statusErr.ErrStatus.Details.Causes).To(HaveLen(2))
@@ -221,13 +217,11 @@ var _ = Describe("ValidationError", func() {
 			// Add some errors
 			valErr.AddInvalidError(field.NewPath("spec").Child("zone"), "", "zone is required")
 
-			// Build error and verify
-			statusErr := func() *apierrors.StatusError {
-				target := &apierrors.StatusError{}
-				_ = errors.As(valErr.BuildError(), &target)
-				return target
-			}()
-			Expect(statusErr).To(HaveOccurred())
+			// Build error and unwrap
+			err := valErr.BuildError()
+			Expect(err).To(HaveOccurred())
+			var statusErr *apierrors.StatusError
+			Expect(errors.As(err, &statusErr)).To(BeTrue())
 
 			Expect(statusErr.ErrStatus.Details.Name).To(Equal("test-object"))
 			Expect(statusErr.ErrStatus.Details.Kind).To(Equal("TestResource"))

--- a/common/pkg/errors/validation_test.go
+++ b/common/pkg/errors/validation_test.go
@@ -5,16 +5,19 @@
 package errors
 
 import (
+	"errors"
 	"fmt"
 
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
-	"github.com/telekom/controlplane/common/pkg/test"
-	"github.com/telekom/controlplane/common/pkg/types"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+
+	"github.com/telekom/controlplane/common/pkg/test"
+	"github.com/telekom/controlplane/common/pkg/types"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 )
 
 // MockNamedObject is a simple implementation of types.NamedObject for testing
@@ -38,7 +41,6 @@ func (m *MockNamedObject) GetGenerateName() string {
 var _ types.NamedObject = &MockNamedObject{}
 
 var _ = Describe("ValidationError", func() {
-
 	var (
 		valErr    *ValidationError
 		testObj   *MockNamedObject
@@ -59,7 +61,7 @@ var _ = Describe("ValidationError", func() {
 		It("should initialize with empty errors and warnings", func() {
 			Expect(valErr.HasErrors()).To(BeFalse())
 			Expect(valErr.BuildWarnings()).To(BeNil())
-			Expect(valErr.BuildError()).To(BeNil())
+			Expect(valErr.BuildError()).To(Succeed())
 
 			// Verify internal state
 			Expect(valErr.Errors).To(BeEmpty())
@@ -100,7 +102,7 @@ var _ = Describe("ValidationError", func() {
 
 	Context("BuildError", func() {
 		It("should return nil when there are no errors", func() {
-			Expect(valErr.BuildError()).To(BeNil())
+			Expect(valErr.BuildError()).To(Succeed())
 		})
 
 		It("should build a properly formatted StatusError when there are errors", func() {
@@ -109,8 +111,12 @@ var _ = Describe("ValidationError", func() {
 			valErr.AddInvalidError(field.NewPath("spec").Child("field2"), "/invalid", "field2 is invalid")
 
 			// Build the error
-			statusErr := valErr.BuildError().(*apierrors.StatusError)
-			Expect(statusErr).NotTo(BeNil())
+			statusErr := func() *apierrors.StatusError {
+				target := &apierrors.StatusError{}
+				_ = errors.As(valErr.BuildError(), &target)
+				return target
+			}()
+			Expect(statusErr).To(HaveOccurred())
 
 			// Verify error details
 			Expect(statusErr.ErrStatus.Status).To(Equal(metav1.StatusFailure))
@@ -140,8 +146,12 @@ var _ = Describe("ValidationError", func() {
 			valErr.Errors = append(valErr.Errors, field.Duplicate(path2, "duplicate value"))
 
 			// Build the error
-			statusErr := valErr.BuildError().(*apierrors.StatusError)
-			Expect(statusErr).NotTo(BeNil())
+			statusErr := func() *apierrors.StatusError {
+				target := &apierrors.StatusError{}
+				_ = errors.As(valErr.BuildError(), &target)
+				return target
+			}()
+			Expect(statusErr).To(HaveOccurred())
 
 			// Verify types are preserved
 			Expect(statusErr.ErrStatus.Details.Causes).To(HaveLen(2))
@@ -212,8 +222,12 @@ var _ = Describe("ValidationError", func() {
 			valErr.AddInvalidError(field.NewPath("spec").Child("zone"), "", "zone is required")
 
 			// Build error and verify
-			statusErr := valErr.BuildError().(*apierrors.StatusError)
-			Expect(statusErr).NotTo(BeNil())
+			statusErr := func() *apierrors.StatusError {
+				target := &apierrors.StatusError{}
+				_ = errors.As(valErr.BuildError(), &target)
+				return target
+			}()
+			Expect(statusErr).To(HaveOccurred())
 
 			Expect(statusErr.ErrStatus.Details.Name).To(Equal("test-object"))
 			Expect(statusErr.ErrStatus.Details.Kind).To(Equal("TestResource"))

--- a/common/pkg/handler/custom.go
+++ b/common/pkg/handler/custom.go
@@ -10,18 +10,20 @@ import (
 	"github.com/telekom/controlplane/common/pkg/types"
 )
 
-type CreateOrUpdateFunc[T types.Object] func(ctx context.Context, object T) error
-type DeleteFunc[T types.Object] func(ctx context.Context, obj T) error
+type (
+	CreateOrUpdateFunc[T types.Object] func(ctx context.Context, object T) error
+	DeleteFunc[T types.Object]         func(ctx context.Context, obj T) error
+)
 
 type CustomHandler[T types.Object] struct {
 	createOrUpdate CreateOrUpdateFunc[T]
-	delete         DeleteFunc[T]
+	deleteFunc     DeleteFunc[T]
 }
 
-func NewCustomHandler[T types.Object](createOrUpdate CreateOrUpdateFunc[T], delete DeleteFunc[T]) *CustomHandler[T] {
+func NewCustomHandler[T types.Object](createOrUpdate CreateOrUpdateFunc[T], deleteFunc DeleteFunc[T]) *CustomHandler[T] {
 	return &CustomHandler[T]{
 		createOrUpdate: createOrUpdate,
-		delete:         delete,
+		deleteFunc:     deleteFunc,
 	}
 }
 
@@ -30,5 +32,5 @@ func (h *CustomHandler[T]) CreateOrUpdate(ctx context.Context, object T) error {
 }
 
 func (h *CustomHandler[T]) Delete(ctx context.Context, obj T) error {
-	return h.delete(ctx, obj)
+	return h.deleteFunc(ctx, obj)
 }

--- a/common/pkg/test/object_test .go
+++ b/common/pkg/test/object_test .go
@@ -5,15 +5,18 @@
 package test
 
 import (
-	"github.com/telekom/controlplane/common/pkg/types"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/telekom/controlplane/common/pkg/types"
 )
 
-var _ types.Object = &TestResource{}
-var _ types.ObjectList = &TestResourceList{}
+var (
+	_ types.Object     = &TestResource{}
+	_ types.ObjectList = &TestResourceList{}
+)
 
 type TestResource struct {
 	metav1.TypeMeta   `json:",inline"`
@@ -27,7 +30,7 @@ func (r *TestResource) GetConditions() []metav1.Condition {
 	return r.Status.Conditions
 }
 
-func (r *TestResource) SetCondition(condition metav1.Condition) bool {
+func (r *TestResource) SetCondition(condition metav1.Condition) bool { //nolint:gocritic // hugeParam: kept as value to match interface
 	return meta.SetStatusCondition(&r.Status.Conditions, condition)
 }
 

--- a/common/pkg/test/testutil/module.go
+++ b/common/pkg/test/testutil/module.go
@@ -54,7 +54,7 @@ func GetCrdPaths(modPathRE string) (paths []string, err error) {
 }
 
 func getCrdPaths(goModFilePath, modPathRE string) (paths []string, err error) {
-	content, err := os.ReadFile(goModFilePath)
+	content, err := os.ReadFile(goModFilePath) //nolint:gosec // G304: file path is constructed from go.mod parsing, not user input
 	if err != nil {
 		return nil, errors.Wrap(err, fmt.Sprintf("failed to read '%s'", goModFilePath))
 	}
@@ -88,7 +88,7 @@ func getCrdPaths(goModFilePath, modPathRE string) (paths []string, err error) {
 			continue
 		}
 
-		crdFilepath := filepath.Join(goPath, "pkg/mod", fmt.Sprintf("%s@%s", req.Mod.Path, req.Mod.Version), PkgModCrdsSubpath)
+		crdFilepath := filepath.Join(goPath, "pkg", "mod", fmt.Sprintf("%s@%s", req.Mod.Path, req.Mod.Version), PkgModCrdsSubpath)
 		paths = append(paths, crdFilepath)
 	}
 	return paths, nil

--- a/common/pkg/test/testutil/module_test.go
+++ b/common/pkg/test/testutil/module_test.go
@@ -13,7 +13,6 @@ import (
 )
 
 var _ = Describe("Module", func() {
-
 	Context("FindNextGoModPath", func() {
 		It("should find the go.mod file", func() {
 			path, err := findNextFileMatch("go.mod")
@@ -47,5 +46,4 @@ var _ = Describe("Module", func() {
 			Expect(paths[0]).To(MatchRegexp(expectedPattern))
 		})
 	})
-
 })

--- a/common/pkg/types/objectref.go
+++ b/common/pkg/types/objectref.go
@@ -121,6 +121,7 @@ func (o *TypedObjectRef) Equals(other TypedNamedObject) bool {
 		o.APIVersion == other.GetAPIVersion() &&
 		o.ObjectRef.Equals(other)
 }
+
 func (o *TypedObjectRef) DeepCopy() *TypedObjectRef {
 	return &TypedObjectRef{
 		TypeMeta:  o.TypeMeta,

--- a/common/pkg/types/types_suite_test.go
+++ b/common/pkg/types/types_suite_test.go
@@ -60,9 +60,9 @@ var _ = Describe("ObjectRef", func() {
 			obj := unstructured.Unstructured{}
 			obj.SetName("test")
 			obj.SetNamespace("test")
-			ref := ObjectRefFromObject(&obj)
-			Expect(ref.Name).To(Equal("test"))
-			Expect(ref.Namespace).To(Equal("test"))
+			newRef := ObjectRefFromObject(&obj)
+			Expect(newRef.Name).To(Equal("test"))
+			Expect(newRef.Namespace).To(Equal("test"))
 		})
 
 		It("should successfully compare", func() {
@@ -146,11 +146,11 @@ var _ = Describe("ObjectRef", func() {
 
 			Expect(err).ToNot(HaveOccurred())
 
-			ref := TypedObjectRefFromObject(&obj, scheme.Scheme)
-			Expect(ref.Name).To(Equal("test"))
-			Expect(ref.Namespace).To(Equal("test"))
-			Expect(ref.Kind).To(Equal("Object"))
-			Expect(ref.APIVersion).To(Equal("testgroup.cp.ei.telekom.de/v1"))
+			newRef := TypedObjectRefFromObject(&obj, scheme.Scheme)
+			Expect(newRef.Name).To(Equal("test"))
+			Expect(newRef.Namespace).To(Equal("test"))
+			Expect(newRef.Kind).To(Equal("Object"))
+			Expect(newRef.APIVersion).To(Equal("testgroup.cp.ei.telekom.de/v1"))
 		})
 
 		It("should successfully compare", func() {

--- a/common/pkg/util/contextutil/contextutil.go
+++ b/common/pkg/util/contextutil/contextutil.go
@@ -8,9 +8,7 @@ import "context"
 
 type contextKey string
 
-var (
-	envKey contextKey = "env"
-)
+var envKey contextKey = "env"
 
 func EnvFromContext(ctx context.Context) (string, bool) {
 	e, ok := ctx.Value(envKey).(string)

--- a/common/pkg/util/contextutil/contextutil_test.go
+++ b/common/pkg/util/contextutil/contextutil_test.go
@@ -12,9 +12,7 @@ import (
 )
 
 var _ = Describe("Contextutil", func() {
-
 	Context("Env", func() {
-
 		It("should manage the environment in the context", func() {
 			ctx := context.Background()
 
@@ -36,6 +34,5 @@ var _ = Describe("Contextutil", func() {
 				EnvFromContextOrDie(ctx)
 			}).To(Panic())
 		})
-
 	})
 })

--- a/common/pkg/util/contextutil/recorder_test.go
+++ b/common/pkg/util/contextutil/recorder_test.go
@@ -7,15 +7,14 @@ package contextutil
 import (
 	"context"
 
+	"github.com/telekom/controlplane/common/pkg/test/mock"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/telekom/controlplane/common/pkg/test/mock"
 )
 
 var _ = Describe("Recorder", func() {
-
 	Context("Env", func() {
-
 		It("should manage the recorder in the context", func() {
 			ctx := context.Background()
 
@@ -37,6 +36,5 @@ var _ = Describe("Recorder", func() {
 				RecorderFromContextOrDie(ctx)
 			}).To(Panic())
 		})
-
 	})
 })

--- a/common/pkg/util/hash/hash.go
+++ b/common/pkg/util/hash/hash.go
@@ -27,7 +27,7 @@ func ComputeHash(content any, collisionCount *uint32) string {
 	if collisionCount != nil {
 		collisionCountBytes := make([]byte, 8)
 		binary.LittleEndian.PutUint32(collisionCountBytes, *collisionCount)
-		hasher.Write(collisionCountBytes)
+		_, _ = hasher.Write(collisionCountBytes)
 	}
 
 	return rand.SafeEncodeString(fmt.Sprint(hasher.Sum32()))

--- a/common/pkg/util/labelutil/labelutil_suite_test.go
+++ b/common/pkg/util/labelutil/labelutil_suite_test.go
@@ -17,11 +17,8 @@ func TestLabelutil(t *testing.T) {
 }
 
 var _ = Describe("Labelutil", func() {
-
 	Context("NormalizeValue", func() {
-
 		It("should normalize value", func() {
-
 			value := " foo/bar_baz/ "
 			Expect(NormalizeValue(value)).To(Equal("foo-bar-baz"))
 
@@ -44,7 +41,7 @@ var _ = Describe("Labelutil", func() {
 		It("should not shorten names", func() {
 			value := "This is a very long value/with some_unwanted\\characters that needs to be normalized and shortened"
 			shortenedValue := NormalizeNameValue(value)
-			Expect(len(shortenedValue)).To(Equal(len(value)))
+			Expect(shortenedValue).To(HaveLen(len(value)))
 			Expect(shortenedValue).To(Equal("this-is-a-very-long-value-with-some-unwanted-characters-that-needs-to-be-normalized-and-shortened"))
 		})
 
@@ -60,6 +57,5 @@ var _ = Describe("Labelutil", func() {
 			shortenedValue := NormalizeLabelValue(value)
 			Expect(shortenedValue).To(Equal("short-value"))
 		})
-
 	})
 })

--- a/common/scripts/install_crds/install_crds.go
+++ b/common/scripts/install_crds/install_crds.go
@@ -27,7 +27,7 @@ func main() {
 			log.Printf("CRD file(s) not found: %s", path)
 			continue
 		}
-		cmd := exec.Command("kubectl", "apply", "-f", path)
+		cmd := exec.Command("kubectl", "apply", "-f", path) //nolint:gosec // G204: arguments are constructed from known file paths, not user input
 		out, err := cmd.CombinedOutput()
 		if err != nil {
 			log.Fatal(err)


### PR DESCRIPTION
 ## Update Makefile
 Update tool versions and golangci-lint target in Makefile.

 ## Autofixes for `common/`
 Use make lint-fix to autofix issues

  ## Manual lint fixes for `common/`
- Apply automated lint fixes (import grouping, var decl simplification, errcheck/gosec suppressions, small refactors).
- Perform a small maintainability refactor in common/pkg/controller/controller.go by extracting deletion handling into a helper.