### PR TITLE
fix(application,identity): handle secret rotation for non-graceful identity clients

### DIFF
--- a/application/internal/handler/application/handler.go
+++ b/application/internal/handler/application/handler.go
@@ -84,7 +84,7 @@ func (h *ApplicationHandler) CreateOrUpdate(ctx context.Context, app *applicatio
 	}
 
 	if rotationInProgress {
-		completeRotation(ctx, app)
+		completeRotation(ctx, app, primaryClient)
 	} else if app.Spec.NeedsClient && app.Status.CurrentExpiresAt != nil {
 		handleSecretExpiringNotifications(ctx, app, zone)
 	}
@@ -176,12 +176,18 @@ func (h *ApplicationHandler) initiateRotationIfNeeded(app *application.Applicati
 	return rotationInProgress
 }
 
-func completeRotation(ctx context.Context, app *application.Application) {
+func completeRotation(ctx context.Context, app *application.Application, primaryClient *identity.Client) {
 	log := logr.FromContextOrDiscard(ctx)
 
-	// Expiry timestamps are already propagated by CreateIdentityClient.
-	// Check that they are available (identity controller has reconciled).
-	if app.Status.RotatedExpiresAt == nil {
+	// If the identity client has graceful rotation disabled, the old secret
+	// was replaced immediately — no expiry timestamps will ever arrive.
+	// Complete the rotation without waiting.
+	if primaryClient != nil && !primaryClient.SupportsSecretRotation() {
+		log.Info("Secret rotation: graceful rotation disabled on identity client, completing immediately",
+			"application", app.Name,
+		)
+		app.Status.RotatedExpiresAt = nil
+	} else if app.Status.RotatedExpiresAt == nil {
 		log.Info("Secret rotation: expiry timestamps not yet available from identity client, staying InProgress",
 			"application", app.Name,
 		)
@@ -329,8 +335,14 @@ func CreateIdentityClient(ctx context.Context, zone *admin.Zone, owner *applicat
 	// and the status fields would be stale.
 	if result == controllerutil.OperationResultNone && !options.Failover {
 		owner.Status.CurrentExpiresAt = idpClient.Status.SecretExpiresAt
+		owner.Status.RotatedExpiresAt = idpClient.Status.RotatedSecretExpiresAt
+
 		if owner.Spec.RotatedSecret != "" {
-			owner.Status.RotatedExpiresAt = idpClient.Status.RotatedSecretExpiresAt
+			// this value is set in the application-webhook if graceful-secret-rotation is used
+			owner.Status.RotatedClientSecret = owner.Spec.RotatedSecret
+		} else {
+			// only as fallback, this field is only set in identity when no secret-manager is configured.
+			owner.Status.RotatedClientSecret = idpClient.Status.RotatedClientSecret
 		}
 	}
 

--- a/application/internal/handler/application/handler_test.go
+++ b/application/internal/handler/application/handler_test.go
@@ -356,6 +356,38 @@ var _ = Describe("ApplicationHandler - Secret Rotation", func() {
 				Expect(app.Status.CurrentExpiresAt.Time).To(BeTemporally("~", currentExpires.Time, time.Second))
 			})
 
+			It("should complete rotation immediately when identity client has disable-secret-rotation annotation", func() {
+				mockClient := fake.NewMockJanitorClient(GinkgoT())
+				ctx = client.WithClient(ctx, mockClient)
+
+				// Identity client has rotation disabled — no expiry timestamps will ever arrive.
+				setupHappyPath(mockClient, zone, false, func(idpClient *identityv1.Client) {
+					idpClient.Annotations = map[string]string{
+						identityv1.DisableSecretRotationAnnotation: "true",
+					}
+				})
+
+				// Simulate InProgress from previous reconcile
+				app.SetCondition(metav1.Condition{
+					Type:    secret.SecretRotationConditionType,
+					Status:  metav1.ConditionFalse,
+					Reason:  secret.SecretRotationReasonInProgress,
+					Message: "Secret rotation initiated",
+				})
+
+				err := handler.CreateOrUpdate(ctx, app)
+				Expect(err).ToNot(HaveOccurred())
+
+				cond := meta.FindStatusCondition(app.Status.Conditions, secret.SecretRotationConditionType)
+				Expect(cond).ToNot(BeNil())
+				Expect(cond.Reason).To(Equal(secret.SecretRotationReasonSuccess))
+				Expect(cond.Status).To(Equal(metav1.ConditionTrue))
+
+				Expect(app.Status.RotatedClientSecret).To(Equal("$<ref:rotated-secret>"))
+				Expect(app.Status.RotatedExpiresAt).To(BeNil(),
+					"RotatedExpiresAt should be nil when graceful rotation is disabled")
+			})
+
 			It("should not re-initiate rotation after Success when spec.rotatedSecret matches status", func() {
 				mockClient := fake.NewMockJanitorClient(GinkgoT())
 				ctx = client.WithClient(ctx, mockClient)

--- a/application/internal/webhook/v1/mutator/mutate.go
+++ b/application/internal/webhook/v1/mutator/mutate.go
@@ -92,8 +92,9 @@ func MutateSecret(ctx context.Context, env string, app *applicationv1.Applicatio
 		return nil
 	}
 
-	// Determine if this is a rotation request. Can only be a rotation if there is an older generation,
-	// otherwise it would be the initial creation of the secret.
+	// Determine if this is a rotation request. This is called from an admission webhook, so the
+	// admission request operation is available: a rotate keyword on anything other than Create is
+	// treated as a rotation request, while Create is the initial secret creation.
 	isRotation := strings.EqualFold(app.Spec.Secret, secret.KeywordRotate) && req.Operation != admissionv1.Create
 
 	// Guard: deny rotation if one is already in progress

--- a/application/internal/webhook/v1/mutator/mutate.go
+++ b/application/internal/webhook/v1/mutator/mutate.go
@@ -10,10 +10,12 @@ import (
 	"strings"
 
 	"github.com/go-logr/logr"
+	admissionv1 "k8s.io/api/admission/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	adminv1 "github.com/telekom/controlplane/admin/api/v1"
 	applicationv1 "github.com/telekom/controlplane/application/api/v1"
@@ -34,6 +36,42 @@ func isRotationInProgress(app *applicationv1.Application) bool {
 	return cond != nil && cond.Reason == secret.SecretRotationReasonInProgress
 }
 
+// resolveRotationOpts checks whether the rotation should be graceful (zone has SecretRotation feature enabled)
+// and, if so, retrieves the current secret value to store as the rotated secret.
+// Returns the additional onboarding options and whether the rotation is graceful.
+func resolveRotationOpts(ctx context.Context, app *applicationv1.Application, reader client.Reader) ([]secretsapi.OnboardingOption, bool, error) {
+	log := logr.FromContextOrDiscard(ctx)
+	eventRecorder := contextutil.EventRecorderFromContextOrDiscard(ctx)
+
+	zone := &adminv1.Zone{}
+	if err := reader.Get(ctx, app.Spec.Zone.K8s(), zone); err != nil {
+		return nil, false, errors.NewInternalError(fmt.Errorf("failed to fetch zone %s to check secret rotation feature: %w", app.Spec.Zone.Name, err))
+	}
+
+	isGraceful := zone.IsFeatureEnabled(adminv1.FeatureSecretRotation)
+	if !isGraceful {
+		log.Info("zone does not have SecretRotation feature enabled, performing non-graceful rotation (no grace period)",
+			"zone", app.Spec.Zone.Name)
+		eventRecorder.Eventf(app, nil, "Normal", "NonGracefulRotation", "StartNonGracefulRotation", "zone %q does not have SecretRotation feature enabled, no grace period", app.Spec.Zone.Name)
+		return nil, false, nil
+	}
+
+	eventRecorder.Eventf(app, nil, "Normal", "GracefulRotation", "StartGracefulRotation", "zone %q has SecretRotation feature enabled, with grace period", app.Spec.Zone.Name)
+
+	if app.Status.ClientSecret == "" {
+		return nil, true, nil
+	}
+
+	currentSecretValue, err := secret.GetSecretManager().Get(ctx, app.Status.ClientSecret)
+	if err != nil {
+		return nil, true, wrapCommunicationError(err, "retrieving current client secret for rotation")
+	}
+
+	return []secretsapi.OnboardingOption{
+		secret.WithSecretValue(secret.RotatedClientSecret, currentSecretValue),
+	}, true, nil
+}
+
 // MutateSecret intercepts Application secret values and replaces them with
 // secret-manager references. If the secret is already a reference, this is a no-op.
 // If the secret is "rotate" or empty, a new secret is generated.
@@ -41,20 +79,26 @@ func isRotationInProgress(app *applicationv1.Application) bool {
 // and a new clientSecret is generated.
 func MutateSecret(ctx context.Context, env string, app *applicationv1.Application, reader client.Reader) error {
 	log := logr.FromContextOrDiscard(ctx)
+	eventRecorder := contextutil.EventRecorderFromContextOrDiscard(ctx)
+
+	req, err := admission.RequestFromContext(ctx)
+	if err != nil {
+		return errors.NewInternalError(fmt.Errorf("failed to get admission request from context: %w", err))
+	}
 
 	if secretsapi.IsRef(app.Spec.Secret) {
 		log.V(1).Info("spec.secret is already a reference, nothing to do")
-		contextutil.EventRecorderFromContextOrDiscard(ctx).Eventf(app, nil, "Normal", "SecretMutationSkipped", "spec.secret is already a reference, skipping mutation", "")
+		eventRecorder.Eventf(app, nil, "Normal", "SecretMutationSkipped", "SkipMutation", "spec.secret is already a reference, skipping mutation")
 		return nil
 	}
 
 	// Determine if this is a rotation request. Can only be a rotation if there is an older generation,
 	// otherwise it would be the initial creation of the secret.
-	isRotation := strings.EqualFold(app.Spec.Secret, secret.KeywordRotate) && app.GetGeneration() > 1
+	isRotation := strings.EqualFold(app.Spec.Secret, secret.KeywordRotate) && req.Operation != admissionv1.Create
 
 	// Guard: deny rotation if one is already in progress
 	if isRotation && isRotationInProgress(app) {
-		contextutil.EventRecorderFromContextOrDiscard(ctx).Eventf(app, nil, "Warning", "SecretRotationBlocked", "a secret rotation is already in progress, blocking new rotation request", "")
+		eventRecorder.Eventf(app, nil, "Warning", "SecretRotationBlocked", "BlockRotation", "a secret rotation is already in progress, blocking new rotation request")
 
 		return errors.NewForbidden(
 			schema.GroupResource{Group: "application.cp.ei.telekom.de", Resource: "applications"},
@@ -63,52 +107,35 @@ func MutateSecret(ctx context.Context, env string, app *applicationv1.Applicatio
 		)
 	}
 
-	contextutil.EventRecorderFromContextOrDiscard(ctx).Eventf(app, nil, "Normal", "SecretMutationStarted", "starting mutation of application secret", "")
+	eventRecorder.Eventf(app, nil, "Normal", "SecretMutationStarted", "StartMutation", "starting mutation of application secret")
 
-	// Determine if the rotation should be graceful (zone has SecretRotation feature enabled)
-	isGracefulRotation := false
+	// Resolve rotation options (graceful rotation check + current secret retrieval)
+	var rotationOpts []secretsapi.OnboardingOption
+	var isGracefulRotation bool
 	if isRotation {
-		zone := &adminv1.Zone{}
-		if err := reader.Get(ctx, app.Spec.Zone.K8s(), zone); err != nil {
-			return errors.NewInternalError(fmt.Errorf("failed to fetch zone %s to check secret rotation feature: %w", app.Spec.Zone.Name, err))
-		}
-		isGracefulRotation = zone.IsFeatureEnabled(adminv1.FeatureSecretRotation)
-		if !isGracefulRotation {
-			log.Info("zone does not have SecretRotation feature enabled, performing non-graceful rotation (no grace period)",
-				"zone", app.Spec.Zone.Name)
-
-			contextutil.EventRecorderFromContextOrDiscard(ctx).Eventf(app, nil, "Normal", "NonGracefulRotation", "zone does not have SecretRotation feature enabled, performing non-graceful rotation (no grace period)", "")
+		var rotErr error
+		rotationOpts, isGracefulRotation, rotErr = resolveRotationOpts(ctx, app, reader)
+		if rotErr != nil {
+			return rotErr
 		}
 	}
 
 	var clientSecret string
 	// On initial creation, or when the secret value is explicitly set to "rotate", generate a new secret value.
 	if strings.EqualFold(app.Spec.Secret, secret.KeywordRotate) || app.Spec.Secret == "" {
-		generatedSecret, err := secretsapi.GenerateSecret()
+		clientSecret, err = secretsapi.GenerateSecret()
 		if err != nil {
 			return errors.NewInternalError(fmt.Errorf("failed to generate secret: %w", err))
 		}
-		clientSecret = generatedSecret
-		contextutil.EventRecorderFromContextOrDiscard(ctx).Eventf(app, nil, "Normal", "SecretGenerated", "generated new client secret for application", "")
+		eventRecorder.Eventf(app, nil, "Normal", "SecretGenerated", "GenerateSecret", "generated new client secret for application")
 	} else {
 		clientSecret = app.Spec.Secret
 	}
 
 	// Build the list of secrets to upsert
-	upsertOpts := []secretsapi.OnboardingOption{
-		secret.WithSecretValue(secret.ClientSecret, clientSecret),
-	}
-
-	// On graceful rotation, retrieve the current secret value and store it as rotatedClientSecret
-	if isGracefulRotation && app.Status.ClientSecret != "" {
-		currentSecretValue, err := secret.GetSecretManager().Get(ctx, app.Status.ClientSecret)
-		if err != nil {
-			return wrapCommunicationError(err, "retrieving current client secret for rotation")
-		}
-		upsertOpts = append(upsertOpts,
-			secret.WithSecretValue(secret.RotatedClientSecret, currentSecretValue),
-		)
-	}
+	upsertOpts := make([]secretsapi.OnboardingOption, 0, 1+len(rotationOpts))
+	upsertOpts = append(upsertOpts, secret.WithSecretValue(secret.ClientSecret, clientSecret))
+	upsertOpts = append(upsertOpts, rotationOpts...)
 
 	availableSecrets, err := secret.GetSecretManager().UpsertApplication(ctx, env, app.Spec.Team, app.GetName(),
 		upsertOpts...)

--- a/application/internal/webhook/v1/mutator/mutate_test.go
+++ b/application/internal/webhook/v1/mutator/mutate_test.go
@@ -10,10 +10,12 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/mock"
+	admissionv1 "k8s.io/api/admission/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	adminv1 "github.com/telekom/controlplane/admin/api/v1"
 	applicationv1 "github.com/telekom/controlplane/application/api/v1"
@@ -53,6 +55,7 @@ func TestMutateSecret(t *testing.T) {
 		app                   *applicationv1.Application
 		env                   string
 		reader                client.Reader
+		operation             admissionv1.Operation
 		mock                  func(t *testing.T) api.SecretManager
 		mockFindSecretId      func(map[string]string, string) (string, bool)
 		expectedError         bool
@@ -68,8 +71,9 @@ func TestMutateSecret(t *testing.T) {
 					Secret: "",
 				},
 			},
-			env:    "dev",
-			reader: newReader(),
+			env:       "dev",
+			reader:    newReader(),
+			operation: admissionv1.Create,
 			mock: func(t *testing.T) api.SecretManager {
 				m := fake.NewMockSecretManager(t)
 				m.EXPECT().
@@ -93,8 +97,9 @@ func TestMutateSecret(t *testing.T) {
 					ClientSecret: "$<old-ref>",
 				},
 			},
-			env:    "dev",
-			reader: newReader(zoneWithRotation.DeepCopy()),
+			env:       "dev",
+			reader:    newReader(zoneWithRotation.DeepCopy()),
+			operation: admissionv1.Update,
 			mock: func(t *testing.T) api.SecretManager {
 				m := fake.NewMockSecretManager(t)
 				m.EXPECT().
@@ -124,8 +129,9 @@ func TestMutateSecret(t *testing.T) {
 					ClientSecret: "$<old-ref>",
 				},
 			},
-			env:    "dev",
-			reader: newReader(zoneWithoutRotation.DeepCopy()),
+			env:       "dev",
+			reader:    newReader(zoneWithoutRotation.DeepCopy()),
+			operation: admissionv1.Update,
 			mock: func(t *testing.T) api.SecretManager {
 				m := fake.NewMockSecretManager(t)
 				m.EXPECT().
@@ -152,8 +158,9 @@ func TestMutateSecret(t *testing.T) {
 					ClientSecret: "",
 				},
 			},
-			env:    "dev",
-			reader: newReader(zoneWithRotation.DeepCopy()),
+			env:       "dev",
+			reader:    newReader(zoneWithRotation.DeepCopy()),
+			operation: admissionv1.Update,
 			mock: func(t *testing.T) api.SecretManager {
 				m := fake.NewMockSecretManager(t)
 				m.EXPECT().
@@ -189,8 +196,9 @@ func TestMutateSecret(t *testing.T) {
 					},
 				},
 			},
-			env:    "dev",
-			reader: newReader(zoneWithRotation.DeepCopy()),
+			env:       "dev",
+			reader:    newReader(zoneWithRotation.DeepCopy()),
+			operation: admissionv1.Update,
 			mock: func(t *testing.T) api.SecretManager {
 				return nil
 			},
@@ -205,8 +213,9 @@ func TestMutateSecret(t *testing.T) {
 					Secret: "my-custom-secret",
 				},
 			},
-			env:    "dev",
-			reader: newReader(),
+			env:       "dev",
+			reader:    newReader(),
+			operation: admissionv1.Create,
 			mock: func(t *testing.T) api.SecretManager {
 				m := fake.NewMockSecretManager(t)
 				m.EXPECT().
@@ -225,8 +234,9 @@ func TestMutateSecret(t *testing.T) {
 					Secret: "$<existing-ref>",
 				},
 			},
-			env:    "dev",
-			reader: newReader(),
+			env:       "dev",
+			reader:    newReader(),
+			operation: admissionv1.Update,
 			mock: func(t *testing.T) api.SecretManager {
 				return nil
 			},
@@ -246,8 +256,9 @@ func TestMutateSecret(t *testing.T) {
 					ClientSecret: "$<old-ref>",
 				},
 			},
-			env:    "dev",
-			reader: newReader(zoneWithRotation.DeepCopy()),
+			env:       "dev",
+			reader:    newReader(zoneWithRotation.DeepCopy()),
+			operation: admissionv1.Update,
 			mock: func(t *testing.T) api.SecretManager {
 				m := fake.NewMockSecretManager(t)
 				m.EXPECT().
@@ -274,8 +285,9 @@ func TestMutateSecret(t *testing.T) {
 					ClientSecret: "$<old-ref>",
 				},
 			},
-			env:    "dev",
-			reader: newReader(zoneWithRotation.DeepCopy()),
+			env:       "dev",
+			reader:    newReader(zoneWithRotation.DeepCopy()),
+			operation: admissionv1.Update,
 			mock: func(t *testing.T) api.SecretManager {
 				m := fake.NewMockSecretManager(t)
 				m.EXPECT().
@@ -299,8 +311,9 @@ func TestMutateSecret(t *testing.T) {
 					ClientSecret: "$<old-ref>",
 				},
 			},
-			env:    "dev",
-			reader: newReader(zoneWithRotation.DeepCopy()),
+			env:       "dev",
+			reader:    newReader(zoneWithRotation.DeepCopy()),
+			operation: admissionv1.Update,
 			mock: func(t *testing.T) api.SecretManager {
 				m := fake.NewMockSecretManager(t)
 				m.EXPECT().
@@ -330,7 +343,9 @@ func TestMutateSecret(t *testing.T) {
 			if tt.mockFindSecretId != nil {
 				secret.FindSecretId = tt.mockFindSecretId
 			}
-			err := MutateSecret(context.Background(), tt.env, tt.app, tt.reader)
+			err := MutateSecret(admission.NewContextWithRequest(context.Background(), admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{Operation: tt.operation},
+			}), tt.env, tt.app, tt.reader)
 			if tt.expectedError {
 				Expect(err).To(HaveOccurred())
 				if tt.expectedForbidden {

--- a/identity/internal/handler/client/handler.go
+++ b/identity/internal/handler/client/handler.go
@@ -161,9 +161,9 @@ func (h *HandlerClient) CreateOrUpdate(ctx context.Context, client *identityv1.C
 			}
 		}
 
-		// --- Current secret expiry: compute when Keycloak will auto-expire it ---
-		if rotationInfo.SecretCreationTime != nil && realm.Spec.SecretRotation != nil {
-			expiresAt := time.Unix(*rotationInfo.SecretCreationTime, 0).Add(realm.Spec.SecretRotation.ExpirationPeriod.Duration)
+		// --- Current secret expiry: read directly from Keycloak's attribute ---
+		if rotationInfo.SecretExpiresAt != nil {
+			expiresAt := time.Unix(*rotationInfo.SecretExpiresAt, 0)
 			client.Status.SecretExpiresAt = &metav1.Time{Time: expiresAt.UTC()}
 		} else {
 			client.Status.SecretExpiresAt = nil

--- a/identity/internal/handler/client/handler_test.go
+++ b/identity/internal/handler/client/handler_test.go
@@ -517,7 +517,7 @@ var _ = Describe("HandlerClient", func() {
 			Expect(cl.Status.RotatedClientSecret).To(Equal("old-secret-value"))
 		})
 
-		It("should set SecretExpiresAt when creation time attribute is present", func() {
+		It("should set SecretExpiresAt when expiration time attribute is present", func() {
 			cl := newValidClient()
 			cl.Spec.ClientSecret = "plain-secret"
 
@@ -533,15 +533,15 @@ var _ = Describe("HandlerClient", func() {
 			})
 			mockRealmGet(mockK8s, realm)
 
-			// Secret created at 2025-06-16T12:00:00Z = 1750075200
-			var creationEpoch int64 = 1750075200
+			// Secret expires at 2025-07-15T12:00:00Z = 1752580800
+			var expirationEpoch int64 = 1752580800
 			mockSvc := keycloakservice.NewMockKeycloakService(GinkgoT())
 			mockSvc.EXPECT().
 				CreateOrReplaceClient(mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 				Return(nil)
 			mockSvc.EXPECT().
 				GetClientSecretRotationInfo(mock.Anything, mock.Anything, mock.Anything).
-				Return(&keycloak.ClientSecretRotationInfo{SecretCreationTime: &creationEpoch}, nil)
+				Return(&keycloak.ClientSecretRotationInfo{SecretExpiresAt: &expirationEpoch}, nil)
 
 			factory := keycloak.ServiceFactoryFunc(func(_ identityv1.RealmStatus) (keycloak.KeycloakService, error) {
 				return mockSvc, nil
@@ -552,14 +552,14 @@ var _ = Describe("HandlerClient", func() {
 
 			Expect(err).ToNot(HaveOccurred())
 
-			By("verifying SecretExpiresAt = creationTime + expirationPeriod")
-			expectedExpiry := time.Unix(creationEpoch, 0).Add(29 * 24 * time.Hour).UTC()
+			By("verifying SecretExpiresAt is set directly from Keycloak's expiration time attribute")
+			expectedExpiry := time.Unix(expirationEpoch, 0).UTC()
 			Expect(cl.Status.SecretExpiresAt).ToNot(BeNil())
 			Expect(cl.Status.SecretExpiresAt.Time.Equal(expectedExpiry)).To(BeTrue(),
 				"expected %v but got %v", expectedExpiry, cl.Status.SecretExpiresAt.Time)
 		})
 
-		It("should set SecretExpiresAt to nil when creation time attribute is missing", func() {
+		It("should set SecretExpiresAt to nil when expiration time attribute is missing", func() {
 			cl := newValidClient()
 			cl.Spec.ClientSecret = "plain-secret"
 

--- a/identity/pkg/keycloak/graceful_secrets.go
+++ b/identity/pkg/keycloak/graceful_secrets.go
@@ -44,6 +44,7 @@ type SecretRotationParams struct {
 
 const (
 	attrSecretCreationTime    = "client.secret.creation.time"
+	attrSecretExpirationTime  = "client.secret.expiration.time"
 	attrRotatedCreationTime   = "client.secret.rotated.creation.time"
 	attrRotatedExpirationTime = "client.secret.rotated.expiration.time"
 )
@@ -72,6 +73,9 @@ type ClientSecretRotationInfo struct {
 	// SecretCreationTime is when the current secret was created (epoch seconds),
 	// as tracked by Keycloak's secret-rotation executor. Nil if unavailable.
 	SecretCreationTime *int64
+	// SecretExpiresAt is when the current secret expires (epoch seconds),
+	// as tracked by Keycloak's secret-rotation executor. Nil if unavailable.
+	SecretExpiresAt *int64
 }
 
 // NewClientSecretRotationInfo builds a ClientSecretRotationInfo from the
@@ -86,6 +90,7 @@ func NewClientSecretRotationInfo(cred *api.CredentialRepresentation, client *api
 		info.RotatedCreatedAt = epochSecondsFromAttr(*client.Attributes, attrRotatedCreationTime)
 		info.RotatedExpiresAt = epochSecondsFromAttr(*client.Attributes, attrRotatedExpirationTime)
 		info.SecretCreationTime = epochSecondsFromAttr(*client.Attributes, attrSecretCreationTime)
+		info.SecretExpiresAt = epochSecondsFromAttr(*client.Attributes, attrSecretExpirationTime)
 	}
 	return info
 }
@@ -310,10 +315,11 @@ func (k *keycloakService) GetClientSecretRotationInfo(ctx context.Context, realm
 	}
 	keycloakId := *existing.Id
 
-	// Start with creation time from the existing client representation.
+	// Start with creation/expiration time from the existing client representation.
 	info := &ClientSecretRotationInfo{}
 	if existing.Attributes != nil {
 		info.SecretCreationTime = epochSecondsFromAttr(*existing.Attributes, attrSecretCreationTime)
+		info.SecretExpiresAt = epochSecondsFromAttr(*existing.Attributes, attrSecretExpirationTime)
 	}
 
 	// Check for a rotated (old) secret.
@@ -342,8 +348,9 @@ func (k *keycloakService) GetClientSecretRotationInfo(ctx context.Context, realm
 
 	logger.V(1).Info("rotated secret found", "clientId", client.Spec.ClientId)
 	rotated := NewClientSecretRotationInfo(resp.JSON2XX, existing)
-	// Preserve SecretCreationTime already extracted above.
+	// Preserve SecretCreationTime and SecretExpiresAt already extracted above.
 	rotated.SecretCreationTime = info.SecretCreationTime
+	rotated.SecretExpiresAt = info.SecretExpiresAt
 	return rotated, nil
 }
 

--- a/identity/pkg/keycloak/graceful_secrets_test.go
+++ b/identity/pkg/keycloak/graceful_secrets_test.go
@@ -70,6 +70,7 @@ var _ = Describe("GracefulSecrets (pure functions)", func() {
 			Expect(info.RotatedCreatedAt).To(BeNil())
 			Expect(info.RotatedExpiresAt).To(BeNil())
 			Expect(info.SecretCreationTime).To(BeNil())
+			Expect(info.SecretExpiresAt).To(BeNil())
 		})
 
 		It("should populate all fields from cred and client attributes", func() {
@@ -79,6 +80,7 @@ var _ = Describe("GracefulSecrets (pure functions)", func() {
 					attrRotatedCreationTime:   "1000",
 					attrRotatedExpirationTime: float64(2000),
 					attrSecretCreationTime:    "3000",
+					attrSecretExpirationTime:  "4000",
 				},
 			}
 			info := NewClientSecretRotationInfo(cred, client)
@@ -89,6 +91,8 @@ var _ = Describe("GracefulSecrets (pure functions)", func() {
 			Expect(*info.RotatedExpiresAt).To(Equal(int64(2000)))
 			Expect(info.SecretCreationTime).ToNot(BeNil())
 			Expect(*info.SecretCreationTime).To(Equal(int64(3000)))
+			Expect(info.SecretExpiresAt).ToNot(BeNil())
+			Expect(*info.SecretExpiresAt).To(Equal(int64(4000)))
 		})
 	})
 


### PR DESCRIPTION
Complete rotation immediately when the identity client has graceful
secret-rotation disabled (disable-secret-rotation annotation), instead
of waiting indefinitely for expiry timestamps that will never arrive.
Also:
- Read SecretExpiresAt directly from Keycloak's expiration time attribute
  instead of computing it from creation time + expiration period
- Detect rotation requests via admission operation type instead of
  generation number, fixing edge cases on first update
- Propagate RotatedExpiresAt and RotatedClientSecret from identity
  client status to application status
- Extract resolveRotationOpts helper in the webhook mutator
