### PR TITLE
fix(discover-server): Fix golangci-lint issues

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -220,6 +220,7 @@ jobs:
       module: discovery-server
       run_check_generated_files: false
       ko_build_path: "cmd/main.go"
+      lint_fail_on_issues: true
 
   pubsub:
     name: PubSub

--- a/discovery-server/Makefile
+++ b/discovery-server/Makefile
@@ -17,6 +17,20 @@ vet: ## Run go vet against code.
 generate: ## Run code generation.
 	go generate ./tools/...
 
+##@ Lint
+
+.PHONY: lint
+lint: golangci-lint ## Run golangci-lint linter
+	"$(GOLANGCI_LINT)" run
+
+.PHONY: lint-fix
+lint-fix: golangci-lint ## Run golangci-lint linter and perform fixes
+	"$(GOLANGCI_LINT)" run --fix
+
+.PHONY: lint-config
+lint-config: golangci-lint ## Verify golangci-lint linter configuration
+	"$(GOLANGCI_LINT)" config verify
+
 ##@ Build
 
 .PHONY: build
@@ -32,3 +46,37 @@ COVER_PACKAGES = $(subst $(space),$(comma),$(strip $(TEST_PACKAGES)))
 .PHONY: test
 test: fmt vet ## Run tests.
 	gotestsum --format pkgname --junitfile junit.xml --jsonfile gotest.log -- $(TEST_PACKAGES) -coverprofile cover.out --coverpkg $(COVER_PACKAGES) -mod=readonly -race
+
+##@ Dependencies
+
+## Location to install dependencies to
+LOCALBIN ?= $(shell pwd)/bin
+$(LOCALBIN):
+	mkdir -p $(LOCALBIN)
+
+## Tool Binaries
+GOLANGCI_LINT = $(LOCALBIN)/golangci-lint
+
+## Tool Versions
+GOLANGCI_LINT_VERSION ?= v2.11.4
+
+.PHONY: golangci-lint
+golangci-lint: $(GOLANGCI_LINT) ## Download golangci-lint locally if necessary.
+$(GOLANGCI_LINT): $(LOCALBIN)
+	$(call go-install-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/v2/cmd/golangci-lint,$(GOLANGCI_LINT_VERSION))
+
+# go-install-tool will 'go install' any package with custom target and name of binary, if it doesn't exist
+# $1 - target path with name of binary
+# $2 - package url which can be installed
+# $3 - specific version of package
+define go-install-tool
+@[ -f "$(1)-$(3)" ] && [ "$$(readlink -- "$(1)" 2>/dev/null)" = "$(1)-$(3)" ] || { \
+set -e; \
+package=$(2)@$(3) ;\
+echo "Downloading $${package}" ;\
+rm -f "$(1)" ;\
+GOBIN="$(LOCALBIN)" go install $${package} ;\
+mv "$(LOCALBIN)/$$(basename "$(1)")" "$(1)-$(3)" ;\
+} ;\
+ln -sf "$$(realpath "$(1)-$(3)")" "$(1)"
+endef

--- a/discovery-server/cmd/main.go
+++ b/discovery-server/cmd/main.go
@@ -14,9 +14,9 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
-	cserver "github.com/telekom/controlplane/common-server/pkg/server"
 	kconfig "sigs.k8s.io/controller-runtime/pkg/client/config"
 
+	cserver "github.com/telekom/controlplane/common-server/pkg/server"
 	"github.com/telekom/controlplane/discovery-server/internal/config"
 	"github.com/telekom/controlplane/discovery-server/internal/controller"
 	"github.com/telekom/controlplane/discovery-server/internal/server"
@@ -59,7 +59,7 @@ func main() {
 	signal.Notify(quit, syscall.SIGINT, syscall.SIGTERM)
 	go func() {
 		err := app.Listen(cfg.Address)
-		if err != nil && err != http.ErrServerClosed {
+		if err != nil && !errors.Is(err, http.ErrServerClosed) {
 			log.Log.Error(err, "Failed to start server")
 		}
 	}()

--- a/discovery-server/internal/controller/apiexposure.go
+++ b/discovery-server/internal/controller/apiexposure.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/telekom/controlplane/common-server/pkg/server/middleware/security"
 	"github.com/telekom/controlplane/common-server/pkg/store"
-
 	"github.com/telekom/controlplane/discovery-server/internal/api"
 	"github.com/telekom/controlplane/discovery-server/internal/mapper"
 	exposuremapper "github.com/telekom/controlplane/discovery-server/internal/mapper/apiexposure"
@@ -121,8 +120,8 @@ func (c *apiExposureController) GetSubscriptions(ctx context.Context, applicatio
 	if err != nil {
 		return nil, err
 	}
-	if err := mapper.VerifyApplicationLabel(exposure, appInfo.AppName); err != nil {
-		return nil, err
+	if verifyErr := mapper.VerifyApplicationLabel(exposure, appInfo.AppName); verifyErr != nil {
+		return nil, verifyErr
 	}
 
 	// Fetch all subscriptions (cross-namespace — no prefix, no app label filter)

--- a/discovery-server/internal/controller/apiexposure_test.go
+++ b/discovery-server/internal/controller/apiexposure_test.go
@@ -10,15 +10,15 @@ import (
 
 	"github.com/gkampitakis/go-snaps/match"
 	"github.com/gkampitakis/go-snaps/snaps"
+
 	. "github.com/onsi/ginkgo/v2"
 )
 
 var _ = Describe("ApiExposure Controller", func() {
-
 	Describe("GET /applications/:applicationId/apiexposures", func() {
 		DescribeTable("should list API exposures with different scopes",
 			func(token string) {
-				req := httptest.NewRequest(http.MethodGet, "/applications/eni--hyperion--my-app/apiexposures", nil)
+				req := httptest.NewRequest(http.MethodGet, "/applications/eni--hyperion--my-app/apiexposures", http.NoBody)
 				resp, err := ExecuteRequest(req, token)
 				body := ExpectStatusOk(resp, err)
 				snaps.MatchJSON(GinkgoT(), body, match.Any("items.0.status"))
@@ -30,25 +30,25 @@ var _ = Describe("ApiExposure Controller", func() {
 		)
 
 		It("should return 403 for a different team", func() {
-			req := httptest.NewRequest(http.MethodGet, "/applications/eni--hyperion--my-app/apiexposures", nil)
+			req := httptest.NewRequest(http.MethodGet, "/applications/eni--hyperion--my-app/apiexposures", http.NoBody)
 			resp, err := ExecuteRequest(req, teamNoResToken)
 			ExpectStatus(resp, err, http.StatusForbidden, "application/problem+json")
 		})
 
 		It("should return 403 for a different group", func() {
-			req := httptest.NewRequest(http.MethodGet, "/applications/eni--hyperion--my-app/apiexposures", nil)
+			req := httptest.NewRequest(http.MethodGet, "/applications/eni--hyperion--my-app/apiexposures", http.NoBody)
 			resp, err := ExecuteRequest(req, groupOtherToken)
 			ExpectStatus(resp, err, http.StatusForbidden, "application/problem+json")
 		})
 
 		It("should return 403 for a partial team name prefix (hyper != hyperion)", func() {
-			req := httptest.NewRequest(http.MethodGet, "/applications/eni--hyperion--my-app/apiexposures", nil)
+			req := httptest.NewRequest(http.MethodGet, "/applications/eni--hyperion--my-app/apiexposures", http.NoBody)
 			resp, err := ExecuteRequest(req, teamPrefixToken)
 			ExpectStatus(resp, err, http.StatusForbidden, "application/problem+json")
 		})
 
 		It("should return 403 for a partial group name prefix (en != eni)", func() {
-			req := httptest.NewRequest(http.MethodGet, "/applications/eni--hyperion--my-app/apiexposures", nil)
+			req := httptest.NewRequest(http.MethodGet, "/applications/eni--hyperion--my-app/apiexposures", http.NoBody)
 			resp, err := ExecuteRequest(req, groupPrefixToken)
 			ExpectStatus(resp, err, http.StatusForbidden, "application/problem+json")
 		})
@@ -57,7 +57,7 @@ var _ = Describe("ApiExposure Controller", func() {
 	Describe("GET /applications/:applicationId/apiexposures/:apiExposureName", func() {
 		DescribeTable("should return a single API exposure with different scopes",
 			func(token string) {
-				req := httptest.NewRequest(http.MethodGet, "/applications/eni--hyperion--my-app/apiexposures/eni-distr-v1", nil)
+				req := httptest.NewRequest(http.MethodGet, "/applications/eni--hyperion--my-app/apiexposures/eni-distr-v1", http.NoBody)
 				resp, err := ExecuteRequest(req, token)
 				body := ExpectStatusOk(resp, err)
 				snaps.MatchJSON(GinkgoT(), body, match.Any("status"))
@@ -69,35 +69,34 @@ var _ = Describe("ApiExposure Controller", func() {
 		)
 
 		It("should return 403 for a different team", func() {
-			req := httptest.NewRequest(http.MethodGet, "/applications/eni--hyperion--my-app/apiexposures/eni-distr-v1", nil)
+			req := httptest.NewRequest(http.MethodGet, "/applications/eni--hyperion--my-app/apiexposures/eni-distr-v1", http.NoBody)
 			resp, err := ExecuteRequest(req, teamNoResToken)
 			ExpectStatus(resp, err, http.StatusForbidden, "application/problem+json")
 		})
 
 		It("should return 403 for a different group", func() {
-			req := httptest.NewRequest(http.MethodGet, "/applications/eni--hyperion--my-app/apiexposures/eni-distr-v1", nil)
+			req := httptest.NewRequest(http.MethodGet, "/applications/eni--hyperion--my-app/apiexposures/eni-distr-v1", http.NoBody)
 			resp, err := ExecuteRequest(req, groupOtherToken)
 			ExpectStatus(resp, err, http.StatusForbidden, "application/problem+json")
 		})
 
 		It("should return 403 for a partial team name prefix (hyper != hyperion)", func() {
-			req := httptest.NewRequest(http.MethodGet, "/applications/eni--hyperion--my-app/apiexposures/eni-distr-v1", nil)
+			req := httptest.NewRequest(http.MethodGet, "/applications/eni--hyperion--my-app/apiexposures/eni-distr-v1", http.NoBody)
 			resp, err := ExecuteRequest(req, teamPrefixToken)
 			ExpectStatus(resp, err, http.StatusForbidden, "application/problem+json")
 		})
 
 		It("should return 403 for a partial group name prefix (en != eni)", func() {
-			req := httptest.NewRequest(http.MethodGet, "/applications/eni--hyperion--my-app/apiexposures/eni-distr-v1", nil)
+			req := httptest.NewRequest(http.MethodGet, "/applications/eni--hyperion--my-app/apiexposures/eni-distr-v1", http.NoBody)
 			resp, err := ExecuteRequest(req, groupPrefixToken)
 			ExpectStatus(resp, err, http.StatusForbidden, "application/problem+json")
 		})
-
 	})
 
 	Describe("GET /applications/:applicationId/apiexposures/:apiExposureName/status", func() {
 		DescribeTable("should return API exposure status with different scopes",
 			func(token string) {
-				req := httptest.NewRequest(http.MethodGet, "/applications/eni--hyperion--my-app/apiexposures/eni-distr-v1/status", nil)
+				req := httptest.NewRequest(http.MethodGet, "/applications/eni--hyperion--my-app/apiexposures/eni-distr-v1/status", http.NoBody)
 				resp, err := ExecuteRequest(req, token)
 				body := ExpectStatusOk(resp, err)
 				snaps.MatchJSON(GinkgoT(), body, match.Any("createdAt"), match.Any("processedAt"))
@@ -109,35 +108,34 @@ var _ = Describe("ApiExposure Controller", func() {
 		)
 
 		It("should return 403 for a different team", func() {
-			req := httptest.NewRequest(http.MethodGet, "/applications/eni--hyperion--my-app/apiexposures/eni-distr-v1/status", nil)
+			req := httptest.NewRequest(http.MethodGet, "/applications/eni--hyperion--my-app/apiexposures/eni-distr-v1/status", http.NoBody)
 			resp, err := ExecuteRequest(req, teamNoResToken)
 			ExpectStatus(resp, err, http.StatusForbidden, "application/problem+json")
 		})
 
 		It("should return 403 for a different group", func() {
-			req := httptest.NewRequest(http.MethodGet, "/applications/eni--hyperion--my-app/apiexposures/eni-distr-v1/status", nil)
+			req := httptest.NewRequest(http.MethodGet, "/applications/eni--hyperion--my-app/apiexposures/eni-distr-v1/status", http.NoBody)
 			resp, err := ExecuteRequest(req, groupOtherToken)
 			ExpectStatus(resp, err, http.StatusForbidden, "application/problem+json")
 		})
 
 		It("should return 403 for a partial team name prefix (hyper != hyperion)", func() {
-			req := httptest.NewRequest(http.MethodGet, "/applications/eni--hyperion--my-app/apiexposures/eni-distr-v1/status", nil)
+			req := httptest.NewRequest(http.MethodGet, "/applications/eni--hyperion--my-app/apiexposures/eni-distr-v1/status", http.NoBody)
 			resp, err := ExecuteRequest(req, teamPrefixToken)
 			ExpectStatus(resp, err, http.StatusForbidden, "application/problem+json")
 		})
 
 		It("should return 403 for a partial group name prefix (en != eni)", func() {
-			req := httptest.NewRequest(http.MethodGet, "/applications/eni--hyperion--my-app/apiexposures/eni-distr-v1/status", nil)
+			req := httptest.NewRequest(http.MethodGet, "/applications/eni--hyperion--my-app/apiexposures/eni-distr-v1/status", http.NoBody)
 			resp, err := ExecuteRequest(req, groupPrefixToken)
 			ExpectStatus(resp, err, http.StatusForbidden, "application/problem+json")
 		})
-
 	})
 
 	Describe("GET /applications/:applicationId/apiexposures/:apiExposureName/apisubscriptions", func() {
 		DescribeTable("should list subscriptions for an API exposure with different scopes",
 			func(token string) {
-				req := httptest.NewRequest(http.MethodGet, "/applications/eni--hyperion--my-app/apiexposures/eni-distr-v1/apisubscriptions", nil)
+				req := httptest.NewRequest(http.MethodGet, "/applications/eni--hyperion--my-app/apiexposures/eni-distr-v1/apisubscriptions", http.NoBody)
 				resp, err := ExecuteRequest(req, token)
 				body := ExpectStatusOk(resp, err)
 				snaps.MatchJSON(GinkgoT(), body, match.Any("items.0.status"))
@@ -149,25 +147,25 @@ var _ = Describe("ApiExposure Controller", func() {
 		)
 
 		It("should return 403 for a different team", func() {
-			req := httptest.NewRequest(http.MethodGet, "/applications/eni--hyperion--my-app/apiexposures/eni-distr-v1/apisubscriptions", nil)
+			req := httptest.NewRequest(http.MethodGet, "/applications/eni--hyperion--my-app/apiexposures/eni-distr-v1/apisubscriptions", http.NoBody)
 			resp, err := ExecuteRequest(req, teamNoResToken)
 			ExpectStatus(resp, err, http.StatusForbidden, "application/problem+json")
 		})
 
 		It("should return 403 for a different group", func() {
-			req := httptest.NewRequest(http.MethodGet, "/applications/eni--hyperion--my-app/apiexposures/eni-distr-v1/apisubscriptions", nil)
+			req := httptest.NewRequest(http.MethodGet, "/applications/eni--hyperion--my-app/apiexposures/eni-distr-v1/apisubscriptions", http.NoBody)
 			resp, err := ExecuteRequest(req, groupOtherToken)
 			ExpectStatus(resp, err, http.StatusForbidden, "application/problem+json")
 		})
 
 		It("should return 403 for a partial team name prefix (hyper != hyperion)", func() {
-			req := httptest.NewRequest(http.MethodGet, "/applications/eni--hyperion--my-app/apiexposures/eni-distr-v1/apisubscriptions", nil)
+			req := httptest.NewRequest(http.MethodGet, "/applications/eni--hyperion--my-app/apiexposures/eni-distr-v1/apisubscriptions", http.NoBody)
 			resp, err := ExecuteRequest(req, teamPrefixToken)
 			ExpectStatus(resp, err, http.StatusForbidden, "application/problem+json")
 		})
 
 		It("should return 403 for a partial group name prefix (en != eni)", func() {
-			req := httptest.NewRequest(http.MethodGet, "/applications/eni--hyperion--my-app/apiexposures/eni-distr-v1/apisubscriptions", nil)
+			req := httptest.NewRequest(http.MethodGet, "/applications/eni--hyperion--my-app/apiexposures/eni-distr-v1/apisubscriptions", http.NoBody)
 			resp, err := ExecuteRequest(req, groupPrefixToken)
 			ExpectStatus(resp, err, http.StatusForbidden, "application/problem+json")
 		})

--- a/discovery-server/internal/controller/apisubscription.go
+++ b/discovery-server/internal/controller/apisubscription.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/telekom/controlplane/common-server/pkg/server/middleware/security"
 	"github.com/telekom/controlplane/common-server/pkg/store"
-
 	"github.com/telekom/controlplane/discovery-server/internal/api"
 	"github.com/telekom/controlplane/discovery-server/internal/mapper"
 	subscriptionmapper "github.com/telekom/controlplane/discovery-server/internal/mapper/apisubscription"
@@ -52,6 +51,7 @@ func (c *apiSubscriptionController) Get(ctx context.Context, applicationId, apiS
 	return subscriptionmapper.MapResponse(ctx, sub, c.stores), nil
 }
 
+//nolint:dupl // type-specific list methods share structure but differ in types and stores
 func (c *apiSubscriptionController) GetAll(ctx context.Context, applicationId string, params api.GetAllApiSubscriptionsParams) (*api.ApiSubscriptionListResponse, error) {
 	appInfo, err := mapper.ParseApplicationId(ctx, applicationId)
 	if err != nil {

--- a/discovery-server/internal/controller/apisubscription_test.go
+++ b/discovery-server/internal/controller/apisubscription_test.go
@@ -10,15 +10,15 @@ import (
 
 	"github.com/gkampitakis/go-snaps/match"
 	"github.com/gkampitakis/go-snaps/snaps"
+
 	. "github.com/onsi/ginkgo/v2"
 )
 
 var _ = Describe("ApiSubscription Controller", func() {
-
 	Describe("GET /applications/:applicationId/apisubscriptions", func() {
 		DescribeTable("should list API subscriptions with different scopes",
 			func(token string) {
-				req := httptest.NewRequest(http.MethodGet, "/applications/eni--hyperion--my-app/apisubscriptions", nil)
+				req := httptest.NewRequest(http.MethodGet, "/applications/eni--hyperion--my-app/apisubscriptions", http.NoBody)
 				resp, err := ExecuteRequest(req, token)
 				body := ExpectStatusOk(resp, err)
 				snaps.MatchJSON(GinkgoT(), body, match.Any("items.0.status"))
@@ -30,25 +30,25 @@ var _ = Describe("ApiSubscription Controller", func() {
 		)
 
 		It("should return 403 for a different team", func() {
-			req := httptest.NewRequest(http.MethodGet, "/applications/eni--hyperion--my-app/apisubscriptions", nil)
+			req := httptest.NewRequest(http.MethodGet, "/applications/eni--hyperion--my-app/apisubscriptions", http.NoBody)
 			resp, err := ExecuteRequest(req, teamNoResToken)
 			ExpectStatus(resp, err, http.StatusForbidden, "application/problem+json")
 		})
 
 		It("should return 403 for a different group", func() {
-			req := httptest.NewRequest(http.MethodGet, "/applications/eni--hyperion--my-app/apisubscriptions", nil)
+			req := httptest.NewRequest(http.MethodGet, "/applications/eni--hyperion--my-app/apisubscriptions", http.NoBody)
 			resp, err := ExecuteRequest(req, groupOtherToken)
 			ExpectStatus(resp, err, http.StatusForbidden, "application/problem+json")
 		})
 
 		It("should return 403 for a partial team name prefix (hyper != hyperion)", func() {
-			req := httptest.NewRequest(http.MethodGet, "/applications/eni--hyperion--my-app/apisubscriptions", nil)
+			req := httptest.NewRequest(http.MethodGet, "/applications/eni--hyperion--my-app/apisubscriptions", http.NoBody)
 			resp, err := ExecuteRequest(req, teamPrefixToken)
 			ExpectStatus(resp, err, http.StatusForbidden, "application/problem+json")
 		})
 
 		It("should return 403 for a partial group name prefix (en != eni)", func() {
-			req := httptest.NewRequest(http.MethodGet, "/applications/eni--hyperion--my-app/apisubscriptions", nil)
+			req := httptest.NewRequest(http.MethodGet, "/applications/eni--hyperion--my-app/apisubscriptions", http.NoBody)
 			resp, err := ExecuteRequest(req, groupPrefixToken)
 			ExpectStatus(resp, err, http.StatusForbidden, "application/problem+json")
 		})
@@ -57,7 +57,7 @@ var _ = Describe("ApiSubscription Controller", func() {
 	Describe("GET /applications/:applicationId/apisubscriptions/:apiSubscriptionName", func() {
 		DescribeTable("should return a single API subscription with different scopes",
 			func(token string) {
-				req := httptest.NewRequest(http.MethodGet, "/applications/eni--hyperion--my-app/apisubscriptions/eni-distr-v1", nil)
+				req := httptest.NewRequest(http.MethodGet, "/applications/eni--hyperion--my-app/apisubscriptions/eni-distr-v1", http.NoBody)
 				resp, err := ExecuteRequest(req, token)
 				body := ExpectStatusOk(resp, err)
 				snaps.MatchJSON(GinkgoT(), body, match.Any("status"))
@@ -69,35 +69,34 @@ var _ = Describe("ApiSubscription Controller", func() {
 		)
 
 		It("should return 403 for a different team", func() {
-			req := httptest.NewRequest(http.MethodGet, "/applications/eni--hyperion--my-app/apisubscriptions/eni-distr-v1", nil)
+			req := httptest.NewRequest(http.MethodGet, "/applications/eni--hyperion--my-app/apisubscriptions/eni-distr-v1", http.NoBody)
 			resp, err := ExecuteRequest(req, teamNoResToken)
 			ExpectStatus(resp, err, http.StatusForbidden, "application/problem+json")
 		})
 
 		It("should return 403 for a different group", func() {
-			req := httptest.NewRequest(http.MethodGet, "/applications/eni--hyperion--my-app/apisubscriptions/eni-distr-v1", nil)
+			req := httptest.NewRequest(http.MethodGet, "/applications/eni--hyperion--my-app/apisubscriptions/eni-distr-v1", http.NoBody)
 			resp, err := ExecuteRequest(req, groupOtherToken)
 			ExpectStatus(resp, err, http.StatusForbidden, "application/problem+json")
 		})
 
 		It("should return 403 for a partial team name prefix (hyper != hyperion)", func() {
-			req := httptest.NewRequest(http.MethodGet, "/applications/eni--hyperion--my-app/apisubscriptions/eni-distr-v1", nil)
+			req := httptest.NewRequest(http.MethodGet, "/applications/eni--hyperion--my-app/apisubscriptions/eni-distr-v1", http.NoBody)
 			resp, err := ExecuteRequest(req, teamPrefixToken)
 			ExpectStatus(resp, err, http.StatusForbidden, "application/problem+json")
 		})
 
 		It("should return 403 for a partial group name prefix (en != eni)", func() {
-			req := httptest.NewRequest(http.MethodGet, "/applications/eni--hyperion--my-app/apisubscriptions/eni-distr-v1", nil)
+			req := httptest.NewRequest(http.MethodGet, "/applications/eni--hyperion--my-app/apisubscriptions/eni-distr-v1", http.NoBody)
 			resp, err := ExecuteRequest(req, groupPrefixToken)
 			ExpectStatus(resp, err, http.StatusForbidden, "application/problem+json")
 		})
-
 	})
 
 	Describe("GET /applications/:applicationId/apisubscriptions/:apiSubscriptionName/status", func() {
 		DescribeTable("should return API subscription status with different scopes",
 			func(token string) {
-				req := httptest.NewRequest(http.MethodGet, "/applications/eni--hyperion--my-app/apisubscriptions/eni-distr-v1/status", nil)
+				req := httptest.NewRequest(http.MethodGet, "/applications/eni--hyperion--my-app/apisubscriptions/eni-distr-v1/status", http.NoBody)
 				resp, err := ExecuteRequest(req, token)
 				body := ExpectStatusOk(resp, err)
 				snaps.MatchJSON(GinkgoT(), body, match.Any("createdAt"), match.Any("processedAt"))
@@ -109,28 +108,27 @@ var _ = Describe("ApiSubscription Controller", func() {
 		)
 
 		It("should return 403 for a different team", func() {
-			req := httptest.NewRequest(http.MethodGet, "/applications/eni--hyperion--my-app/apisubscriptions/eni-distr-v1/status", nil)
+			req := httptest.NewRequest(http.MethodGet, "/applications/eni--hyperion--my-app/apisubscriptions/eni-distr-v1/status", http.NoBody)
 			resp, err := ExecuteRequest(req, teamNoResToken)
 			ExpectStatus(resp, err, http.StatusForbidden, "application/problem+json")
 		})
 
 		It("should return 403 for a different group", func() {
-			req := httptest.NewRequest(http.MethodGet, "/applications/eni--hyperion--my-app/apisubscriptions/eni-distr-v1/status", nil)
+			req := httptest.NewRequest(http.MethodGet, "/applications/eni--hyperion--my-app/apisubscriptions/eni-distr-v1/status", http.NoBody)
 			resp, err := ExecuteRequest(req, groupOtherToken)
 			ExpectStatus(resp, err, http.StatusForbidden, "application/problem+json")
 		})
 
 		It("should return 403 for a partial team name prefix (hyper != hyperion)", func() {
-			req := httptest.NewRequest(http.MethodGet, "/applications/eni--hyperion--my-app/apisubscriptions/eni-distr-v1/status", nil)
+			req := httptest.NewRequest(http.MethodGet, "/applications/eni--hyperion--my-app/apisubscriptions/eni-distr-v1/status", http.NoBody)
 			resp, err := ExecuteRequest(req, teamPrefixToken)
 			ExpectStatus(resp, err, http.StatusForbidden, "application/problem+json")
 		})
 
 		It("should return 403 for a partial group name prefix (en != eni)", func() {
-			req := httptest.NewRequest(http.MethodGet, "/applications/eni--hyperion--my-app/apisubscriptions/eni-distr-v1/status", nil)
+			req := httptest.NewRequest(http.MethodGet, "/applications/eni--hyperion--my-app/apisubscriptions/eni-distr-v1/status", http.NoBody)
 			resp, err := ExecuteRequest(req, groupPrefixToken)
 			ExpectStatus(resp, err, http.StatusForbidden, "application/problem+json")
 		})
-
 	})
 })

--- a/discovery-server/internal/controller/application.go
+++ b/discovery-server/internal/controller/application.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/telekom/controlplane/common-server/pkg/server/middleware/security"
 	"github.com/telekom/controlplane/common-server/pkg/store"
-
 	"github.com/telekom/controlplane/discovery-server/internal/api"
 	"github.com/telekom/controlplane/discovery-server/internal/mapper"
 	applicationmapper "github.com/telekom/controlplane/discovery-server/internal/mapper/application"

--- a/discovery-server/internal/controller/application_test.go
+++ b/discovery-server/internal/controller/application_test.go
@@ -10,15 +10,15 @@ import (
 
 	"github.com/gkampitakis/go-snaps/match"
 	"github.com/gkampitakis/go-snaps/snaps"
+
 	. "github.com/onsi/ginkgo/v2"
 )
 
 var _ = Describe("Application Controller", func() {
-
 	Describe("GET /applications", func() {
 		DescribeTable("should list applications with different scopes",
 			func(token string) {
-				req := httptest.NewRequest(http.MethodGet, "/applications", nil)
+				req := httptest.NewRequest(http.MethodGet, "/applications", http.NoBody)
 				resp, err := ExecuteRequest(req, token)
 				body := ExpectStatusOk(resp, err)
 				snaps.MatchJSON(GinkgoT(), body, match.Any("items.0.status"))
@@ -29,28 +29,28 @@ var _ = Describe("Application Controller", func() {
 		)
 
 		It("should return applications for a different team (empty if no data)", func() {
-			req := httptest.NewRequest(http.MethodGet, "/applications", nil)
+			req := httptest.NewRequest(http.MethodGet, "/applications", http.NoBody)
 			resp, err := ExecuteRequest(req, teamNoResToken)
 			body := ExpectStatusOk(resp, err)
 			snaps.MatchJSON(GinkgoT(), body)
 		})
 
 		It("should return applications for a different group (empty if no data)", func() {
-			req := httptest.NewRequest(http.MethodGet, "/applications", nil)
+			req := httptest.NewRequest(http.MethodGet, "/applications", http.NoBody)
 			resp, err := ExecuteRequest(req, groupOtherToken)
 			body := ExpectStatusOk(resp, err)
 			snaps.MatchJSON(GinkgoT(), body)
 		})
 
 		It("should return applications for a partial team prefix (empty if no data)", func() {
-			req := httptest.NewRequest(http.MethodGet, "/applications", nil)
+			req := httptest.NewRequest(http.MethodGet, "/applications", http.NoBody)
 			resp, err := ExecuteRequest(req, teamPrefixToken)
 			body := ExpectStatusOk(resp, err)
 			snaps.MatchJSON(GinkgoT(), body)
 		})
 
 		It("should return applications for a partial group prefix (empty if no data)", func() {
-			req := httptest.NewRequest(http.MethodGet, "/applications", nil)
+			req := httptest.NewRequest(http.MethodGet, "/applications", http.NoBody)
 			resp, err := ExecuteRequest(req, groupPrefixToken)
 			body := ExpectStatusOk(resp, err)
 			snaps.MatchJSON(GinkgoT(), body)
@@ -60,7 +60,7 @@ var _ = Describe("Application Controller", func() {
 	Describe("GET /applications/:applicationId", func() {
 		DescribeTable("should return an application with different scopes",
 			func(token string) {
-				req := httptest.NewRequest(http.MethodGet, "/applications/eni--hyperion--my-app", nil)
+				req := httptest.NewRequest(http.MethodGet, "/applications/eni--hyperion--my-app", http.NoBody)
 				resp, err := ExecuteRequest(req, token)
 				body := ExpectStatusOk(resp, err)
 				snaps.MatchJSON(GinkgoT(), body, match.Any("status"))
@@ -71,35 +71,34 @@ var _ = Describe("Application Controller", func() {
 		)
 
 		It("should return 403 for a different team", func() {
-			req := httptest.NewRequest(http.MethodGet, "/applications/eni--hyperion--my-app", nil)
+			req := httptest.NewRequest(http.MethodGet, "/applications/eni--hyperion--my-app", http.NoBody)
 			resp, err := ExecuteRequest(req, teamNoResToken)
 			ExpectStatus(resp, err, http.StatusForbidden, "application/problem+json")
 		})
 
 		It("should return 403 for a different group", func() {
-			req := httptest.NewRequest(http.MethodGet, "/applications/eni--hyperion--my-app", nil)
+			req := httptest.NewRequest(http.MethodGet, "/applications/eni--hyperion--my-app", http.NoBody)
 			resp, err := ExecuteRequest(req, groupOtherToken)
 			ExpectStatus(resp, err, http.StatusForbidden, "application/problem+json")
 		})
 
 		It("should return 403 for a partial team name prefix (hyper != hyperion)", func() {
-			req := httptest.NewRequest(http.MethodGet, "/applications/eni--hyperion--my-app", nil)
+			req := httptest.NewRequest(http.MethodGet, "/applications/eni--hyperion--my-app", http.NoBody)
 			resp, err := ExecuteRequest(req, teamPrefixToken)
 			ExpectStatus(resp, err, http.StatusForbidden, "application/problem+json")
 		})
 
 		It("should return 403 for a partial group name prefix (en != eni)", func() {
-			req := httptest.NewRequest(http.MethodGet, "/applications/eni--hyperion--my-app", nil)
+			req := httptest.NewRequest(http.MethodGet, "/applications/eni--hyperion--my-app", http.NoBody)
 			resp, err := ExecuteRequest(req, groupPrefixToken)
 			ExpectStatus(resp, err, http.StatusForbidden, "application/problem+json")
 		})
-
 	})
 
 	Describe("GET /applications/:applicationId/status", func() {
 		DescribeTable("should return application status with different scopes",
 			func(token string) {
-				req := httptest.NewRequest(http.MethodGet, "/applications/eni--hyperion--my-app/status", nil)
+				req := httptest.NewRequest(http.MethodGet, "/applications/eni--hyperion--my-app/status", http.NoBody)
 				resp, err := ExecuteRequest(req, token)
 				body := ExpectStatusOk(resp, err)
 				snaps.MatchJSON(GinkgoT(), body, match.Any("createdAt"), match.Any("processedAt"))
@@ -110,28 +109,27 @@ var _ = Describe("Application Controller", func() {
 		)
 
 		It("should return 403 for a different team", func() {
-			req := httptest.NewRequest(http.MethodGet, "/applications/eni--hyperion--my-app/status", nil)
+			req := httptest.NewRequest(http.MethodGet, "/applications/eni--hyperion--my-app/status", http.NoBody)
 			resp, err := ExecuteRequest(req, teamNoResToken)
 			ExpectStatus(resp, err, http.StatusForbidden, "application/problem+json")
 		})
 
 		It("should return 403 for a different group", func() {
-			req := httptest.NewRequest(http.MethodGet, "/applications/eni--hyperion--my-app/status", nil)
+			req := httptest.NewRequest(http.MethodGet, "/applications/eni--hyperion--my-app/status", http.NoBody)
 			resp, err := ExecuteRequest(req, groupOtherToken)
 			ExpectStatus(resp, err, http.StatusForbidden, "application/problem+json")
 		})
 
 		It("should return 403 for a partial team name prefix (hyper != hyperion)", func() {
-			req := httptest.NewRequest(http.MethodGet, "/applications/eni--hyperion--my-app/status", nil)
+			req := httptest.NewRequest(http.MethodGet, "/applications/eni--hyperion--my-app/status", http.NoBody)
 			resp, err := ExecuteRequest(req, teamPrefixToken)
 			ExpectStatus(resp, err, http.StatusForbidden, "application/problem+json")
 		})
 
 		It("should return 403 for a partial group name prefix (en != eni)", func() {
-			req := httptest.NewRequest(http.MethodGet, "/applications/eni--hyperion--my-app/status", nil)
+			req := httptest.NewRequest(http.MethodGet, "/applications/eni--hyperion--my-app/status", http.NoBody)
 			resp, err := ExecuteRequest(req, groupPrefixToken)
 			ExpectStatus(resp, err, http.StatusForbidden, "application/problem+json")
 		})
-
 	})
 })

--- a/discovery-server/internal/controller/deprecated_test.go
+++ b/discovery-server/internal/controller/deprecated_test.go
@@ -12,10 +12,9 @@ import (
 )
 
 var _ = Describe("Deprecated Endpoints", func() {
-
 	DescribeTable("should return 410 Gone for deprecated write endpoints",
 		func(method, path string) {
-			req := httptest.NewRequest(method, path, nil)
+			req := httptest.NewRequest(method, path, http.NoBody)
 			resp, err := ExecuteRequest(req, teamToken)
 			ExpectStatus(resp, err, http.StatusGone, "application/problem+json")
 		},

--- a/discovery-server/internal/controller/eventexposure.go
+++ b/discovery-server/internal/controller/eventexposure.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/telekom/controlplane/common-server/pkg/server/middleware/security"
 	"github.com/telekom/controlplane/common-server/pkg/store"
-
 	"github.com/telekom/controlplane/discovery-server/internal/api"
 	"github.com/telekom/controlplane/discovery-server/internal/mapper"
 	eventexposuremapper "github.com/telekom/controlplane/discovery-server/internal/mapper/eventexposure"
@@ -53,6 +52,7 @@ func (c *eventExposureController) Get(ctx context.Context, applicationId, eventE
 	return eventexposuremapper.MapResponse(ctx, exposure, c.stores), nil
 }
 
+//nolint:dupl // type-specific list methods share structure but differ in types and stores
 func (c *eventExposureController) GetAll(ctx context.Context, applicationId string, params api.GetAllEventExposuresParams) (*api.EventExposureListResponse, error) {
 	appInfo, err := mapper.ParseApplicationId(ctx, applicationId)
 	if err != nil {
@@ -121,8 +121,8 @@ func (c *eventExposureController) GetSubscriptions(ctx context.Context, applicat
 	if err != nil {
 		return nil, err
 	}
-	if err := mapper.VerifyApplicationLabel(exposure, appInfo.AppName); err != nil {
-		return nil, err
+	if verifyErr := mapper.VerifyApplicationLabel(exposure, appInfo.AppName); verifyErr != nil {
+		return nil, verifyErr
 	}
 
 	// Fetch all event subscriptions (cross-namespace — no prefix, no app label filter)

--- a/discovery-server/internal/controller/eventexposure_test.go
+++ b/discovery-server/internal/controller/eventexposure_test.go
@@ -10,15 +10,15 @@ import (
 
 	"github.com/gkampitakis/go-snaps/match"
 	"github.com/gkampitakis/go-snaps/snaps"
+
 	. "github.com/onsi/ginkgo/v2"
 )
 
 var _ = Describe("EventExposure Controller", func() {
-
 	Describe("GET /applications/:applicationId/eventexposures", func() {
 		DescribeTable("should list event exposures with different scopes",
 			func(token string) {
-				req := httptest.NewRequest(http.MethodGet, "/applications/eni--hyperion--my-app/eventexposures", nil)
+				req := httptest.NewRequest(http.MethodGet, "/applications/eni--hyperion--my-app/eventexposures", http.NoBody)
 				resp, err := ExecuteRequest(req, token)
 				body := ExpectStatusOk(resp, err)
 				snaps.MatchJSON(GinkgoT(), body, match.Any("items.0.status"))
@@ -29,25 +29,25 @@ var _ = Describe("EventExposure Controller", func() {
 		)
 
 		It("should return 403 for a different team", func() {
-			req := httptest.NewRequest(http.MethodGet, "/applications/eni--hyperion--my-app/eventexposures", nil)
+			req := httptest.NewRequest(http.MethodGet, "/applications/eni--hyperion--my-app/eventexposures", http.NoBody)
 			resp, err := ExecuteRequest(req, teamNoResToken)
 			ExpectStatus(resp, err, http.StatusForbidden, "application/problem+json")
 		})
 
 		It("should return 403 for a different group", func() {
-			req := httptest.NewRequest(http.MethodGet, "/applications/eni--hyperion--my-app/eventexposures", nil)
+			req := httptest.NewRequest(http.MethodGet, "/applications/eni--hyperion--my-app/eventexposures", http.NoBody)
 			resp, err := ExecuteRequest(req, groupOtherToken)
 			ExpectStatus(resp, err, http.StatusForbidden, "application/problem+json")
 		})
 
 		It("should return 403 for a partial team name prefix (hyper != hyperion)", func() {
-			req := httptest.NewRequest(http.MethodGet, "/applications/eni--hyperion--my-app/eventexposures", nil)
+			req := httptest.NewRequest(http.MethodGet, "/applications/eni--hyperion--my-app/eventexposures", http.NoBody)
 			resp, err := ExecuteRequest(req, teamPrefixToken)
 			ExpectStatus(resp, err, http.StatusForbidden, "application/problem+json")
 		})
 
 		It("should return 403 for a partial group name prefix (en != eni)", func() {
-			req := httptest.NewRequest(http.MethodGet, "/applications/eni--hyperion--my-app/eventexposures", nil)
+			req := httptest.NewRequest(http.MethodGet, "/applications/eni--hyperion--my-app/eventexposures", http.NoBody)
 			resp, err := ExecuteRequest(req, groupPrefixToken)
 			ExpectStatus(resp, err, http.StatusForbidden, "application/problem+json")
 		})
@@ -56,7 +56,7 @@ var _ = Describe("EventExposure Controller", func() {
 	Describe("GET /applications/:applicationId/eventexposures/:eventExposureName", func() {
 		DescribeTable("should return a single event exposure with different scopes",
 			func(token string) {
-				req := httptest.NewRequest(http.MethodGet, "/applications/eni--hyperion--my-app/eventexposures/de-telekom-eni-quickstart-v1", nil)
+				req := httptest.NewRequest(http.MethodGet, "/applications/eni--hyperion--my-app/eventexposures/de-telekom-eni-quickstart-v1", http.NoBody)
 				resp, err := ExecuteRequest(req, token)
 				body := ExpectStatusOk(resp, err)
 				snaps.MatchJSON(GinkgoT(), body, match.Any("status"))
@@ -67,35 +67,34 @@ var _ = Describe("EventExposure Controller", func() {
 		)
 
 		It("should return 403 for a different team", func() {
-			req := httptest.NewRequest(http.MethodGet, "/applications/eni--hyperion--my-app/eventexposures/de-telekom-eni-quickstart-v1", nil)
+			req := httptest.NewRequest(http.MethodGet, "/applications/eni--hyperion--my-app/eventexposures/de-telekom-eni-quickstart-v1", http.NoBody)
 			resp, err := ExecuteRequest(req, teamNoResToken)
 			ExpectStatus(resp, err, http.StatusForbidden, "application/problem+json")
 		})
 
 		It("should return 403 for a different group", func() {
-			req := httptest.NewRequest(http.MethodGet, "/applications/eni--hyperion--my-app/eventexposures/de-telekom-eni-quickstart-v1", nil)
+			req := httptest.NewRequest(http.MethodGet, "/applications/eni--hyperion--my-app/eventexposures/de-telekom-eni-quickstart-v1", http.NoBody)
 			resp, err := ExecuteRequest(req, groupOtherToken)
 			ExpectStatus(resp, err, http.StatusForbidden, "application/problem+json")
 		})
 
 		It("should return 403 for a partial team name prefix (hyper != hyperion)", func() {
-			req := httptest.NewRequest(http.MethodGet, "/applications/eni--hyperion--my-app/eventexposures/de-telekom-eni-quickstart-v1", nil)
+			req := httptest.NewRequest(http.MethodGet, "/applications/eni--hyperion--my-app/eventexposures/de-telekom-eni-quickstart-v1", http.NoBody)
 			resp, err := ExecuteRequest(req, teamPrefixToken)
 			ExpectStatus(resp, err, http.StatusForbidden, "application/problem+json")
 		})
 
 		It("should return 403 for a partial group name prefix (en != eni)", func() {
-			req := httptest.NewRequest(http.MethodGet, "/applications/eni--hyperion--my-app/eventexposures/de-telekom-eni-quickstart-v1", nil)
+			req := httptest.NewRequest(http.MethodGet, "/applications/eni--hyperion--my-app/eventexposures/de-telekom-eni-quickstart-v1", http.NoBody)
 			resp, err := ExecuteRequest(req, groupPrefixToken)
 			ExpectStatus(resp, err, http.StatusForbidden, "application/problem+json")
 		})
-
 	})
 
 	Describe("GET /applications/:applicationId/eventexposures/:eventExposureName/status", func() {
 		DescribeTable("should return event exposure status with different scopes",
 			func(token string) {
-				req := httptest.NewRequest(http.MethodGet, "/applications/eni--hyperion--my-app/eventexposures/de-telekom-eni-quickstart-v1/status", nil)
+				req := httptest.NewRequest(http.MethodGet, "/applications/eni--hyperion--my-app/eventexposures/de-telekom-eni-quickstart-v1/status", http.NoBody)
 				resp, err := ExecuteRequest(req, token)
 				body := ExpectStatusOk(resp, err)
 				snaps.MatchJSON(GinkgoT(), body, match.Any("createdAt"), match.Any("processedAt"))
@@ -106,35 +105,34 @@ var _ = Describe("EventExposure Controller", func() {
 		)
 
 		It("should return 403 for a different team", func() {
-			req := httptest.NewRequest(http.MethodGet, "/applications/eni--hyperion--my-app/eventexposures/de-telekom-eni-quickstart-v1/status", nil)
+			req := httptest.NewRequest(http.MethodGet, "/applications/eni--hyperion--my-app/eventexposures/de-telekom-eni-quickstart-v1/status", http.NoBody)
 			resp, err := ExecuteRequest(req, teamNoResToken)
 			ExpectStatus(resp, err, http.StatusForbidden, "application/problem+json")
 		})
 
 		It("should return 403 for a different group", func() {
-			req := httptest.NewRequest(http.MethodGet, "/applications/eni--hyperion--my-app/eventexposures/de-telekom-eni-quickstart-v1/status", nil)
+			req := httptest.NewRequest(http.MethodGet, "/applications/eni--hyperion--my-app/eventexposures/de-telekom-eni-quickstart-v1/status", http.NoBody)
 			resp, err := ExecuteRequest(req, groupOtherToken)
 			ExpectStatus(resp, err, http.StatusForbidden, "application/problem+json")
 		})
 
 		It("should return 403 for a partial team name prefix (hyper != hyperion)", func() {
-			req := httptest.NewRequest(http.MethodGet, "/applications/eni--hyperion--my-app/eventexposures/de-telekom-eni-quickstart-v1/status", nil)
+			req := httptest.NewRequest(http.MethodGet, "/applications/eni--hyperion--my-app/eventexposures/de-telekom-eni-quickstart-v1/status", http.NoBody)
 			resp, err := ExecuteRequest(req, teamPrefixToken)
 			ExpectStatus(resp, err, http.StatusForbidden, "application/problem+json")
 		})
 
 		It("should return 403 for a partial group name prefix (en != eni)", func() {
-			req := httptest.NewRequest(http.MethodGet, "/applications/eni--hyperion--my-app/eventexposures/de-telekom-eni-quickstart-v1/status", nil)
+			req := httptest.NewRequest(http.MethodGet, "/applications/eni--hyperion--my-app/eventexposures/de-telekom-eni-quickstart-v1/status", http.NoBody)
 			resp, err := ExecuteRequest(req, groupPrefixToken)
 			ExpectStatus(resp, err, http.StatusForbidden, "application/problem+json")
 		})
-
 	})
 
 	Describe("GET /applications/:applicationId/eventexposures/:eventExposureName/eventsubscriptions", func() {
 		DescribeTable("should list subscriptions for an event exposure with different scopes",
 			func(token string) {
-				req := httptest.NewRequest(http.MethodGet, "/applications/eni--hyperion--my-app/eventexposures/de-telekom-eni-quickstart-v1/eventsubscriptions", nil)
+				req := httptest.NewRequest(http.MethodGet, "/applications/eni--hyperion--my-app/eventexposures/de-telekom-eni-quickstart-v1/eventsubscriptions", http.NoBody)
 				resp, err := ExecuteRequest(req, token)
 				body := ExpectStatusOk(resp, err)
 				snaps.MatchJSON(GinkgoT(), body, match.Any("items.0.status"))
@@ -145,25 +143,25 @@ var _ = Describe("EventExposure Controller", func() {
 		)
 
 		It("should return 403 for a different team", func() {
-			req := httptest.NewRequest(http.MethodGet, "/applications/eni--hyperion--my-app/eventexposures/de-telekom-eni-quickstart-v1/eventsubscriptions", nil)
+			req := httptest.NewRequest(http.MethodGet, "/applications/eni--hyperion--my-app/eventexposures/de-telekom-eni-quickstart-v1/eventsubscriptions", http.NoBody)
 			resp, err := ExecuteRequest(req, teamNoResToken)
 			ExpectStatus(resp, err, http.StatusForbidden, "application/problem+json")
 		})
 
 		It("should return 403 for a different group", func() {
-			req := httptest.NewRequest(http.MethodGet, "/applications/eni--hyperion--my-app/eventexposures/de-telekom-eni-quickstart-v1/eventsubscriptions", nil)
+			req := httptest.NewRequest(http.MethodGet, "/applications/eni--hyperion--my-app/eventexposures/de-telekom-eni-quickstart-v1/eventsubscriptions", http.NoBody)
 			resp, err := ExecuteRequest(req, groupOtherToken)
 			ExpectStatus(resp, err, http.StatusForbidden, "application/problem+json")
 		})
 
 		It("should return 403 for a partial team name prefix (hyper != hyperion)", func() {
-			req := httptest.NewRequest(http.MethodGet, "/applications/eni--hyperion--my-app/eventexposures/de-telekom-eni-quickstart-v1/eventsubscriptions", nil)
+			req := httptest.NewRequest(http.MethodGet, "/applications/eni--hyperion--my-app/eventexposures/de-telekom-eni-quickstart-v1/eventsubscriptions", http.NoBody)
 			resp, err := ExecuteRequest(req, teamPrefixToken)
 			ExpectStatus(resp, err, http.StatusForbidden, "application/problem+json")
 		})
 
 		It("should return 403 for a partial group name prefix (en != eni)", func() {
-			req := httptest.NewRequest(http.MethodGet, "/applications/eni--hyperion--my-app/eventexposures/de-telekom-eni-quickstart-v1/eventsubscriptions", nil)
+			req := httptest.NewRequest(http.MethodGet, "/applications/eni--hyperion--my-app/eventexposures/de-telekom-eni-quickstart-v1/eventsubscriptions", http.NoBody)
 			resp, err := ExecuteRequest(req, groupPrefixToken)
 			ExpectStatus(resp, err, http.StatusForbidden, "application/problem+json")
 		})

--- a/discovery-server/internal/controller/eventsubscription.go
+++ b/discovery-server/internal/controller/eventsubscription.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/telekom/controlplane/common-server/pkg/server/middleware/security"
 	"github.com/telekom/controlplane/common-server/pkg/store"
-
 	"github.com/telekom/controlplane/discovery-server/internal/api"
 	"github.com/telekom/controlplane/discovery-server/internal/mapper"
 	eventsubscriptionmapper "github.com/telekom/controlplane/discovery-server/internal/mapper/eventsubscription"
@@ -52,6 +51,7 @@ func (c *eventSubscriptionController) Get(ctx context.Context, applicationId, ev
 	return eventsubscriptionmapper.MapResponse(ctx, sub, c.stores), nil
 }
 
+//nolint:dupl // type-specific list methods share structure but differ in types and stores
 func (c *eventSubscriptionController) GetAll(ctx context.Context, applicationId string, params api.GetAllEventSubscriptionsParams) (*api.EventSubscriptionListResponse, error) {
 	appInfo, err := mapper.ParseApplicationId(ctx, applicationId)
 	if err != nil {

--- a/discovery-server/internal/controller/eventsubscription_test.go
+++ b/discovery-server/internal/controller/eventsubscription_test.go
@@ -10,15 +10,15 @@ import (
 
 	"github.com/gkampitakis/go-snaps/match"
 	"github.com/gkampitakis/go-snaps/snaps"
+
 	. "github.com/onsi/ginkgo/v2"
 )
 
 var _ = Describe("EventSubscription Controller", func() {
-
 	Describe("GET /applications/:applicationId/eventsubscriptions", func() {
 		DescribeTable("should list event subscriptions with different scopes",
 			func(token string) {
-				req := httptest.NewRequest(http.MethodGet, "/applications/eni--hyperion--my-app/eventsubscriptions", nil)
+				req := httptest.NewRequest(http.MethodGet, "/applications/eni--hyperion--my-app/eventsubscriptions", http.NoBody)
 				resp, err := ExecuteRequest(req, token)
 				body := ExpectStatusOk(resp, err)
 				snaps.MatchJSON(GinkgoT(), body, match.Any("items.0.status"))
@@ -29,25 +29,25 @@ var _ = Describe("EventSubscription Controller", func() {
 		)
 
 		It("should return 403 for a different team", func() {
-			req := httptest.NewRequest(http.MethodGet, "/applications/eni--hyperion--my-app/eventsubscriptions", nil)
+			req := httptest.NewRequest(http.MethodGet, "/applications/eni--hyperion--my-app/eventsubscriptions", http.NoBody)
 			resp, err := ExecuteRequest(req, teamNoResToken)
 			ExpectStatus(resp, err, http.StatusForbidden, "application/problem+json")
 		})
 
 		It("should return 403 for a different group", func() {
-			req := httptest.NewRequest(http.MethodGet, "/applications/eni--hyperion--my-app/eventsubscriptions", nil)
+			req := httptest.NewRequest(http.MethodGet, "/applications/eni--hyperion--my-app/eventsubscriptions", http.NoBody)
 			resp, err := ExecuteRequest(req, groupOtherToken)
 			ExpectStatus(resp, err, http.StatusForbidden, "application/problem+json")
 		})
 
 		It("should return 403 for a partial team name prefix (hyper != hyperion)", func() {
-			req := httptest.NewRequest(http.MethodGet, "/applications/eni--hyperion--my-app/eventsubscriptions", nil)
+			req := httptest.NewRequest(http.MethodGet, "/applications/eni--hyperion--my-app/eventsubscriptions", http.NoBody)
 			resp, err := ExecuteRequest(req, teamPrefixToken)
 			ExpectStatus(resp, err, http.StatusForbidden, "application/problem+json")
 		})
 
 		It("should return 403 for a partial group name prefix (en != eni)", func() {
-			req := httptest.NewRequest(http.MethodGet, "/applications/eni--hyperion--my-app/eventsubscriptions", nil)
+			req := httptest.NewRequest(http.MethodGet, "/applications/eni--hyperion--my-app/eventsubscriptions", http.NoBody)
 			resp, err := ExecuteRequest(req, groupPrefixToken)
 			ExpectStatus(resp, err, http.StatusForbidden, "application/problem+json")
 		})
@@ -56,7 +56,7 @@ var _ = Describe("EventSubscription Controller", func() {
 	Describe("GET /applications/:applicationId/eventsubscriptions/:eventSubscriptionName", func() {
 		DescribeTable("should return a single event subscription with different scopes",
 			func(token string) {
-				req := httptest.NewRequest(http.MethodGet, "/applications/eni--hyperion--my-app/eventsubscriptions/de-telekom-eni-quickstart-v1", nil)
+				req := httptest.NewRequest(http.MethodGet, "/applications/eni--hyperion--my-app/eventsubscriptions/de-telekom-eni-quickstart-v1", http.NoBody)
 				resp, err := ExecuteRequest(req, token)
 				body := ExpectStatusOk(resp, err)
 				snaps.MatchJSON(GinkgoT(), body, match.Any("status"))
@@ -67,35 +67,34 @@ var _ = Describe("EventSubscription Controller", func() {
 		)
 
 		It("should return 403 for a different team", func() {
-			req := httptest.NewRequest(http.MethodGet, "/applications/eni--hyperion--my-app/eventsubscriptions/de-telekom-eni-quickstart-v1", nil)
+			req := httptest.NewRequest(http.MethodGet, "/applications/eni--hyperion--my-app/eventsubscriptions/de-telekom-eni-quickstart-v1", http.NoBody)
 			resp, err := ExecuteRequest(req, teamNoResToken)
 			ExpectStatus(resp, err, http.StatusForbidden, "application/problem+json")
 		})
 
 		It("should return 403 for a different group", func() {
-			req := httptest.NewRequest(http.MethodGet, "/applications/eni--hyperion--my-app/eventsubscriptions/de-telekom-eni-quickstart-v1", nil)
+			req := httptest.NewRequest(http.MethodGet, "/applications/eni--hyperion--my-app/eventsubscriptions/de-telekom-eni-quickstart-v1", http.NoBody)
 			resp, err := ExecuteRequest(req, groupOtherToken)
 			ExpectStatus(resp, err, http.StatusForbidden, "application/problem+json")
 		})
 
 		It("should return 403 for a partial team name prefix (hyper != hyperion)", func() {
-			req := httptest.NewRequest(http.MethodGet, "/applications/eni--hyperion--my-app/eventsubscriptions/de-telekom-eni-quickstart-v1", nil)
+			req := httptest.NewRequest(http.MethodGet, "/applications/eni--hyperion--my-app/eventsubscriptions/de-telekom-eni-quickstart-v1", http.NoBody)
 			resp, err := ExecuteRequest(req, teamPrefixToken)
 			ExpectStatus(resp, err, http.StatusForbidden, "application/problem+json")
 		})
 
 		It("should return 403 for a partial group name prefix (en != eni)", func() {
-			req := httptest.NewRequest(http.MethodGet, "/applications/eni--hyperion--my-app/eventsubscriptions/de-telekom-eni-quickstart-v1", nil)
+			req := httptest.NewRequest(http.MethodGet, "/applications/eni--hyperion--my-app/eventsubscriptions/de-telekom-eni-quickstart-v1", http.NoBody)
 			resp, err := ExecuteRequest(req, groupPrefixToken)
 			ExpectStatus(resp, err, http.StatusForbidden, "application/problem+json")
 		})
-
 	})
 
 	Describe("GET /applications/:applicationId/eventsubscriptions/:eventSubscriptionName/status", func() {
 		DescribeTable("should return event subscription status with different scopes",
 			func(token string) {
-				req := httptest.NewRequest(http.MethodGet, "/applications/eni--hyperion--my-app/eventsubscriptions/de-telekom-eni-quickstart-v1/status", nil)
+				req := httptest.NewRequest(http.MethodGet, "/applications/eni--hyperion--my-app/eventsubscriptions/de-telekom-eni-quickstart-v1/status", http.NoBody)
 				resp, err := ExecuteRequest(req, token)
 				body := ExpectStatusOk(resp, err)
 				snaps.MatchJSON(GinkgoT(), body, match.Any("createdAt"), match.Any("processedAt"))
@@ -106,28 +105,27 @@ var _ = Describe("EventSubscription Controller", func() {
 		)
 
 		It("should return 403 for a different team", func() {
-			req := httptest.NewRequest(http.MethodGet, "/applications/eni--hyperion--my-app/eventsubscriptions/de-telekom-eni-quickstart-v1/status", nil)
+			req := httptest.NewRequest(http.MethodGet, "/applications/eni--hyperion--my-app/eventsubscriptions/de-telekom-eni-quickstart-v1/status", http.NoBody)
 			resp, err := ExecuteRequest(req, teamNoResToken)
 			ExpectStatus(resp, err, http.StatusForbidden, "application/problem+json")
 		})
 
 		It("should return 403 for a different group", func() {
-			req := httptest.NewRequest(http.MethodGet, "/applications/eni--hyperion--my-app/eventsubscriptions/de-telekom-eni-quickstart-v1/status", nil)
+			req := httptest.NewRequest(http.MethodGet, "/applications/eni--hyperion--my-app/eventsubscriptions/de-telekom-eni-quickstart-v1/status", http.NoBody)
 			resp, err := ExecuteRequest(req, groupOtherToken)
 			ExpectStatus(resp, err, http.StatusForbidden, "application/problem+json")
 		})
 
 		It("should return 403 for a partial team name prefix (hyper != hyperion)", func() {
-			req := httptest.NewRequest(http.MethodGet, "/applications/eni--hyperion--my-app/eventsubscriptions/de-telekom-eni-quickstart-v1/status", nil)
+			req := httptest.NewRequest(http.MethodGet, "/applications/eni--hyperion--my-app/eventsubscriptions/de-telekom-eni-quickstart-v1/status", http.NoBody)
 			resp, err := ExecuteRequest(req, teamPrefixToken)
 			ExpectStatus(resp, err, http.StatusForbidden, "application/problem+json")
 		})
 
 		It("should return 403 for a partial group name prefix (en != eni)", func() {
-			req := httptest.NewRequest(http.MethodGet, "/applications/eni--hyperion--my-app/eventsubscriptions/de-telekom-eni-quickstart-v1/status", nil)
+			req := httptest.NewRequest(http.MethodGet, "/applications/eni--hyperion--my-app/eventsubscriptions/de-telekom-eni-quickstart-v1/status", http.NoBody)
 			resp, err := ExecuteRequest(req, groupPrefixToken)
 			ExpectStatus(resp, err, http.StatusForbidden, "application/problem+json")
 		})
-
 	})
 })

--- a/discovery-server/internal/controller/eventtype.go
+++ b/discovery-server/internal/controller/eventtype.go
@@ -10,7 +10,6 @@ import (
 	"github.com/telekom/controlplane/common-server/pkg/problems"
 	"github.com/telekom/controlplane/common-server/pkg/server/middleware/security"
 	"github.com/telekom/controlplane/common-server/pkg/store"
-
 	"github.com/telekom/controlplane/discovery-server/internal/api"
 	"github.com/telekom/controlplane/discovery-server/internal/mapper"
 	eventtypemapper "github.com/telekom/controlplane/discovery-server/internal/mapper/eventtype"

--- a/discovery-server/internal/controller/eventtype_test.go
+++ b/discovery-server/internal/controller/eventtype_test.go
@@ -10,21 +10,21 @@ import (
 
 	"github.com/gkampitakis/go-snaps/match"
 	"github.com/gkampitakis/go-snaps/snaps"
+
 	. "github.com/onsi/ginkgo/v2"
 )
 
 var _ = Describe("EventType Controller", func() {
-
 	Describe("GET /eventtypes", func() {
 		It("should list event types with team token", func() {
-			req := httptest.NewRequest(http.MethodGet, "/eventtypes", nil)
+			req := httptest.NewRequest(http.MethodGet, "/eventtypes", http.NoBody)
 			resp, err := ExecuteRequest(req, teamToken)
 			body := ExpectStatusOk(resp, err)
 			snaps.MatchJSON(GinkgoT(), body, match.Any("items.0.status"))
 		})
 
 		It("should list event types with admin token", func() {
-			req := httptest.NewRequest(http.MethodGet, "/eventtypes", nil)
+			req := httptest.NewRequest(http.MethodGet, "/eventtypes", http.NoBody)
 			resp, err := ExecuteRequest(req, adminToken)
 			body := ExpectStatusOk(resp, err)
 			snaps.MatchJSON(GinkgoT(), body, match.Any("items.0.status"))
@@ -33,27 +33,25 @@ var _ = Describe("EventType Controller", func() {
 
 	Describe("GET /eventtypes/:eventTypeId", func() {
 		It("should return a single event type", func() {
-			req := httptest.NewRequest(http.MethodGet, "/eventtypes/eni--hyperion--de-telekom-eni-quickstart-v1", nil)
+			req := httptest.NewRequest(http.MethodGet, "/eventtypes/eni--hyperion--de-telekom-eni-quickstart-v1", http.NoBody)
 			resp, err := ExecuteRequest(req, teamToken)
 			body := ExpectStatusOk(resp, err)
 			snaps.MatchJSON(GinkgoT(), body, match.Any("status"))
 		})
-
 	})
 
 	Describe("GET /eventtypes/:eventTypeId/status", func() {
 		It("should return event type status", func() {
-			req := httptest.NewRequest(http.MethodGet, "/eventtypes/eni--hyperion--de-telekom-eni-quickstart-v1/status", nil)
+			req := httptest.NewRequest(http.MethodGet, "/eventtypes/eni--hyperion--de-telekom-eni-quickstart-v1/status", http.NoBody)
 			resp, err := ExecuteRequest(req, teamToken)
 			body := ExpectStatusOk(resp, err)
 			snaps.MatchJSON(GinkgoT(), body, match.Any("createdAt"), match.Any("processedAt"))
 		})
-
 	})
 
 	Describe("GET /eventtypes/:eventTypeName/active", func() {
 		It("should return the active event type", func() {
-			req := httptest.NewRequest(http.MethodGet, "/eventtypes/de-telekom-eni-quickstart-v1/active", nil)
+			req := httptest.NewRequest(http.MethodGet, "/eventtypes/de-telekom-eni-quickstart-v1/active", http.NoBody)
 			resp, err := ExecuteRequest(req, teamToken)
 			body := ExpectStatusOk(resp, err)
 			snaps.MatchJSON(GinkgoT(), body, match.Any("status"))

--- a/discovery-server/internal/controller/invalid_ids_test.go
+++ b/discovery-server/internal/controller/invalid_ids_test.go
@@ -25,7 +25,7 @@ var _ = Describe("Controller Invalid IDs", func() {
 
 	DescribeTable("should return 404 when app name does not match resource label",
 		func(path string) {
-			req := httptest.NewRequest(http.MethodGet, path, nil)
+			req := httptest.NewRequest(http.MethodGet, path, http.NoBody)
 			resp, err := ExecuteRequest(req, teamToken)
 			ExpectStatus(resp, err, http.StatusNotFound, "application/problem+json")
 		},
@@ -43,7 +43,7 @@ var _ = Describe("Controller Invalid IDs", func() {
 
 	DescribeTable("should return 400 for malformed event type ID",
 		func(path string) {
-			req := httptest.NewRequest(http.MethodGet, path, nil)
+			req := httptest.NewRequest(http.MethodGet, path, http.NoBody)
 			resp, err := ExecuteRequest(req, teamToken)
 			ExpectStatus(resp, err, http.StatusBadRequest, "application/problem+json")
 		},

--- a/discovery-server/internal/controller/suite_controller_test.go
+++ b/discovery-server/internal/controller/suite_controller_test.go
@@ -11,8 +11,6 @@ import (
 	"testing"
 
 	"github.com/gofiber/fiber/v2"
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
 	"github.com/stretchr/testify/mock"
 
 	apiv1 "github.com/telekom/controlplane/api/api/v1"
@@ -21,12 +19,14 @@ import (
 	csstore "github.com/telekom/controlplane/common-server/pkg/store"
 	"github.com/telekom/controlplane/common-server/pkg/store/secrets"
 	csmocks "github.com/telekom/controlplane/common-server/test/mocks"
-
 	"github.com/telekom/controlplane/discovery-server/internal/config"
 	"github.com/telekom/controlplane/discovery-server/internal/server"
 	"github.com/telekom/controlplane/discovery-server/pkg/log"
 	sstore "github.com/telekom/controlplane/discovery-server/pkg/store"
 	"github.com/telekom/controlplane/discovery-server/test/mocks"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 )
 
 var (
@@ -78,7 +78,7 @@ var _ = BeforeSuite(func() {
 		mock.AnythingOfType("*context.valueCtx"),
 		mock.AnythingOfType("string"),
 		mock.Anything,
-	).RunAndReturn(func(_ context.Context, _ string, _ string) (*apiv1.ApiExposure, error) {
+	).RunAndReturn(func(_ context.Context, _, _ string) (*apiv1.ApiExposure, error) {
 		return apiExposure.DeepCopy(), nil
 	}).Maybe()
 	exposureSecretMock.EXPECT().List(
@@ -94,7 +94,7 @@ var _ = BeforeSuite(func() {
 		mock.AnythingOfType("*context.valueCtx"),
 		mock.AnythingOfType("string"),
 		mock.Anything,
-	).RunAndReturn(func(_ context.Context, _ string, _ string) (*apiv1.ApiSubscription, error) {
+	).RunAndReturn(func(_ context.Context, _, _ string) (*apiv1.ApiSubscription, error) {
 		return apiSubscription.DeepCopy(), nil
 	}).Maybe()
 	subscriptionSecretMock.EXPECT().List(
@@ -160,7 +160,7 @@ func ExpectStatus(response *http.Response, err error, statusCode int, contentTyp
 }
 
 func expectNoError(err error) {
-	Expect(err).To(BeNil())
+	Expect(err).ToNot(HaveOccurred())
 	Expect(err).ToNot(HaveOccurred())
 }
 

--- a/discovery-server/internal/controller/suite_controller_test.go
+++ b/discovery-server/internal/controller/suite_controller_test.go
@@ -161,7 +161,6 @@ func ExpectStatus(response *http.Response, err error, statusCode int, contentTyp
 
 func expectNoError(err error) {
 	Expect(err).ToNot(HaveOccurred())
-	Expect(err).ToNot(HaveOccurred())
 }
 
 func expectResponseWithStatus(response *http.Response, statusCode int, contentType string) {

--- a/discovery-server/internal/mapper/apiexposure/out.go
+++ b/discovery-server/internal/mapper/apiexposure/out.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 
 	apiv1 "github.com/telekom/controlplane/api/api/v1"
-
 	"github.com/telekom/controlplane/discovery-server/internal/api"
 	"github.com/telekom/controlplane/discovery-server/internal/mapper"
 	"github.com/telekom/controlplane/discovery-server/internal/mapper/status"
@@ -75,7 +74,7 @@ func mapSecurity(in *apiv1.ApiExposure, out *api.ApiExposureResponse) {
 			Password: m2m.Basic.Password,
 		}
 		out.Security = api.SubscriberSecurity{}
-		_ = out.Security.FromBasicAuth(basicAuth)
+		out.Security.FromBasicAuth(basicAuth) //nolint:errcheck,gosec // union setter only fails on JSON marshal of simple struct
 		return
 	}
 
@@ -101,7 +100,7 @@ func mapSecurity(in *apiv1.ApiExposure, out *api.ApiExposureResponse) {
 		}
 
 		out.Security = api.SubscriberSecurity{}
-		_ = out.Security.FromOAuth2(oauth2)
+		out.Security.FromOAuth2(oauth2) //nolint:errcheck,gosec // union setter only fails on JSON marshal of simple struct
 		return
 	}
 
@@ -111,7 +110,7 @@ func mapSecurity(in *apiv1.ApiExposure, out *api.ApiExposureResponse) {
 			Scopes: m2m.Scopes,
 		}
 		out.Security = api.SubscriberSecurity{}
-		_ = out.Security.FromOAuth2(oauth2)
+		out.Security.FromOAuth2(oauth2) //nolint:errcheck,gosec // union setter only fails on JSON marshal of simple struct
 	}
 }
 
@@ -136,9 +135,9 @@ func mapTraffic(in *apiv1.ApiExposure, out *api.ApiExposureResponse) {
 	if in.Spec.Traffic.RateLimit != nil && in.Spec.Traffic.RateLimit.Provider != nil {
 		limits := in.Spec.Traffic.RateLimit.Provider.Limits
 		out.RateLimit = api.RateLimit{
-			Second:            int32(limits.Second),
-			Minute:            int32(limits.Minute),
-			Hour:              int32(limits.Hour),
+			Second:            int32(limits.Second), //nolint:gosec // G115: rate limit values are validated by kubebuilder (>=0, practically small)
+			Minute:            int32(limits.Minute), //nolint:gosec // G115: rate limit values are validated by kubebuilder (>=0, practically small)
+			Hour:              int32(limits.Hour),   //nolint:gosec // G115: rate limit values are validated by kubebuilder (>=0, practically small)
 			FaultTolerant:     in.Spec.Traffic.RateLimit.Provider.Options.FaultTolerant,
 			HideClientHeaders: in.Spec.Traffic.RateLimit.Provider.Options.HideClientHeaders,
 		}

--- a/discovery-server/internal/mapper/apisubscription/out.go
+++ b/discovery-server/internal/mapper/apisubscription/out.go
@@ -9,12 +9,12 @@ import (
 	"strings"
 
 	openapi_types "github.com/oapi-codegen/runtime/types"
+
 	adminv1 "github.com/telekom/controlplane/admin/api/v1"
 	apiv1 "github.com/telekom/controlplane/api/api/v1"
 	applicationv1 "github.com/telekom/controlplane/application/api/v1"
 	approvalv1 "github.com/telekom/controlplane/approval/api/v1"
 	"github.com/telekom/controlplane/common-server/pkg/store"
-
 	"github.com/telekom/controlplane/discovery-server/internal/api"
 	"github.com/telekom/controlplane/discovery-server/internal/mapper"
 	"github.com/telekom/controlplane/discovery-server/internal/mapper/status"
@@ -53,7 +53,7 @@ func mapSecurity(in *apiv1.ApiSubscription, out *api.ApiSubscriptionResponse) {
 			Password: m2m.Basic.Password,
 		}
 		out.Security = api.SubscriberSecurity{}
-		_ = out.Security.FromBasicAuth(basicAuth)
+		out.Security.FromBasicAuth(basicAuth) //nolint:errcheck,gosec // union setter only fails on JSON marshal of simple struct
 		return
 	}
 
@@ -68,7 +68,7 @@ func mapSecurity(in *apiv1.ApiSubscription, out *api.ApiSubscriptionResponse) {
 		}
 
 		out.Security = api.SubscriberSecurity{}
-		_ = out.Security.FromOAuth2(oauth2)
+		out.Security.FromOAuth2(oauth2) //nolint:errcheck,gosec // union setter only fails on JSON marshal of simple struct
 		return
 	}
 
@@ -78,7 +78,7 @@ func mapSecurity(in *apiv1.ApiSubscription, out *api.ApiSubscriptionResponse) {
 			Scopes: m2m.Scopes,
 		}
 		out.Security = api.SubscriberSecurity{}
-		_ = out.Security.FromOAuth2(oauth2)
+		out.Security.FromOAuth2(oauth2) //nolint:errcheck,gosec // union setter only fails on JSON marshal of simple struct
 	}
 }
 

--- a/discovery-server/internal/mapper/apisubscription/out_test.go
+++ b/discovery-server/internal/mapper/apisubscription/out_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/mock"
+
 	adminv1 "github.com/telekom/controlplane/admin/api/v1"
 	apiv1 "github.com/telekom/controlplane/api/api/v1"
 	applicationv1 "github.com/telekom/controlplane/application/api/v1"

--- a/discovery-server/internal/mapper/application/out.go
+++ b/discovery-server/internal/mapper/application/out.go
@@ -8,7 +8,6 @@ import (
 	openapi_types "github.com/oapi-codegen/runtime/types"
 
 	applicationv1 "github.com/telekom/controlplane/application/api/v1"
-
 	"github.com/telekom/controlplane/discovery-server/internal/api"
 	"github.com/telekom/controlplane/discovery-server/internal/mapper"
 	"github.com/telekom/controlplane/discovery-server/internal/mapper/status"

--- a/discovery-server/internal/mapper/application/out_test.go
+++ b/discovery-server/internal/mapper/application/out_test.go
@@ -7,10 +7,11 @@ package application
 import (
 	"testing"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	applicationv1 "github.com/telekom/controlplane/application/api/v1"
 	commonTypes "github.com/telekom/controlplane/common/pkg/types"
 	"github.com/telekom/controlplane/discovery-server/internal/api"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestMapResponse(t *testing.T) {

--- a/discovery-server/internal/mapper/eventexposure/out.go
+++ b/discovery-server/internal/mapper/eventexposure/out.go
@@ -10,14 +10,14 @@ import (
 	"strings"
 
 	openapi_types "github.com/oapi-codegen/runtime/types"
+
 	applicationv1 "github.com/telekom/controlplane/application/api/v1"
 	"github.com/telekom/controlplane/common-server/pkg/store"
-	eventv1 "github.com/telekom/controlplane/event/api/v1"
-
 	"github.com/telekom/controlplane/discovery-server/internal/api"
 	"github.com/telekom/controlplane/discovery-server/internal/mapper"
 	"github.com/telekom/controlplane/discovery-server/internal/mapper/status"
 	sstore "github.com/telekom/controlplane/discovery-server/pkg/store"
+	eventv1 "github.com/telekom/controlplane/event/api/v1"
 )
 
 // MapResponse maps an EventExposure CRD to an EventExposureResponse,

--- a/discovery-server/internal/mapper/eventexposure/out_test.go
+++ b/discovery-server/internal/mapper/eventexposure/out_test.go
@@ -9,13 +9,14 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/mock"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+
 	applicationv1 "github.com/telekom/controlplane/application/api/v1"
 	csmocks "github.com/telekom/controlplane/common-server/test/mocks"
 	ctypes "github.com/telekom/controlplane/common/pkg/types"
 	"github.com/telekom/controlplane/discovery-server/internal/api"
 	sstore "github.com/telekom/controlplane/discovery-server/pkg/store"
 	eventv1 "github.com/telekom/controlplane/event/api/v1"
-	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 )
 
 func TestMapResponse_ResolvedApplication(t *testing.T) {

--- a/discovery-server/internal/mapper/eventsubscription/out.go
+++ b/discovery-server/internal/mapper/eventsubscription/out.go
@@ -9,15 +9,15 @@ import (
 	"encoding/json"
 
 	openapi_types "github.com/oapi-codegen/runtime/types"
+
 	applicationv1 "github.com/telekom/controlplane/application/api/v1"
 	approvalv1 "github.com/telekom/controlplane/approval/api/v1"
 	"github.com/telekom/controlplane/common-server/pkg/store"
-	eventv1 "github.com/telekom/controlplane/event/api/v1"
-
 	"github.com/telekom/controlplane/discovery-server/internal/api"
 	"github.com/telekom/controlplane/discovery-server/internal/mapper"
 	"github.com/telekom/controlplane/discovery-server/internal/mapper/status"
 	sstore "github.com/telekom/controlplane/discovery-server/pkg/store"
+	eventv1 "github.com/telekom/controlplane/event/api/v1"
 )
 
 // MapResponse maps an EventSubscription CRD to an EventSubscriptionResponse,

--- a/discovery-server/internal/mapper/eventsubscription/out_test.go
+++ b/discovery-server/internal/mapper/eventsubscription/out_test.go
@@ -9,13 +9,14 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/mock"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+
 	applicationv1 "github.com/telekom/controlplane/application/api/v1"
 	approvalv1 "github.com/telekom/controlplane/approval/api/v1"
 	csmocks "github.com/telekom/controlplane/common-server/test/mocks"
 	ctypes "github.com/telekom/controlplane/common/pkg/types"
 	sstore "github.com/telekom/controlplane/discovery-server/pkg/store"
 	eventv1 "github.com/telekom/controlplane/event/api/v1"
-	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 )
 
 func TestMapResponse_ResolvedReferences(t *testing.T) {

--- a/discovery-server/internal/mapper/eventtype/out.go
+++ b/discovery-server/internal/mapper/eventtype/out.go
@@ -5,11 +5,10 @@
 package eventtype
 
 import (
-	eventv1 "github.com/telekom/controlplane/event/api/v1"
-
 	"github.com/telekom/controlplane/discovery-server/internal/api"
 	"github.com/telekom/controlplane/discovery-server/internal/mapper"
 	"github.com/telekom/controlplane/discovery-server/internal/mapper/status"
+	eventv1 "github.com/telekom/controlplane/event/api/v1"
 )
 
 const (

--- a/discovery-server/internal/mapper/status/response.go
+++ b/discovery-server/internal/mapper/status/response.go
@@ -7,10 +7,10 @@ package status
 import (
 	"time"
 
-	"github.com/telekom/controlplane/common/pkg/condition"
-	ctypes "github.com/telekom/controlplane/common/pkg/types"
 	"k8s.io/apimachinery/pkg/api/meta"
 
+	"github.com/telekom/controlplane/common/pkg/condition"
+	ctypes "github.com/telekom/controlplane/common/pkg/types"
 	"github.com/telekom/controlplane/discovery-server/internal/api"
 )
 

--- a/discovery-server/internal/mapper/status/response_test.go
+++ b/discovery-server/internal/mapper/status/response_test.go
@@ -8,9 +8,10 @@ import (
 	"testing"
 	"time"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	applicationv1 "github.com/telekom/controlplane/application/api/v1"
 	"github.com/telekom/controlplane/common/pkg/condition"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestMapResponse(t *testing.T) {

--- a/discovery-server/internal/mapper/status/status.go
+++ b/discovery-server/internal/mapper/status/status.go
@@ -5,10 +5,10 @@
 package status
 
 import (
-	"github.com/telekom/controlplane/common/pkg/condition"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/telekom/controlplane/common/pkg/condition"
 	"github.com/telekom/controlplane/discovery-server/internal/api"
 )
 

--- a/discovery-server/internal/mapper/status/status_test.go
+++ b/discovery-server/internal/mapper/status/status_test.go
@@ -8,9 +8,10 @@ import (
 	"testing"
 	"time"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"github.com/telekom/controlplane/common/pkg/condition"
 	"github.com/telekom/controlplane/discovery-server/internal/api"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func cond(t, status, reason, msg string) metav1.Condition {

--- a/discovery-server/internal/mapper/util.go
+++ b/discovery-server/internal/mapper/util.go
@@ -10,9 +10,10 @@ import (
 	"regexp"
 	"strings"
 
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
 	"github.com/telekom/controlplane/common-server/pkg/problems"
 	"github.com/telekom/controlplane/common-server/pkg/server/middleware/security"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const (
@@ -146,7 +147,7 @@ func VerifyApplicationLabel(obj client.Object, expectedAppName string) error {
 	return nil
 }
 
-func SplitTeamName(teamName string) (group string, team string) {
+func SplitTeamName(teamName string) (group, team string) {
 	parts := strings.Split(teamName, "--")
 	if len(parts) != 2 {
 		return "", teamName

--- a/discovery-server/internal/mapper/util_test.go
+++ b/discovery-server/internal/mapper/util_test.go
@@ -8,9 +8,10 @@ import (
 	"context"
 	"testing"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	applicationv1 "github.com/telekom/controlplane/application/api/v1"
 	"github.com/telekom/controlplane/common-server/pkg/server/middleware/security"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 type parseIDResult struct {

--- a/discovery-server/internal/pagination/pagination.go
+++ b/discovery-server/internal/pagination/pagination.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 
 	"github.com/telekom/controlplane/common-server/pkg/store"
-
 	"github.com/telekom/controlplane/discovery-server/internal/api"
 )
 
@@ -31,7 +30,7 @@ type PaginatedResult[T any] struct {
 // FetchAll retrieves every item from an ObjectStore by following cursor-based
 // pagination to completion. The caller provides the initial ListOpts (with
 // Prefix / Filters already set); this function overrides Limit and Cursor.
-func FetchAll[T store.Object](ctx context.Context, s store.ObjectStore[T], opts store.ListOpts) ([]T, error) {
+func FetchAll[T store.Object](ctx context.Context, s store.ObjectStore[T], opts store.ListOpts) ([]T, error) { //nolint:gocritic // hugeParam: opts is intentionally copied since we mutate Limit/Cursor
 	opts.Limit = fetchBatchSize
 	opts.Cursor = ""
 

--- a/discovery-server/internal/server/apiexposure_server.go
+++ b/discovery-server/internal/server/apiexposure_server.go
@@ -8,9 +8,9 @@ import (
 	"strconv"
 
 	"github.com/gofiber/fiber/v2"
+
 	"github.com/telekom/controlplane/common-server/pkg/problems"
 	cserver "github.com/telekom/controlplane/common-server/pkg/server"
-
 	"github.com/telekom/controlplane/discovery-server/internal/api"
 )
 

--- a/discovery-server/internal/server/apisubscription_server.go
+++ b/discovery-server/internal/server/apisubscription_server.go
@@ -8,9 +8,9 @@ import (
 	"strconv"
 
 	"github.com/gofiber/fiber/v2"
+
 	"github.com/telekom/controlplane/common-server/pkg/problems"
 	cserver "github.com/telekom/controlplane/common-server/pkg/server"
-
 	"github.com/telekom/controlplane/discovery-server/internal/api"
 )
 

--- a/discovery-server/internal/server/application_server.go
+++ b/discovery-server/internal/server/application_server.go
@@ -8,9 +8,9 @@ import (
 	"strconv"
 
 	"github.com/gofiber/fiber/v2"
+
 	"github.com/telekom/controlplane/common-server/pkg/problems"
 	cserver "github.com/telekom/controlplane/common-server/pkg/server"
-
 	"github.com/telekom/controlplane/discovery-server/internal/api"
 )
 

--- a/discovery-server/internal/server/deprecated.go
+++ b/discovery-server/internal/server/deprecated.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 
 	"github.com/gofiber/fiber/v2"
+
 	"github.com/telekom/controlplane/common-server/pkg/problems"
 	cserver "github.com/telekom/controlplane/common-server/pkg/server"
 )

--- a/discovery-server/internal/server/eventexposure_server.go
+++ b/discovery-server/internal/server/eventexposure_server.go
@@ -8,9 +8,9 @@ import (
 	"strconv"
 
 	"github.com/gofiber/fiber/v2"
+
 	"github.com/telekom/controlplane/common-server/pkg/problems"
 	cserver "github.com/telekom/controlplane/common-server/pkg/server"
-
 	"github.com/telekom/controlplane/discovery-server/internal/api"
 )
 

--- a/discovery-server/internal/server/eventsubscription_server.go
+++ b/discovery-server/internal/server/eventsubscription_server.go
@@ -8,9 +8,9 @@ import (
 	"strconv"
 
 	"github.com/gofiber/fiber/v2"
+
 	"github.com/telekom/controlplane/common-server/pkg/problems"
 	cserver "github.com/telekom/controlplane/common-server/pkg/server"
-
 	"github.com/telekom/controlplane/discovery-server/internal/api"
 )
 

--- a/discovery-server/internal/server/eventtype_server.go
+++ b/discovery-server/internal/server/eventtype_server.go
@@ -8,9 +8,9 @@ import (
 	"strconv"
 
 	"github.com/gofiber/fiber/v2"
+
 	"github.com/telekom/controlplane/common-server/pkg/problems"
 	cserver "github.com/telekom/controlplane/common-server/pkg/server"
-
 	"github.com/telekom/controlplane/discovery-server/internal/api"
 )
 

--- a/discovery-server/internal/server/server.go
+++ b/discovery-server/internal/server/server.go
@@ -8,13 +8,12 @@ import (
 	"context"
 
 	"github.com/getkin/kin-openapi/openapi3filter"
+	"github.com/go-logr/logr"
+	"github.com/gofiber/fiber/v2"
 	requestValidator "github.com/oapi-codegen/fiber-middleware"
 	"github.com/pkg/errors"
 
-	"github.com/go-logr/logr"
-	"github.com/gofiber/fiber/v2"
 	"github.com/telekom/controlplane/common-server/pkg/server/middleware/security"
-
 	"github.com/telekom/controlplane/discovery-server/internal/api"
 	"github.com/telekom/controlplane/discovery-server/internal/config"
 )

--- a/discovery-server/pkg/store/stores.go
+++ b/discovery-server/pkg/store/stores.go
@@ -8,6 +8,10 @@ import (
 	"context"
 
 	"github.com/spf13/viper"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/rest"
+
 	adminv1 "github.com/telekom/controlplane/admin/api/v1"
 	apiv1 "github.com/telekom/controlplane/api/api/v1"
 	applicationv1 "github.com/telekom/controlplane/application/api/v1"
@@ -17,9 +21,6 @@ import (
 	"github.com/telekom/controlplane/common-server/pkg/store/secrets"
 	eventv1 "github.com/telekom/controlplane/event/api/v1"
 	secretsapi "github.com/telekom/controlplane/secret-manager/api"
-	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/client-go/dynamic"
-	"k8s.io/client-go/rest"
 )
 
 // Stores is the dependency container holding all ObjectStore instances

--- a/discovery-server/pkg/store/stores_secret_test.go
+++ b/discovery-server/pkg/store/stores_secret_test.go
@@ -8,24 +8,25 @@ import (
 	"context"
 
 	"github.com/stretchr/testify/mock"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	apiv1 "github.com/telekom/controlplane/api/api/v1"
 	csstore "github.com/telekom/controlplane/common-server/pkg/store"
 	"github.com/telekom/controlplane/common-server/pkg/store/secrets"
 	csmocks "github.com/telekom/controlplane/common-server/test/mocks"
 	"github.com/telekom/controlplane/secret-manager/api/fake"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
 
-const secretPlaceholder = "$<test-secret-id>"
-const resolvedSecret = "super-secret-value"
+const (
+	secretPlaceholder = "$<test-secret-id>"
+	resolvedSecret    = "super-secret-value"
+)
 
 var _ = Describe("Secret Store Integration", func() {
-
 	Describe("ApiSubscription secrets", func() {
-
 		var (
 			ctx          context.Context
 			mockStore    *csmocks.MockObjectStore[*apiv1.ApiSubscription]
@@ -94,7 +95,6 @@ var _ = Describe("Secret Store Integration", func() {
 				Expect(result.Spec.Security.M2M.Basic.Password).To(Equal(resolvedSecret))
 				Expect(result.Spec.Security.M2M.Client.ClientSecret).To(Equal("plain-secret"))
 			})
-
 		})
 
 		Context("List", func() {
@@ -117,7 +117,6 @@ var _ = Describe("Secret Store Integration", func() {
 	})
 
 	Describe("ApiExposure secrets", func() {
-
 		var (
 			ctx          context.Context
 			mockStore    *csmocks.MockObjectStore[*apiv1.ApiExposure]

--- a/discovery-server/test/mocks/data/testdata.go
+++ b/discovery-server/test/mocks/data/testdata.go
@@ -22,7 +22,7 @@ func ReadFile(testing ginkgo.FullGinkgoTInterface, filePath string) []byte {
 	testDataDir, err := filepath.Abs(getCurrentFileDir())
 	require.NoError(testing, err)
 	testDataFile := filepath.Join(testDataDir, filePath)
-	file, err := os.ReadFile(testDataFile)
+	file, err := os.ReadFile(testDataFile) //nolint:gosec // G304: path is constructed from runtime.Caller dir + test fixture name
 	require.NoError(testing, err)
 	return file
 }

--- a/discovery-server/test/mocks/mocks.go
+++ b/discovery-server/test/mocks/mocks.go
@@ -9,13 +9,13 @@ import (
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/stretchr/testify/require"
+
 	adminv1 "github.com/telekom/controlplane/admin/api/v1"
 	apiv1 "github.com/telekom/controlplane/api/api/v1"
 	applicationv1 "github.com/telekom/controlplane/application/api/v1"
 	approvalv1 "github.com/telekom/controlplane/approval/api/v1"
-	eventv1 "github.com/telekom/controlplane/event/api/v1"
-
 	"github.com/telekom/controlplane/discovery-server/test/mocks/data"
+	eventv1 "github.com/telekom/controlplane/event/api/v1"
 )
 
 const (

--- a/discovery-server/test/mocks/mocks_ApiExposure.go
+++ b/discovery-server/test/mocks/mocks_ApiExposure.go
@@ -7,6 +7,7 @@ package mocks
 import (
 	"github.com/onsi/ginkgo/v2"
 	"github.com/stretchr/testify/mock"
+
 	apiv1 "github.com/telekom/controlplane/api/api/v1"
 	"github.com/telekom/controlplane/common-server/pkg/store"
 	csmocks "github.com/telekom/controlplane/common-server/test/mocks"
@@ -32,5 +33,6 @@ func ConfigureAPIExposureStoreMock(testing ginkgo.FullGinkgoTInterface, mockedSt
 		mock.Anything,
 	).Return(
 		&store.ListResponse[*apiv1.ApiExposure]{
-			Items: []*apiv1.ApiExposure{apiExposure}}, nil).Maybe()
+			Items: []*apiv1.ApiExposure{apiExposure},
+		}, nil).Maybe()
 }

--- a/discovery-server/test/mocks/mocks_ApiSubscription.go
+++ b/discovery-server/test/mocks/mocks_ApiSubscription.go
@@ -7,6 +7,7 @@ package mocks
 import (
 	"github.com/onsi/ginkgo/v2"
 	"github.com/stretchr/testify/mock"
+
 	apiv1 "github.com/telekom/controlplane/api/api/v1"
 	"github.com/telekom/controlplane/common-server/pkg/store"
 	csmocks "github.com/telekom/controlplane/common-server/test/mocks"
@@ -32,5 +33,6 @@ func ConfigureAPISubscriptionStoreMock(testing ginkgo.FullGinkgoTInterface, mock
 		mock.Anything,
 	).Return(
 		&store.ListResponse[*apiv1.ApiSubscription]{
-			Items: []*apiv1.ApiSubscription{apiSubscription}}, nil).Maybe()
+			Items: []*apiv1.ApiSubscription{apiSubscription},
+		}, nil).Maybe()
 }

--- a/discovery-server/test/mocks/mocks_Application.go
+++ b/discovery-server/test/mocks/mocks_Application.go
@@ -7,6 +7,7 @@ package mocks
 import (
 	"github.com/onsi/ginkgo/v2"
 	"github.com/stretchr/testify/mock"
+
 	applicationv1 "github.com/telekom/controlplane/application/api/v1"
 	"github.com/telekom/controlplane/common-server/pkg/store"
 	csmocks "github.com/telekom/controlplane/common-server/test/mocks"
@@ -32,5 +33,6 @@ func ConfigureApplicationStoreMock(testing ginkgo.FullGinkgoTInterface, mockedSt
 		mock.Anything,
 	).Return(
 		&store.ListResponse[*applicationv1.Application]{
-			Items: []*applicationv1.Application{application}}, nil).Maybe()
+			Items: []*applicationv1.Application{application},
+		}, nil).Maybe()
 }

--- a/discovery-server/test/mocks/mocks_Approval.go
+++ b/discovery-server/test/mocks/mocks_Approval.go
@@ -7,6 +7,7 @@ package mocks
 import (
 	"github.com/onsi/ginkgo/v2"
 	"github.com/stretchr/testify/mock"
+
 	approvalv1 "github.com/telekom/controlplane/approval/api/v1"
 	"github.com/telekom/controlplane/common-server/pkg/store"
 	csmocks "github.com/telekom/controlplane/common-server/test/mocks"

--- a/discovery-server/test/mocks/mocks_EventExposure.go
+++ b/discovery-server/test/mocks/mocks_EventExposure.go
@@ -7,6 +7,7 @@ package mocks
 import (
 	"github.com/onsi/ginkgo/v2"
 	"github.com/stretchr/testify/mock"
+
 	"github.com/telekom/controlplane/common-server/pkg/store"
 	csmocks "github.com/telekom/controlplane/common-server/test/mocks"
 	eventv1 "github.com/telekom/controlplane/event/api/v1"
@@ -32,5 +33,6 @@ func ConfigureEventExposureStoreMock(testing ginkgo.FullGinkgoTInterface, mocked
 		mock.Anything,
 	).Return(
 		&store.ListResponse[*eventv1.EventExposure]{
-			Items: []*eventv1.EventExposure{eventExposure}}, nil).Maybe()
+			Items: []*eventv1.EventExposure{eventExposure},
+		}, nil).Maybe()
 }

--- a/discovery-server/test/mocks/mocks_EventSubscription.go
+++ b/discovery-server/test/mocks/mocks_EventSubscription.go
@@ -7,6 +7,7 @@ package mocks
 import (
 	"github.com/onsi/ginkgo/v2"
 	"github.com/stretchr/testify/mock"
+
 	"github.com/telekom/controlplane/common-server/pkg/store"
 	csmocks "github.com/telekom/controlplane/common-server/test/mocks"
 	eventv1 "github.com/telekom/controlplane/event/api/v1"
@@ -32,5 +33,6 @@ func ConfigureEventSubscriptionStoreMock(testing ginkgo.FullGinkgoTInterface, mo
 		mock.Anything,
 	).Return(
 		&store.ListResponse[*eventv1.EventSubscription]{
-			Items: []*eventv1.EventSubscription{eventSubscription}}, nil).Maybe()
+			Items: []*eventv1.EventSubscription{eventSubscription},
+		}, nil).Maybe()
 }

--- a/discovery-server/test/mocks/mocks_EventType.go
+++ b/discovery-server/test/mocks/mocks_EventType.go
@@ -7,6 +7,7 @@ package mocks
 import (
 	"github.com/onsi/ginkgo/v2"
 	"github.com/stretchr/testify/mock"
+
 	"github.com/telekom/controlplane/common-server/pkg/store"
 	csmocks "github.com/telekom/controlplane/common-server/test/mocks"
 	eventv1 "github.com/telekom/controlplane/event/api/v1"
@@ -32,5 +33,6 @@ func ConfigureEventTypeStoreMock(testing ginkgo.FullGinkgoTInterface, mockedStor
 		mock.Anything,
 	).Return(
 		&store.ListResponse[*eventv1.EventType]{
-			Items: []*eventv1.EventType{eventType}}, nil).Maybe()
+			Items: []*eventv1.EventType{eventType},
+		}, nil).Maybe()
 }

--- a/discovery-server/test/mocks/mocks_Zone.go
+++ b/discovery-server/test/mocks/mocks_Zone.go
@@ -7,6 +7,7 @@ package mocks
 import (
 	"github.com/onsi/ginkgo/v2"
 	"github.com/stretchr/testify/mock"
+
 	adminv1 "github.com/telekom/controlplane/admin/api/v1"
 	"github.com/telekom/controlplane/common-server/pkg/store"
 	csmocks "github.com/telekom/controlplane/common-server/test/mocks"


### PR DESCRIPTION
 ## Update Makefile
 Update tool versions and golangci-lint target in Makefile.

 ## Autofixes for `discovery-server/`
 Use make lint-fix to autofix issues

  ## Manual lint fixes for `discovery-server/`
Apply lint-driven refactors across discovery-server (import grouping, minor test cleanup, added nolint annotations).