### PR TITLE
fix(identity): resolve all golangci-lint issues

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -114,6 +114,7 @@ jobs:
       module: identity
       run_check_generated_files: true
       ko_build_path: "cmd/main.go"
+      lint_fail_on_issues: true
 
   organization:
     name: Organization

--- a/identity/Makefile
+++ b/identity/Makefile
@@ -158,7 +158,7 @@ $(ENVTEST): $(LOCALBIN)
 .PHONY: golangci-lint
 golangci-lint: $(GOLANGCI_LINT) ## Download golangci-lint locally if necessary.
 $(GOLANGCI_LINT): $(LOCALBIN)
-	$(call go-install-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/cmd/golangci-lint,$(GOLANGCI_LINT_VERSION))
+	$(call go-install-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/v2/cmd/golangci-lint,$(GOLANGCI_LINT_VERSION))
 
 # go-install-tool will 'go install' any package with custom target and name of binary, if it doesn't exist
 # $1 - target path with name of binary

--- a/identity/cmd/main.go
+++ b/identity/cmd/main.go
@@ -24,6 +24,8 @@ import (
 	"github.com/telekom/controlplane/identity/internal/controller"
 	secretmetrics "github.com/telekom/controlplane/secret-manager/api/metrics"
 
+	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
+	// to ensure that exec-entrypoint and run can make use of them.
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	// +kubebuilder:scaffold:imports
 )

--- a/identity/cmd/main.go
+++ b/identity/cmd/main.go
@@ -9,19 +9,13 @@ import (
 	"flag"
 	"os"
 
-	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
-	// to ensure that exec-entrypoint and run can make use of them.
-
-	_ "k8s.io/client-go/plugin/pkg/client/auth"
-
-	"sigs.k8s.io/controller-runtime/pkg/metrics"
-
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/filters"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
@@ -29,6 +23,8 @@ import (
 	identityv1 "github.com/telekom/controlplane/identity/api/v1"
 	"github.com/telekom/controlplane/identity/internal/controller"
 	secretmetrics "github.com/telekom/controlplane/secret-manager/api/metrics"
+
+	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	// +kubebuilder:scaffold:imports
 )
 

--- a/identity/internal/controller/client_controller.go
+++ b/identity/internal/controller/client_controller.go
@@ -2,14 +2,12 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+//nolint:dupl // Controllers intentionally mirror each other.
 package controller
 
 import (
 	"context"
 
-	cconfig "github.com/telekom/controlplane/common/pkg/config"
-	cc "github.com/telekom/controlplane/common/pkg/controller"
-	"github.com/telekom/controlplane/common/pkg/types"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -21,6 +19,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
+	cconfig "github.com/telekom/controlplane/common/pkg/config"
+	cc "github.com/telekom/controlplane/common/pkg/controller"
+	"github.com/telekom/controlplane/common/pkg/types"
 	identityv1 "github.com/telekom/controlplane/identity/api/v1"
 	clientHandler "github.com/telekom/controlplane/identity/internal/handler/client"
 	"github.com/telekom/controlplane/identity/pkg/keycloak"
@@ -93,14 +94,15 @@ func (r *ClientReconciler) mapRealmObjToIdentityClient(ctx context.Context, obj 
 	}
 
 	list := &identityv1.ClientList{}
-	if err := r.Client.List(ctx, list, listOpts...); err != nil {
+	if err := r.List(ctx, list, listOpts...); err != nil {
 		logger.Error(err, "failed to list Clients")
 		return nil
 	}
 
 	requests := make([]reconcile.Request, 0, len(list.Items))
-	for _, item := range list.Items {
-		requests = append(requests, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(&item)})
+	for i := range list.Items {
+		item := &list.Items[i]
+		requests = append(requests, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(item)})
 	}
 
 	return requests

--- a/identity/internal/controller/client_controller_test.go
+++ b/identity/internal/controller/client_controller_test.go
@@ -7,17 +7,18 @@ package controller
 import (
 	"context"
 
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
-	"github.com/telekom/controlplane/common/pkg/condition"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/telekom/controlplane/common/pkg/condition"
 	identityv1 "github.com/telekom/controlplane/identity/api/v1"
 	clientModel "github.com/telekom/controlplane/identity/internal/testutil/fixtures/client"
 	identityproviderModel "github.com/telekom/controlplane/identity/internal/testutil/fixtures/identityprovider"
 	realmModel "github.com/telekom/controlplane/identity/internal/testutil/fixtures/realm"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("Client Controller", func() {
@@ -69,7 +70,6 @@ var _ = Describe("Client Controller", func() {
 
 			By("deleting the custom resource for the Kind IdentityProvider")
 			DeleteIdentityProvider(ctx, clientIdpRef)
-
 		})
 		It("should successfully reconcile the resource", func() {
 			Eventually(func(g Gomega) {

--- a/identity/internal/controller/identityprovider_controller.go
+++ b/identity/internal/controller/identityprovider_controller.go
@@ -7,14 +7,14 @@ package controller
 import (
 	"context"
 
-	cconfig "github.com/telekom/controlplane/common/pkg/config"
-	cc "github.com/telekom/controlplane/common/pkg/controller"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 
+	cconfig "github.com/telekom/controlplane/common/pkg/config"
+	cc "github.com/telekom/controlplane/common/pkg/controller"
 	identityv1 "github.com/telekom/controlplane/identity/api/v1"
 	identityproviderHandler "github.com/telekom/controlplane/identity/internal/handler/identityprovider"
 )

--- a/identity/internal/controller/identityprovider_controller_test.go
+++ b/identity/internal/controller/identityprovider_controller_test.go
@@ -7,15 +7,16 @@ package controller
 import (
 	"context"
 
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
-	"github.com/telekom/controlplane/common/pkg/condition"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/telekom/controlplane/common/pkg/condition"
 	identityv1 "github.com/telekom/controlplane/identity/api/v1"
 	identityproviderModel "github.com/telekom/controlplane/identity/internal/testutil/fixtures/identityprovider"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("IdentityProvider Controller", func() {
@@ -42,7 +43,6 @@ var _ = Describe("IdentityProvider Controller", func() {
 		It("should successfully reconcile the resource", func() {
 			Eventually(func(g Gomega) {
 				VerifyIdentityProvider(ctx, g, idpRef, testIdp)
-
 			}, timeout, interval).Should(Succeed())
 		})
 	})

--- a/identity/internal/controller/index.go
+++ b/identity/internal/controller/index.go
@@ -8,13 +8,16 @@ import (
 	"context"
 	"os"
 
-	identityv1 "github.com/telekom/controlplane/identity/api/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	identityv1 "github.com/telekom/controlplane/identity/api/v1"
 )
 
-var IndexFieldSpecIdentityProvider = "spec.identityProvider"
-var IndexFieldSpecRealm = "spec.realm"
+var (
+	IndexFieldSpecIdentityProvider = "spec.identityProvider"
+	IndexFieldSpecRealm            = "spec.realm"
+)
 
 func RegisterIndexesOrDie(ctx context.Context, mgr ctrl.Manager) {
 	// Index the Realm by the IdentityProvider it references.

--- a/identity/internal/controller/realm_controller.go
+++ b/identity/internal/controller/realm_controller.go
@@ -2,14 +2,12 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+//nolint:dupl // Controllers intentionally mirror each other.
 package controller
 
 import (
 	"context"
 
-	cconfig "github.com/telekom/controlplane/common/pkg/config"
-	cc "github.com/telekom/controlplane/common/pkg/controller"
-	"github.com/telekom/controlplane/common/pkg/types"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -21,6 +19,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
+	cconfig "github.com/telekom/controlplane/common/pkg/config"
+	cc "github.com/telekom/controlplane/common/pkg/controller"
+	"github.com/telekom/controlplane/common/pkg/types"
 	identityv1 "github.com/telekom/controlplane/identity/api/v1"
 	realmHandler "github.com/telekom/controlplane/identity/internal/handler/realm"
 	"github.com/telekom/controlplane/identity/pkg/keycloak"
@@ -93,14 +94,15 @@ func (r *RealmReconciler) mapIdpObjToRealm(ctx context.Context, obj client.Objec
 	}
 
 	list := &identityv1.RealmList{}
-	if err := r.Client.List(ctx, list, listOpts...); err != nil {
+	if err := r.List(ctx, list, listOpts...); err != nil {
 		logger.Error(err, "failed to list Realms")
 		return nil
 	}
 
 	requests := make([]reconcile.Request, 0, len(list.Items))
-	for _, item := range list.Items {
-		requests = append(requests, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(&item)})
+	for i := range list.Items {
+		item := &list.Items[i]
+		requests = append(requests, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(item)})
 	}
 
 	return requests

--- a/identity/internal/controller/realm_controller_test.go
+++ b/identity/internal/controller/realm_controller_test.go
@@ -7,17 +7,18 @@ package controller
 import (
 	"context"
 
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
 	ghErrors "github.com/pkg/errors"
-	"github.com/telekom/controlplane/common/pkg/condition"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/telekom/controlplane/common/pkg/condition"
 	identityv1 "github.com/telekom/controlplane/identity/api/v1"
 	identityproviderModel "github.com/telekom/controlplane/identity/internal/testutil/fixtures/identityprovider"
 	realmModel "github.com/telekom/controlplane/identity/internal/testutil/fixtures/realm"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("Realm Controller", func() {
@@ -67,12 +68,12 @@ var _ = Describe("Realm Controller", func() {
 		It("should successfully reconcile the resource", func() {
 			Eventually(func(g Gomega) {
 				VerifyRealm(ctx, g, realmRef, testRealm, expectedRealmStatus)
-
 			}, timeout, interval).Should(Succeed())
 		})
 	})
 })
 
+//nolint:gocritic // Test helper compares the full expected status structure.
 func VerifyRealm(ctx context.Context, gomega Gomega, namespacedName client.ObjectKey, realmToVerify *identityv1.Realm, expectedRealmStatus identityv1.RealmStatus) {
 	realmResource := &identityv1.Realm{}
 	err := k8sClient.Get(ctx, namespacedName, realmResource)
@@ -89,7 +90,6 @@ func VerifyRealm(ctx context.Context, gomega Gomega, namespacedName client.Objec
 	gomega.Expect(realmResource.Status.AdminTokenUrl).To(Equal(expectedRealmStatus.AdminTokenUrl))
 	gomega.Expect(meta.IsStatusConditionTrue(realmResource.Status.Conditions, condition.ConditionTypeProcessing)).To(BeFalse())
 	gomega.Expect(meta.IsStatusConditionTrue(realmResource.Status.Conditions, condition.ConditionTypeReady)).To(BeTrue())
-
 }
 
 func VerifyRealmIsAvailable(clientRealmRef client.ObjectKey) {

--- a/identity/internal/controller/suite_test.go
+++ b/identity/internal/controller/suite_test.go
@@ -13,21 +13,21 @@ import (
 	"testing"
 	"time"
 
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
-	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
-
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
 	identityv1 "github.com/telekom/controlplane/identity/api/v1"
 	"github.com/telekom/controlplane/identity/pkg/keycloak"
 	"github.com/telekom/controlplane/identity/test/utils"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 	// +kubebuilder:scaffold:imports
 )
 
@@ -42,11 +42,13 @@ const (
 	mockKeycloak    = true
 )
 
-var cfg *rest.Config
-var k8sClient client.Client
-var testEnv *envtest.Environment
-var ctx context.Context
-var cancel context.CancelFunc
+var (
+	cfg       *rest.Config
+	k8sClient client.Client
+	testEnv   *envtest.Environment
+	ctx       context.Context
+	cancel    context.CancelFunc
+)
 
 func TestControllers(t *testing.T) {
 	RegisterFailHandler(Fail)
@@ -105,7 +107,7 @@ var _ = BeforeSuite(func() {
 			utils.ConfigureKeycloakClientMock(mockClient)
 			return keycloak.NewKeycloakService(mockClient), nil
 		}
-		return keycloak.NewKeycloakServiceFor(realmStatus)
+		return keycloak.NewKeycloakServiceFor(&realmStatus)
 	})
 
 	err = (&ClientReconciler{
@@ -133,7 +135,6 @@ var _ = BeforeSuite(func() {
 		err = k8sManager.Start(ctx)
 		Expect(err).ToNot(HaveOccurred(), "failed to run manager")
 	}()
-
 })
 
 var _ = AfterSuite(func() {

--- a/identity/internal/handler/client/handler.go
+++ b/identity/internal/handler/client/handler.go
@@ -11,14 +11,14 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
-	"github.com/telekom/controlplane/common/pkg/condition"
-	"github.com/telekom/controlplane/common/pkg/errors/ctrlerrors"
-	"github.com/telekom/controlplane/common/pkg/handler"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
+	"github.com/telekom/controlplane/common/pkg/condition"
+	"github.com/telekom/controlplane/common/pkg/errors/ctrlerrors"
+	"github.com/telekom/controlplane/common/pkg/handler"
 	identityv1 "github.com/telekom/controlplane/identity/api/v1"
 	realmHandler "github.com/telekom/controlplane/identity/internal/handler/realm"
 	"github.com/telekom/controlplane/identity/pkg/keycloak"
@@ -57,8 +57,7 @@ func (h *HandlerClient) CreateOrUpdate(ctx context.Context, client *identityv1.C
 	}
 
 	mapToClientStatus(&realm.Status, &client.Status)
-	err = realmHandler.ValidateRealmStatus(&realm.Status)
-	if err != nil {
+	if err = realmHandler.ValidateRealmStatus(&realm.Status); err != nil {
 		return ctrlerrors.BlockedErrorf("Realm %q is not valid: %s", client.Spec.Realm.String(), err)
 	}
 
@@ -82,21 +81,15 @@ func (h *HandlerClient) CreateOrUpdate(ctx context.Context, client *identityv1.C
 	// We skip forceSecretRotation to avoid re-entering the Accepted state
 	// (which would cause an Accepted→Completed loop on every reconcile)
 	// and to prevent evicting the original secret from Keycloak's rotated slot.
-	skipForceRotation := false
-	if supportsRotation {
-		if cond := meta.FindStatusCondition(client.GetConditions(), identityv1.SecretRotationConditionType); cond != nil {
-			if cond.ObservedGeneration == client.Generation {
-				skipForceRotation = true
-			}
-		}
-		// Mark rotation as accepted before calling CreateOrReplaceClient.
-		// If the handler returns an error after forceSecretRotation, the
-		// controller persists this condition so that the next reconciliation
-		// can detect the retry and skip the destructive rotation step.
-		if !skipForceRotation {
-			logger.Info("Marking secret rotation as accepted", "client", client.Name)
-			client.SetCondition(identityv1.NewSecretRotationAcceptedCondition())
-		}
+	skipForceRotation := supportsRotation && shouldSkipForceRotation(client)
+
+	// Mark rotation as accepted before calling CreateOrReplaceClient.
+	// If the handler returns an error after forceSecretRotation, the
+	// controller persists this condition so that the next reconciliation
+	// can detect the retry and skip the destructive rotation step.
+	if supportsRotation && !skipForceRotation {
+		logger.Info("Marking secret rotation as accepted", "client", client.Name)
+		client.SetCondition(identityv1.NewSecretRotationAcceptedCondition())
 	}
 
 	err = realmClient.CreateOrReplaceClient(ctx, realm.Name, clientCopy, keycloak.ClientUpdateOptions{
@@ -107,73 +100,8 @@ func (h *HandlerClient) CreateOrUpdate(ctx context.Context, client *identityv1.C
 		return fmt.Errorf("failed to create or update client: %w", err)
 	}
 
-	// --- Graceful rotation: check for a rotated (old) secret ---
-	// Only query rotation state when both the realm and client support it.
-	if supportsRotation {
-		rotationInfo, rotErr := realmClient.GetClientSecretRotationInfo(ctx, realm.Name, clientCopy)
-		if rotErr != nil {
-			return fmt.Errorf("failed to check client secret rotation info: %w", rotErr)
-		}
-
-		if rotationInfo.RotatedSecret != "" {
-			// if the original client secret was a reference, we should not expose the rotated secret in the status, as it may be sensitive.
-			if !secrets.IsRef(client.Spec.ClientSecret) {
-				client.Status.RotatedClientSecret = rotationInfo.RotatedSecret
-			} else {
-				client.Status.RotatedClientSecret = ""
-			}
-
-			// Use the expiration timestamp directly from Keycloak's client
-			// attributes (epoch seconds). This is the final expiry — no grace
-			// period arithmetic is needed on our side.
-			if rotationInfo.RotatedExpiresAt != nil {
-				expiresAt := time.Unix(*rotationInfo.RotatedExpiresAt, 0)
-				client.Status.RotatedSecretExpiresAt = &metav1.Time{Time: expiresAt.UTC()}
-			} else {
-				client.Status.RotatedSecretExpiresAt = nil
-			}
-			if rotationInfo.RotatedCreatedAt != nil {
-				// Only transition to Rotated if the condition is not already
-				// in the Rotated state. This avoids resetting LastTransitionTime
-				// on every reconciliation which would cause a status update loop.
-				existing := meta.FindStatusCondition(client.Status.Conditions, identityv1.SecretRotationConditionType)
-				if existing == nil || existing.Reason != identityv1.SecretRotationReasonRotated {
-					createdAt := time.Unix(*rotationInfo.RotatedCreatedAt, 0)
-					client.SetCondition(identityv1.NewSecretRotatedCondition(createdAt))
-				}
-			}
-
-		} else {
-			logger.Info("No rotated secret in Keycloak, clearing rotation status", "client", client.Name)
-			// No rotation in progress — clear the status fields.
-			client.Status.RotatedClientSecret = ""
-			client.Status.RotatedSecretExpiresAt = nil
-			// Only mark as Completed if a rotation was previously active
-			// (Accepted or Rotated). Avoid setting a misleading condition
-			// on clients that were never rotated.
-			existing := meta.FindStatusCondition(client.Status.Conditions, identityv1.SecretRotationConditionType)
-			if existing != nil {
-				isAccepted := existing.Reason == identityv1.SecretRotationReasonAccepted
-				isRotated := existing.Reason == identityv1.SecretRotationReasonRotated
-				if isAccepted || isRotated {
-					client.SetCondition(identityv1.NewSecretRotationCompletedCondition())
-				}
-			}
-		}
-
-		// --- Current secret expiry: read directly from Keycloak's attribute ---
-		if rotationInfo.SecretExpiresAt != nil {
-			expiresAt := time.Unix(*rotationInfo.SecretExpiresAt, 0)
-			client.Status.SecretExpiresAt = &metav1.Time{Time: expiresAt.UTC()}
-		} else {
-			client.Status.SecretExpiresAt = nil
-		}
-	} else {
-		// Rotation not supported (or was just disabled) — clear any stale
-		// rotation status fields from a previous opt-in.
-		client.Status.RotatedClientSecret = ""
-		client.Status.RotatedSecretExpiresAt = nil
-		client.Status.SecretExpiresAt = nil
+	if err := syncRotationStatus(ctx, client, realmClient, realm.Name, clientCopy, supportsRotation); err != nil {
+		return err
 	}
 
 	client.Status.ClientUid = clientCopy.Status.ClientUid
@@ -181,6 +109,108 @@ func (h *HandlerClient) CreateOrUpdate(ctx context.Context, client *identityv1.C
 	client.SetCondition(condition.NewReadyCondition("Ready", "Client is ready"))
 
 	return nil
+}
+
+// shouldSkipForceRotation reports whether the force-rotation step should be
+// skipped for this reconcile cycle. It returns true when the SecretRotation
+// condition's ObservedGeneration already matches the current generation,
+// indicating that a previous reconciliation already processed the rotation
+// for this spec revision.
+func shouldSkipForceRotation(client *identityv1.Client) bool {
+	cond := meta.FindStatusCondition(client.GetConditions(), identityv1.SecretRotationConditionType)
+	return cond != nil && cond.ObservedGeneration == client.Generation
+}
+
+// syncRotationStatus updates client.Status rotation fields after a successful
+// CreateOrReplaceClient call. When supportsRotation is false it clears any
+// stale fields left from a previous opt-in.
+func syncRotationStatus(ctx context.Context, client *identityv1.Client, realmClient keycloak.KeycloakService, realmName string, clientCopy *identityv1.Client, supportsRotation bool) error {
+	if !supportsRotation {
+		// Rotation not supported (or was just disabled) — clear any stale
+		// rotation status fields from a previous opt-in.
+		client.Status.RotatedClientSecret = ""
+		client.Status.RotatedSecretExpiresAt = nil
+		client.Status.SecretExpiresAt = nil
+		return nil
+	}
+
+	logger := logr.FromContextOrDiscard(ctx)
+
+	rotationInfo, err := realmClient.GetClientSecretRotationInfo(ctx, realmName, clientCopy)
+	if err != nil {
+		return fmt.Errorf("failed to check client secret rotation info: %w", err)
+	}
+
+	if rotationInfo.RotatedSecret != "" {
+		updateActiveRotationStatus(client, rotationInfo)
+	} else {
+		clearRotationStatus(logger, client)
+	}
+
+	// --- Current secret expiry: read directly from Keycloak's attribute ---
+	if rotationInfo.SecretExpiresAt != nil {
+		expiresAt := time.Unix(*rotationInfo.SecretExpiresAt, 0)
+		client.Status.SecretExpiresAt = &metav1.Time{Time: expiresAt.UTC()}
+	} else {
+		client.Status.SecretExpiresAt = nil
+	}
+
+	return nil
+}
+
+// updateActiveRotationStatus sets the rotation status fields when a rotated
+// (old) secret is present in Keycloak. If the original secret was a
+// secret-manager reference the rotated value is not exposed in the status.
+func updateActiveRotationStatus(client *identityv1.Client, rotationInfo *keycloak.ClientSecretRotationInfo) {
+	// Do not expose the plaintext rotated secret when the original was a reference.
+	if !secrets.IsRef(client.Spec.ClientSecret) {
+		client.Status.RotatedClientSecret = rotationInfo.RotatedSecret
+	} else {
+		client.Status.RotatedClientSecret = ""
+	}
+
+	// Use the expiration timestamp directly from Keycloak's client
+	// attributes (epoch seconds). This is the final expiry — no grace
+	// period arithmetic is needed on our side.
+	if rotationInfo.RotatedExpiresAt != nil {
+		expiresAt := time.Unix(*rotationInfo.RotatedExpiresAt, 0)
+		client.Status.RotatedSecretExpiresAt = &metav1.Time{Time: expiresAt.UTC()}
+	} else {
+		client.Status.RotatedSecretExpiresAt = nil
+	}
+
+	if rotationInfo.RotatedCreatedAt != nil {
+		// Only transition to Rotated if the condition is not already
+		// in the Rotated state. This avoids resetting LastTransitionTime
+		// on every reconciliation which would cause a status update loop.
+		existing := meta.FindStatusCondition(client.Status.Conditions, identityv1.SecretRotationConditionType)
+		if existing == nil || existing.Reason != identityv1.SecretRotationReasonRotated {
+			createdAt := time.Unix(*rotationInfo.RotatedCreatedAt, 0)
+			client.SetCondition(identityv1.NewSecretRotatedCondition(createdAt))
+		}
+	}
+}
+
+// clearRotationStatus removes the rotated-secret status fields and, when a
+// rotation was previously active (Accepted or Rotated), transitions the
+// condition to Completed.
+func clearRotationStatus(logger logr.Logger, client *identityv1.Client) {
+	logger.Info("No rotated secret in Keycloak, clearing rotation status", "client", client.Name)
+
+	// No rotation in progress — clear the status fields.
+	client.Status.RotatedClientSecret = ""
+	client.Status.RotatedSecretExpiresAt = nil
+
+	// Only mark as Completed if a rotation was previously active
+	// (Accepted or Rotated). Avoid setting a misleading condition
+	// on clients that were never rotated.
+	existing := meta.FindStatusCondition(client.Status.Conditions, identityv1.SecretRotationConditionType)
+	if existing == nil {
+		return
+	}
+	if existing.Reason == identityv1.SecretRotationReasonAccepted || existing.Reason == identityv1.SecretRotationReasonRotated {
+		client.SetCondition(identityv1.NewSecretRotationCompletedCondition())
+	}
 }
 
 func (h *HandlerClient) Delete(ctx context.Context, obj *identityv1.Client) error {

--- a/identity/internal/handler/client/handler_test.go
+++ b/identity/internal/handler/client/handler_test.go
@@ -10,8 +10,6 @@ import (
 	"fmt"
 	"time"
 
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
 	"github.com/stretchr/testify/mock"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -29,6 +27,9 @@ import (
 	"github.com/telekom/controlplane/identity/pkg/keycloak"
 	"github.com/telekom/controlplane/identity/test/mocks/keycloakservice"
 	secrets "github.com/telekom/controlplane/secret-manager/api"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 )
 
 // notFoundError implements the apierrors.APIStatus interface for testing.
@@ -96,7 +97,6 @@ func mockRealmGet(mockK8s *fake.MockJanitorClient, realm *identityv1.Realm) {
 }
 
 var _ = Describe("HandlerClient", func() {
-
 	var (
 		mockK8s *fake.MockJanitorClient
 		ctx     context.Context
@@ -108,7 +108,6 @@ var _ = Describe("HandlerClient", func() {
 	})
 
 	Context("CreateOrUpdate", func() {
-
 		It("should return an error when the client is nil", func() {
 			handler := NewHandlerClient(keycloak.NewServiceFactory())
 			err := handler.CreateOrUpdate(context.Background(), nil)
@@ -1089,11 +1088,9 @@ var _ = Describe("HandlerClient", func() {
 			Expect(cl.Status.RotatedSecretExpiresAt).To(BeNil())
 			Expect(cl.Status.SecretExpiresAt).To(BeNil())
 		})
-
 	})
 
 	Context("Delete", func() {
-
 		BeforeEach(func() {
 			overrideSecretsGet(func(_ context.Context, _ string) (string, error) {
 				return "resolved-secret", nil
@@ -1194,7 +1191,6 @@ var _ = Describe("HandlerClient", func() {
 	})
 
 	Context("mapToClientStatus", func() {
-
 		It("should set IssuerUrl from realm status", func() {
 			realmStatus := &identityv1.RealmStatus{
 				IssuerUrl: "https://issuer.example.com",

--- a/identity/internal/handler/identityprovider/get.go
+++ b/identity/internal/handler/identityprovider/get.go
@@ -8,17 +8,18 @@ import (
 	"context"
 
 	"github.com/pkg/errors"
+
 	"github.com/telekom/controlplane/common/pkg/client"
 	"github.com/telekom/controlplane/common/pkg/condition"
 	"github.com/telekom/controlplane/common/pkg/errors/ctrlerrors"
 	common "github.com/telekom/controlplane/common/pkg/types"
-
 	identityv1 "github.com/telekom/controlplane/identity/api/v1"
 )
 
 func GetIdentityProviderByName(
 	ctx context.Context,
-	identityProviderRef *common.ObjectRef) (*identityv1.IdentityProvider, error) {
+	identityProviderRef *common.ObjectRef,
+) (*identityv1.IdentityProvider, error) {
 	clientFromContext := client.ClientFromContextOrDie(ctx)
 
 	identityProvider := &identityv1.IdentityProvider{}

--- a/identity/internal/handler/identityprovider/handler.go
+++ b/identity/internal/handler/identityprovider/handler.go
@@ -8,10 +8,10 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/telekom/controlplane/common/pkg/condition"
-	"github.com/telekom/controlplane/common/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
+	"github.com/telekom/controlplane/common/pkg/condition"
+	"github.com/telekom/controlplane/common/pkg/handler"
 	identityv1 "github.com/telekom/controlplane/identity/api/v1"
 	"github.com/telekom/controlplane/identity/pkg/keycloak"
 )
@@ -33,7 +33,7 @@ func (h *HandlerIdentityProvider) CreateOrUpdate(ctx context.Context, idp *ident
 	idp.SetCondition(condition.NewDoneProcessingCondition("Created IdentityProvider"))
 	idp.SetCondition(condition.NewReadyCondition("Ready", "IdentityProvider is ready"))
 
-	var message = fmt.Sprintf("IdentityProvider %s is ready", idp.Name)
+	message := fmt.Sprintf("IdentityProvider %s is ready", idp.Name)
 	logger.V(1).Info(message, "IdentityProviderStatus", idp.Status)
 
 	return nil

--- a/identity/internal/handler/identityprovider/handler_test.go
+++ b/identity/internal/handler/identityprovider/handler_test.go
@@ -7,19 +7,18 @@ package identityprovider
 import (
 	"context"
 
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/telekom/controlplane/common/pkg/condition"
 	identityv1 "github.com/telekom/controlplane/identity/api/v1"
 	"github.com/telekom/controlplane/identity/pkg/keycloak"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("HandlerIdentityProvider", func() {
-
 	Context("CreateOrUpdate", func() {
-
 		It("should return an error when the IdentityProvider is nil", func() {
 			handler := &HandlerIdentityProvider{}
 			err := handler.CreateOrUpdate(context.Background(), nil)

--- a/identity/internal/handler/realm/get.go
+++ b/identity/internal/handler/realm/get.go
@@ -9,13 +9,13 @@ import (
 	"fmt"
 
 	"github.com/pkg/errors"
+
 	"github.com/telekom/controlplane/common/pkg/client"
 	"github.com/telekom/controlplane/common/pkg/condition"
 	"github.com/telekom/controlplane/common/pkg/errors/ctrlerrors"
 	common "github.com/telekom/controlplane/common/pkg/types"
-	secrets "github.com/telekom/controlplane/secret-manager/api"
-
 	identityv1 "github.com/telekom/controlplane/identity/api/v1"
+	secrets "github.com/telekom/controlplane/secret-manager/api"
 )
 
 func GetRealmByName(ctx context.Context, realmRef *common.ObjectRef, resolveSecret bool) (bool, *identityv1.Realm, error) {
@@ -27,7 +27,7 @@ func GetRealmByName(ctx context.Context, realmRef *common.ObjectRef, resolveSecr
 		return false, nil, errors.Wrapf(err, "failed to get realm %s", realmRef.String())
 	}
 
-	if err := condition.EnsureReady(realm); err != nil {
+	if readyErr := condition.EnsureReady(realm); readyErr != nil {
 		return false, nil, ctrlerrors.BlockedErrorf("realm %q is not ready", realmRef.String())
 	}
 

--- a/identity/internal/handler/realm/get_test.go
+++ b/identity/internal/handler/realm/get_test.go
@@ -5,14 +5,13 @@
 package realm
 
 import (
+	identityv1 "github.com/telekom/controlplane/identity/api/v1"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-
-	identityv1 "github.com/telekom/controlplane/identity/api/v1"
 )
 
 var _ = Describe("ValidateRealmStatus", func() {
-
 	It("should return an error when status is nil", func() {
 		err := ValidateRealmStatus(nil)
 		Expect(err).To(HaveOccurred())

--- a/identity/internal/handler/realm/handler.go
+++ b/identity/internal/handler/realm/handler.go
@@ -8,16 +8,15 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/telekom/controlplane/common/pkg/condition"
-	"github.com/telekom/controlplane/common/pkg/errors/ctrlerrors"
-	"github.com/telekom/controlplane/common/pkg/handler"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
+	"github.com/telekom/controlplane/common/pkg/condition"
+	"github.com/telekom/controlplane/common/pkg/errors/ctrlerrors"
+	"github.com/telekom/controlplane/common/pkg/handler"
 	identityv1 "github.com/telekom/controlplane/identity/api/v1"
 	"github.com/telekom/controlplane/identity/internal/handler/identityprovider"
 	"github.com/telekom/controlplane/identity/pkg/keycloak"
-
 	secrets "github.com/telekom/controlplane/secret-manager/api"
 )
 
@@ -105,7 +104,6 @@ func (h *HandlerRealm) CreateOrUpdate(ctx context.Context, realm *identityv1.Rea
 }
 
 func (h *HandlerRealm) Delete(ctx context.Context, realm *identityv1.Realm) error {
-
 	logger := log.FromContext(ctx)
 	logger.Info("RealmHandler Delete", "realm", realm.Name, "namespace", realm.Namespace)
 

--- a/identity/internal/handler/realm/handler_test.go
+++ b/identity/internal/handler/realm/handler_test.go
@@ -10,8 +10,6 @@ import (
 	"fmt"
 	"time"
 
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
 	"github.com/stretchr/testify/mock"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -28,6 +26,9 @@ import (
 	"github.com/telekom/controlplane/identity/pkg/keycloak"
 	"github.com/telekom/controlplane/identity/test/mocks/keycloakservice"
 	secrets "github.com/telekom/controlplane/secret-manager/api"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 )
 
 // notFoundError implements the apierrors interface for testing.
@@ -82,7 +83,6 @@ func newValidRealm() *identityv1.Realm {
 }
 
 var _ = Describe("HandlerRealm", func() {
-
 	var (
 		mockK8s *fake.MockJanitorClient
 		ctx     context.Context
@@ -94,7 +94,6 @@ var _ = Describe("HandlerRealm", func() {
 	})
 
 	Context("CreateOrUpdate", func() {
-
 		It("should return an error when the realm is nil", func() {
 			handler := NewHandlerRealm(keycloak.NewServiceFactory())
 			err := handler.CreateOrUpdate(context.Background(), nil)
@@ -473,7 +472,6 @@ var _ = Describe("HandlerRealm", func() {
 	})
 
 	Context("Delete", func() {
-
 		It("should succeed and not mutate the admin password", func() {
 			realm := newValidRealm()
 			realm.Status = identityv1.RealmStatus{

--- a/identity/internal/testutil/fixtures/client/default.go
+++ b/identity/internal/testutil/fixtures/client/default.go
@@ -5,14 +5,14 @@
 package client
 
 import (
-	"github.com/telekom/controlplane/common/pkg/config"
-	"github.com/telekom/controlplane/common/pkg/types"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/telekom/controlplane/common/pkg/config"
+	"github.com/telekom/controlplane/common/pkg/types"
 	identityv1 "github.com/telekom/controlplane/identity/api/v1"
 )
 
-func NewClientSpec(realmName string, namespace string) *identityv1.ClientSpec {
+func NewClientSpec(realmName, namespace string) *identityv1.ClientSpec {
 	return &identityv1.ClientSpec{
 		Realm: &types.ObjectRef{
 			Name:      realmName,
@@ -23,7 +23,7 @@ func NewClientSpec(realmName string, namespace string) *identityv1.ClientSpec {
 	}
 }
 
-func NewClientMeta(name string, namespace string, environment string) *metav1.ObjectMeta {
+func NewClientMeta(name, namespace, environment string) *metav1.ObjectMeta {
 	return &metav1.ObjectMeta{
 		Name:      name,
 		Namespace: namespace,
@@ -33,7 +33,7 @@ func NewClientMeta(name string, namespace string, environment string) *metav1.Ob
 	}
 }
 
-func NewClient(name string, namespace string, environment string, realmName string) *identityv1.Client {
+func NewClient(name, namespace, environment, realmName string) *identityv1.Client {
 	return &identityv1.Client{
 		ObjectMeta: *NewClientMeta(name, namespace, environment),
 		Spec:       *NewClientSpec(realmName, namespace),

--- a/identity/internal/testutil/fixtures/identityprovider/default.go
+++ b/identity/internal/testutil/fixtures/identityprovider/default.go
@@ -5,9 +5,9 @@
 package identityprovider
 
 import (
-	"github.com/telekom/controlplane/common/pkg/config"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/telekom/controlplane/common/pkg/config"
 	identityv1 "github.com/telekom/controlplane/identity/api/v1"
 )
 
@@ -20,7 +20,7 @@ func NewIdentityProviderSpec() *identityv1.IdentityProviderSpec {
 	}
 }
 
-func NewIdentityProviderMeta(name string, namespace string, environment string) *metav1.ObjectMeta {
+func NewIdentityProviderMeta(name, namespace, environment string) *metav1.ObjectMeta {
 	return &metav1.ObjectMeta{
 		Name:      name,
 		Namespace: namespace,
@@ -30,7 +30,7 @@ func NewIdentityProviderMeta(name string, namespace string, environment string) 
 	}
 }
 
-func NewIdentityProvider(name string, namespace string, environment string) *identityv1.IdentityProvider {
+func NewIdentityProvider(name, namespace, environment string) *identityv1.IdentityProvider {
 	return &identityv1.IdentityProvider{
 		ObjectMeta: *NewIdentityProviderMeta(name, namespace, environment),
 		Spec:       *NewIdentityProviderSpec(),

--- a/identity/internal/testutil/fixtures/realm/default.go
+++ b/identity/internal/testutil/fixtures/realm/default.go
@@ -5,14 +5,14 @@
 package realm
 
 import (
-	"github.com/telekom/controlplane/common/pkg/config"
-	"github.com/telekom/controlplane/common/pkg/types"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/telekom/controlplane/common/pkg/config"
+	"github.com/telekom/controlplane/common/pkg/types"
 	identityv1 "github.com/telekom/controlplane/identity/api/v1"
 )
 
-func NewRealmSpec(identityProviderName string, namespace string) *identityv1.RealmSpec {
+func NewRealmSpec(identityProviderName, namespace string) *identityv1.RealmSpec {
 	return &identityv1.RealmSpec{
 		IdentityProvider: &types.ObjectRef{
 			Name:      identityProviderName,
@@ -21,7 +21,7 @@ func NewRealmSpec(identityProviderName string, namespace string) *identityv1.Rea
 	}
 }
 
-func NewRealmMeta(name string, namespace string, environment string) *metav1.ObjectMeta {
+func NewRealmMeta(name, namespace, environment string) *metav1.ObjectMeta {
 	return &metav1.ObjectMeta{
 		Name:      name,
 		Namespace: namespace,
@@ -31,7 +31,7 @@ func NewRealmMeta(name string, namespace string, environment string) *metav1.Obj
 	}
 }
 
-func NewRealm(name string, namespace string, environment string, identityProviderName string) *identityv1.Realm {
+func NewRealm(name, namespace, environment, identityProviderName string) *identityv1.Realm {
 	return &identityv1.Realm{
 		ObjectMeta: *NewRealmMeta(name, namespace, environment),
 		Spec:       *NewRealmSpec(identityProviderName, namespace),

--- a/identity/pkg/keycloak/client_error.go
+++ b/identity/pkg/keycloak/client_error.go
@@ -112,6 +112,4 @@ func IsNotFound(err error) bool {
 
 // errorAs is a thin wrapper around errors.As to allow testing with the
 // unexported apiError type. Production code uses the standard library.
-var errorAs = func(err error, target interface{}) bool {
-	return stderrors.As(err, target)
-}
+var errorAs = stderrors.As

--- a/identity/pkg/keycloak/client_scopes.go
+++ b/identity/pkg/keycloak/client_scopes.go
@@ -10,10 +10,11 @@ import (
 	"net/http"
 
 	"github.com/go-logr/logr"
+	"k8s.io/utils/ptr"
+
 	identityv1 "github.com/telekom/controlplane/identity/api/v1"
 	"github.com/telekom/controlplane/identity/pkg/api"
 	"github.com/telekom/controlplane/identity/pkg/keycloak/protocolmappers"
-	"k8s.io/utils/ptr"
 )
 
 // ManagedClientScopeName is the name of the Keycloak client scope managed by
@@ -167,8 +168,15 @@ func clientScopeMatchesDesired(existing, desired *api.ClientScopeRepresentation)
 		if !ptrStringEqual(em.ProtocolMapper, dm.ProtocolMapper) {
 			return false
 		}
-		if !protocolMapperConfigEqual(em.Config, dm.Config) {
-			return false
+		switch {
+		case em.Config == nil || dm.Config == nil:
+			if em.Config != dm.Config {
+				return false
+			}
+		default:
+			if !protocolMapperConfigEqual(*em.Config, *dm.Config) {
+				return false
+			}
 		}
 	}
 	return true
@@ -186,18 +194,12 @@ func ptrStringEqual(a, b *string) bool {
 }
 
 // protocolMapperConfigEqual compares two protocol mapper config maps.
-func protocolMapperConfigEqual(a, b *map[string]interface{}) bool {
-	if a == nil && b == nil {
-		return true
-	}
-	if a == nil || b == nil {
+func protocolMapperConfigEqual(a, b map[string]interface{}) bool {
+	if len(a) != len(b) {
 		return false
 	}
-	if len(*a) != len(*b) {
-		return false
-	}
-	for k, va := range *a {
-		vb, ok := (*b)[k]
+	for k, va := range a {
+		vb, ok := b[k]
 		if !ok {
 			return false
 		}
@@ -211,6 +213,8 @@ func protocolMapperConfigEqual(a, b *map[string]interface{}) bool {
 // reconcileProtocolMappers diffs existing vs desired protocol mappers and
 // applies granular create/update/delete operations. This avoids removing the
 // client scope (which would cause a window where tokens lack the claims).
+//
+//nolint:gocyclo // The reconciliation flow keeps create, update, and delete decisions in one place.
 func (k *keycloakService) reconcileProtocolMappers(
 	ctx context.Context,
 	realmName, scopeID string,
@@ -276,8 +280,11 @@ func (k *keycloakService) reconcileProtocolMappers(
 		}
 
 		// Existing mapper — update only if type or config changed.
-		if ptrStringEqual(em.mapper.ProtocolMapper, dm.ProtocolMapper) &&
-			protocolMapperConfigEqual(em.mapper.Config, dm.Config) {
+		configsEqual := em.mapper.Config == nil && dm.Config == nil
+		if em.mapper.Config != nil && dm.Config != nil {
+			configsEqual = protocolMapperConfigEqual(*em.mapper.Config, *dm.Config)
+		}
+		if ptrStringEqual(em.mapper.ProtocolMapper, dm.ProtocolMapper) && configsEqual {
 			continue
 		}
 

--- a/identity/pkg/keycloak/client_scopes_test.go
+++ b/identity/pkg/keycloak/client_scopes_test.go
@@ -7,8 +7,6 @@ package keycloak_test
 import (
 	"context"
 
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
 	"github.com/stretchr/testify/mock"
 	"k8s.io/utils/ptr"
 
@@ -17,6 +15,9 @@ import (
 	"github.com/telekom/controlplane/identity/pkg/keycloak"
 	"github.com/telekom/controlplane/identity/pkg/keycloak/protocolmappers"
 	"github.com/telekom/controlplane/identity/test/mocks/keycloakclient"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 )
 
 const testRealm = "test-realm"
@@ -49,6 +50,8 @@ func emptyDefaultScopesResp() *api.GetRealmDefaultDefaultClientScopesResponse {
 
 // managedScope builds a ClientScopeRepresentation mimicking the managed scope
 // in Keycloak, with the given mappers and a Keycloak-assigned scope ID.
+//
+//nolint:unparam // Keeping the explicit scopeID parameter makes table-style tests easier to read.
 func managedScope(scopeID string, mappers []api.ProtocolMapperRepresentation) api.ClientScopeRepresentation {
 	return api.ClientScopeRepresentation{
 		Id:              ptr.To(scopeID),

--- a/identity/pkg/keycloak/config.go
+++ b/identity/pkg/keycloak/config.go
@@ -12,11 +12,13 @@ import "strings"
 // AdminTokenURL example:
 //			"https://iris-distcp1-dataplane1.dev.dhei.telekom.de/auth/realms/master/protocol/openid-connect/token"
 
-const MasterRealm = "master"
-const TokenEndpointSuffix = "/protocol/openid-connect/token"
-const ConsoleEndpointSuffix = "/console/#/" // + realm name to directly open the realm in the console
+const (
+	MasterRealm           = "master"
+	TokenEndpointSuffix   = "/protocol/openid-connect/token"
+	ConsoleEndpointSuffix = "/console/#/" // + realm name to directly open the realm in the console
+)
 
-func DetermineAdminConsoleUrlFrom(adminUrl string, realmName string) string {
+func DetermineAdminConsoleUrlFrom(adminUrl, realmName string) string {
 	i := strings.Index(adminUrl, "/realms")
 	if i == -1 {
 		return adminUrl + MasterRealm + ConsoleEndpointSuffix + realmName

--- a/identity/pkg/keycloak/factory.go
+++ b/identity/pkg/keycloak/factory.go
@@ -12,10 +12,10 @@ import (
 	"sync"
 	"time"
 
-	commonclient "github.com/telekom/controlplane/common-server/pkg/client"
-	"github.com/telekom/controlplane/common-server/pkg/client/metrics"
 	"golang.org/x/oauth2"
 
+	commonclient "github.com/telekom/controlplane/common-server/pkg/client"
+	"github.com/telekom/controlplane/common-server/pkg/client/metrics"
 	identityv1 "github.com/telekom/controlplane/identity/api/v1"
 	"github.com/telekom/controlplane/identity/pkg/api"
 )
@@ -29,6 +29,7 @@ type ServiceFactory interface {
 // ServiceFactory interface. Useful for tests.
 type ServiceFactoryFunc func(identityv1.RealmStatus) (KeycloakService, error)
 
+//nolint:gocritic // Function adapter preserves the shared ServiceFactory signature.
 func (f ServiceFactoryFunc) ServiceFor(s identityv1.RealmStatus) (KeycloakService, error) {
 	return f(s)
 }
@@ -46,8 +47,9 @@ func NewServiceFactory() ServiceFactory {
 	return &serviceFactory{cache: make(map[string]KeycloakService)}
 }
 
+//nolint:gocritic // ServiceFactory keeps a value-based API for callers.
 func (f *serviceFactory) ServiceFor(status identityv1.RealmStatus) (KeycloakService, error) {
-	key := cacheKey(status)
+	key := cacheKey(&status)
 
 	// Fast path: read lock only.
 	f.mu.RLock()
@@ -65,7 +67,7 @@ func (f *serviceFactory) ServiceFor(status identityv1.RealmStatus) (KeycloakServ
 		return svc, nil
 	}
 
-	svc, err := NewKeycloakServiceFor(status)
+	svc, err := NewKeycloakServiceFor(&status)
 	if err != nil {
 		return nil, err
 	}
@@ -75,17 +77,27 @@ func (f *serviceFactory) ServiceFor(status identityv1.RealmStatus) (KeycloakServ
 }
 
 // cacheKey produces a SHA-256 hex digest of the connection parameters.
-func cacheKey(s identityv1.RealmStatus) string {
+func cacheKey(s *identityv1.RealmStatus) string {
+	if s == nil {
+		return ""
+	}
+
 	h := sha256.New()
-	_, _ = fmt.Fprintf(h, "%s\x00%s\x00%s\x00%s\x00%s",
+	if _, err := fmt.Fprintf(h, "%s\x00%s\x00%s\x00%s\x00%s",
 		s.AdminUrl, s.AdminTokenUrl, s.AdminClientId,
-		s.AdminUserName, s.AdminPassword)
+		s.AdminUserName, s.AdminPassword); err != nil {
+		panic(fmt.Sprintf("write cache key hash: %v", err))
+	}
 	return fmt.Sprintf("%x", h.Sum(nil))
 }
 
 // NewKeycloakServiceFor builds the full HTTP client stack and wraps
 // it in a KeycloakService.
-func NewKeycloakServiceFor(status identityv1.RealmStatus) (KeycloakService, error) {
+func NewKeycloakServiceFor(status *identityv1.RealmStatus) (KeycloakService, error) {
+	if status == nil {
+		return nil, fmt.Errorf("realm status is nil")
+	}
+
 	tokenUrl, err := url.Parse(status.AdminTokenUrl)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse token URL: %w", err)

--- a/identity/pkg/keycloak/graceful_secrets.go
+++ b/identity/pkg/keycloak/graceful_secrets.go
@@ -165,106 +165,125 @@ func (k *keycloakService) DeleteSecretRotationPolicy(ctx context.Context, realmN
 	return nil
 }
 
-// removeSecretRotationProfile removes the "controlplane-secret-rotation"
-// profile from the realm's client-policy profiles. No-op if not present.
-func (k *keycloakService) removeSecretRotationProfile(ctx context.Context, realmName string) error {
+// removeNamedClientPolicyEntry is a generic helper for the GET → filter-by-name → PUT
+// pattern shared by removeSecretRotationProfile and removeSecretRotationPolicyEntry.
+//
+// getItems must return the current items slice together with a put function that
+// persists the updated slice; all error formatting is done inside the closure.
+// getName extracts the Name pointer from an item.
+func removeNamedClientPolicyEntry[T any](
+	ctx context.Context,
+	realmName, label, targetName string,
+	getItems func() (*[]T, func(*[]T) error, error),
+	getName func(T) *string,
+) error {
 	logger := logr.FromContextOrDiscard(ctx)
 
-	getResp, err := k.Client.GetRealmClientPoliciesProfilesWithResponse(
-		ctx, realmName, &api.GetRealmClientPoliciesProfilesParams{})
+	items, putItems, err := getItems()
 	if err != nil {
-		return fmt.Errorf("failed to get client profiles for realm %s: %w", realmName, err)
+		return err
 	}
-	if responseErr := CheckStatusCode(getResp, http.StatusOK); responseErr != nil {
-		return fmt.Errorf("unexpected status getting client profiles for realm %s: %d: %w",
-			realmName, getResp.StatusCode(), responseErr)
-	}
-
-	profiles := getResp.JSON2XX
-	if profiles == nil || profiles.Profiles == nil {
+	if items == nil {
 		return nil
 	}
 
-	filtered := make([]api.ClientProfileRepresentation, 0, len(*profiles.Profiles))
+	filtered := make([]T, 0, len(*items))
 	found := false
-	for _, p := range *profiles.Profiles {
-		if p.Name != nil && *p.Name == secretRotationProfileName {
+	for _, item := range *items {
+		if n := getName(item); n != nil && *n == targetName {
 			found = true
 			continue
 		}
-		filtered = append(filtered, p)
+		filtered = append(filtered, item)
 	}
 
 	if !found {
-		logger.V(1).Info("secret rotation profile not found, nothing to remove", "realm", realmName)
+		logger.V(1).Info("secret rotation "+label+" not found, nothing to remove", "realm", realmName)
 		return nil
 	}
 
-	profiles.Profiles = &filtered
-	profiles.GlobalProfiles = nil
+	logger.V(1).Info("removing secret rotation "+label, "realm", realmName)
+	return putItems(&filtered)
+}
 
-	logger.V(1).Info("removing secret rotation profile", "realm", realmName)
-
-	putResp, err := k.Client.PutRealmClientPoliciesProfilesWithResponse(ctx, realmName, *profiles)
-	if err != nil {
-		return fmt.Errorf("failed to put client profiles for realm %s: %w", realmName, err)
-	}
-	if responseErr := CheckStatusCode(putResp, http.StatusNoContent); responseErr != nil {
-		return fmt.Errorf("unexpected status putting client profiles for realm %s: %d: %w",
-			realmName, putResp.StatusCode(), responseErr)
-	}
-	return nil
+// removeSecretRotationProfile removes the "controlplane-secret-rotation"
+// profile from the realm's client-policy profiles. No-op if not present.
+//
+//nolint:dupl // parallel structure with removeSecretRotationPolicyEntry; differs in API calls and generated types (ClientProfileRepresentation vs ClientPolicyRepresentation)
+func (k *keycloakService) removeSecretRotationProfile(ctx context.Context, realmName string) error {
+	return removeNamedClientPolicyEntry(ctx, realmName,
+		"profile", secretRotationProfileName,
+		func() (*[]api.ClientProfileRepresentation, func(*[]api.ClientProfileRepresentation) error, error) {
+			getResp, err := k.Client.GetRealmClientPoliciesProfilesWithResponse(
+				ctx, realmName, &api.GetRealmClientPoliciesProfilesParams{})
+			if err != nil {
+				return nil, nil, fmt.Errorf("failed to get client profiles for realm %s: %w", realmName, err)
+			}
+			if responseErr := CheckStatusCode(getResp, http.StatusOK); responseErr != nil {
+				return nil, nil, fmt.Errorf("unexpected status getting client profiles for realm %s: %d: %w",
+					realmName, getResp.StatusCode(), responseErr)
+			}
+			profiles := getResp.JSON2XX
+			if profiles == nil {
+				return nil, nil, nil
+			}
+			putFn := func(filtered *[]api.ClientProfileRepresentation) error {
+				profiles.Profiles = filtered
+				profiles.GlobalProfiles = nil
+				putResp, err := k.Client.PutRealmClientPoliciesProfilesWithResponse(ctx, realmName, *profiles)
+				if err != nil {
+					return fmt.Errorf("failed to put client profiles for realm %s: %w", realmName, err)
+				}
+				if responseErr := CheckStatusCode(putResp, http.StatusNoContent); responseErr != nil {
+					return fmt.Errorf("unexpected status putting client profiles for realm %s: %d: %w",
+						realmName, putResp.StatusCode(), responseErr)
+				}
+				return nil
+			}
+			return profiles.Profiles, putFn, nil
+		},
+		func(p api.ClientProfileRepresentation) *string { return p.Name },
+	)
 }
 
 // removeSecretRotationPolicyEntry removes the "controlplane-secret-rotation-policy"
 // from the realm's client policies. No-op if not present.
+//
+//nolint:dupl // parallel structure with removeSecretRotationProfile; differs in API calls and generated types (ClientPolicyRepresentation vs ClientProfileRepresentation)
 func (k *keycloakService) removeSecretRotationPolicyEntry(ctx context.Context, realmName string) error {
-	logger := logr.FromContextOrDiscard(ctx)
-
-	getResp, err := k.Client.GetRealmClientPoliciesPoliciesWithResponse(
-		ctx, realmName, &api.GetRealmClientPoliciesPoliciesParams{})
-	if err != nil {
-		return fmt.Errorf("failed to get client policies for realm %s: %w", realmName, err)
-	}
-	if responseErr := CheckStatusCode(getResp, http.StatusOK); responseErr != nil {
-		return fmt.Errorf("unexpected status getting client policies for realm %s: %d: %w",
-			realmName, getResp.StatusCode(), responseErr)
-	}
-
-	policies := getResp.JSON2XX
-	if policies == nil || policies.Policies == nil {
-		return nil
-	}
-
-	filtered := make([]api.ClientPolicyRepresentation, 0, len(*policies.Policies))
-	found := false
-	for _, p := range *policies.Policies {
-		if p.Name != nil && *p.Name == secretRotationPolicyName {
-			found = true
-			continue
-		}
-		filtered = append(filtered, p)
-	}
-
-	if !found {
-		logger.V(1).Info("secret rotation policy entry not found, nothing to remove", "realm", realmName)
-		return nil
-	}
-
-	policies.Policies = &filtered
-	policies.GlobalPolicies = nil
-
-	logger.V(1).Info("removing secret rotation policy entry", "realm", realmName)
-
-	putResp, err := k.Client.PutRealmClientPoliciesPoliciesWithResponse(ctx, realmName, *policies)
-	if err != nil {
-		return fmt.Errorf("failed to put client policies for realm %s: %w", realmName, err)
-	}
-	if responseErr := CheckStatusCode(putResp, http.StatusNoContent); responseErr != nil {
-		return fmt.Errorf("unexpected status putting client policies for realm %s: %d: %w",
-			realmName, putResp.StatusCode(), responseErr)
-	}
-	return nil
+	return removeNamedClientPolicyEntry(ctx, realmName,
+		"policy entry", secretRotationPolicyName,
+		func() (*[]api.ClientPolicyRepresentation, func(*[]api.ClientPolicyRepresentation) error, error) {
+			getResp, err := k.Client.GetRealmClientPoliciesPoliciesWithResponse(
+				ctx, realmName, &api.GetRealmClientPoliciesPoliciesParams{})
+			if err != nil {
+				return nil, nil, fmt.Errorf("failed to get client policies for realm %s: %w", realmName, err)
+			}
+			if responseErr := CheckStatusCode(getResp, http.StatusOK); responseErr != nil {
+				return nil, nil, fmt.Errorf("unexpected status getting client policies for realm %s: %d: %w",
+					realmName, getResp.StatusCode(), responseErr)
+			}
+			policies := getResp.JSON2XX
+			if policies == nil {
+				return nil, nil, nil
+			}
+			putFn := func(filtered *[]api.ClientPolicyRepresentation) error {
+				policies.Policies = filtered
+				policies.GlobalPolicies = nil
+				putResp, err := k.Client.PutRealmClientPoliciesPoliciesWithResponse(ctx, realmName, *policies)
+				if err != nil {
+					return fmt.Errorf("failed to put client policies for realm %s: %w", realmName, err)
+				}
+				if responseErr := CheckStatusCode(putResp, http.StatusNoContent); responseErr != nil {
+					return fmt.Errorf("unexpected status putting client policies for realm %s: %d: %w",
+						realmName, putResp.StatusCode(), responseErr)
+				}
+				return nil
+			}
+			return policies.Policies, putFn, nil
+		},
+		func(p api.ClientPolicyRepresentation) *string { return p.Name },
+	)
 }
 
 // ensureSecretRotationProfile creates or updates the "controlplane-secret-rotation"

--- a/identity/pkg/keycloak/graceful_secrets.go
+++ b/identity/pkg/keycloak/graceful_secrets.go
@@ -13,10 +13,11 @@ import (
 	"strconv"
 
 	"github.com/go-logr/logr"
+	"k8s.io/utils/ptr"
+
 	identityv1 "github.com/telekom/controlplane/identity/api/v1"
 	"github.com/telekom/controlplane/identity/pkg/api"
 	"github.com/telekom/controlplane/identity/pkg/keycloak/util"
-	"k8s.io/utils/ptr"
 )
 
 // Constants for the managed secret-rotation profile and policy names.
@@ -127,9 +128,9 @@ func (k *keycloakService) ConfigureSecretRotationPolicy(ctx context.Context, rea
 	// ── 1. Ensure the client-policy profile exists ──────────────────────
 
 	params := SecretRotationParams{
-		ExpirationPeriodSeconds:        int(policy.ExpirationPeriod.Duration.Seconds()),
-		RotatedExpirationPeriodSeconds: int(policy.GracePeriod.Duration.Seconds()),
-		RemainingRotationPeriodSeconds: int(policy.RemainingRotationPeriod.Duration.Seconds()),
+		ExpirationPeriodSeconds:        int(policy.ExpirationPeriod.Seconds()),
+		RotatedExpirationPeriodSeconds: int(policy.GracePeriod.Seconds()),
+		RemainingRotationPeriodSeconds: int(policy.RemainingRotationPeriod.Seconds()),
 	}
 
 	if err := k.ensureSecretRotationProfile(ctx, realmName, params); err != nil {
@@ -480,7 +481,10 @@ func marshalPolicyAttributes(key, value string) string {
 		Key   string `json:"key"`
 		Value string `json:"value"`
 	}
-	b, _ := json.Marshal([]kvPair{{Key: key, Value: value}})
+	b, err := json.Marshal([]kvPair{{Key: key, Value: value}})
+	if err != nil {
+		return "[]"
+	}
 	return string(b)
 }
 

--- a/identity/pkg/keycloak/graceful_secrets_test.go
+++ b/identity/pkg/keycloak/graceful_secrets_test.go
@@ -5,18 +5,17 @@
 package keycloak
 
 import (
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
 	"k8s.io/utils/ptr"
 
 	"github.com/telekom/controlplane/identity/pkg/api"
 	"github.com/telekom/controlplane/identity/pkg/keycloak/util"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("GracefulSecrets (pure functions)", func() {
-
 	Describe("epochSecondsFromAttr", func() {
-
 		DescribeTable("should extract or reject epoch-seconds values",
 			func(attrs map[string]interface{}, key string, expected *int64) {
 				got := epochSecondsFromAttr(attrs, key)
@@ -37,7 +36,6 @@ var _ = Describe("GracefulSecrets (pure functions)", func() {
 	})
 
 	Describe("GetSecretCreationTime", func() {
-
 		It("should return nil for nil attrs", func() {
 			Expect(GetSecretCreationTime(nil)).To(BeNil())
 		})
@@ -63,7 +61,6 @@ var _ = Describe("GracefulSecrets (pure functions)", func() {
 	})
 
 	Describe("NewClientSecretRotationInfo", func() {
-
 		It("should handle nil cred and nil client", func() {
 			info := NewClientSecretRotationInfo(nil, nil)
 			Expect(info.RotatedSecret).To(BeEmpty())
@@ -97,7 +94,6 @@ var _ = Describe("GracefulSecrets (pure functions)", func() {
 	})
 
 	Describe("marshalPolicyAttributes", func() {
-
 		It("should produce a JSON array of key-value pairs", func() {
 			result := marshalPolicyAttributes(util.SecretRotationClientAttribute, "true")
 			expected := `[{"key":"` + util.SecretRotationClientAttribute + `","value":"true"}]`

--- a/identity/pkg/keycloak/keycloak_service.go
+++ b/identity/pkg/keycloak/keycloak_service.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 
 	"github.com/go-logr/logr"
+
 	identityv1 "github.com/telekom/controlplane/identity/api/v1"
 	"github.com/telekom/controlplane/identity/pkg/api"
 	"github.com/telekom/controlplane/identity/pkg/keycloak/util"
@@ -31,28 +32,28 @@ type KeycloakClient interface {
 	// Client CRUD operations
 	GetRealmClientsWithResponse(ctx context.Context, realm string, params *api.GetRealmClientsParams,
 		reqEditors ...api.RequestEditorFn) (*api.GetRealmClientsResponse, error)
-	GetRealmClientsIdWithResponse(ctx context.Context, realm string, id string,
+	GetRealmClientsIdWithResponse(ctx context.Context, realm, id string,
 		reqEditors ...api.RequestEditorFn) (*api.GetRealmClientsIdResponse, error)
 	PostRealmClientsWithResponse(ctx context.Context, realm string, body api.PostRealmClientsJSONRequestBody,
 		reqEditors ...api.RequestEditorFn) (*api.PostRealmClientsResponse, error)
-	PutRealmClientsIdWithResponse(ctx context.Context, realm string, id string, body api.PutRealmClientsIdJSONRequestBody,
+	PutRealmClientsIdWithResponse(ctx context.Context, realm, id string, body api.PutRealmClientsIdJSONRequestBody,
 		reqEditors ...api.RequestEditorFn) (*api.PutRealmClientsIdResponse, error)
-	DeleteRealmClientsIdWithResponse(ctx context.Context, realm string, id string,
+	DeleteRealmClientsIdWithResponse(ctx context.Context, realm, id string,
 		reqEditors ...api.RequestEditorFn) (*api.DeleteRealmClientsIdResponse, error)
 
 	// Secret rotation operations
 	// PostRealmClientsIdClientSecretWithResponse regenerates the client secret.
 	// When the secret-rotation executor is active, this moves the current
 	// secret into the "rotated" slot with the configured grace period.
-	PostRealmClientsIdClientSecretWithResponse(ctx context.Context, realm string, id string,
+	PostRealmClientsIdClientSecretWithResponse(ctx context.Context, realm, id string,
 		reqEditors ...api.RequestEditorFn) (*api.PostRealmClientsIdClientSecretResponse, error)
 
-	DeleteRealmClientsIdClientSecretRotatedWithResponse(ctx context.Context, realm string, id string,
+	DeleteRealmClientsIdClientSecretRotatedWithResponse(ctx context.Context, realm, id string,
 		reqEditors ...api.RequestEditorFn) (*api.DeleteRealmClientsIdClientSecretRotatedResponse, error)
 
 	// GetRealmClientsIdClientSecretRotatedWithResponse retrieves the rotated
 	// (old) client secret during a graceful rotation grace period.
-	GetRealmClientsIdClientSecretRotatedWithResponse(ctx context.Context, realm string, id string,
+	GetRealmClientsIdClientSecretRotatedWithResponse(ctx context.Context, realm, id string,
 		reqEditors ...api.RequestEditorFn) (*api.GetRealmClientsIdClientSecretRotatedResponse, error)
 
 	// Client policies operations (secret rotation policy configuration)
@@ -70,23 +71,23 @@ type KeycloakClient interface {
 		reqEditors ...api.RequestEditorFn) (*api.GetRealmClientScopesResponse, error)
 	PostRealmClientScopesWithResponse(ctx context.Context, realm string, body api.PostRealmClientScopesJSONRequestBody,
 		reqEditors ...api.RequestEditorFn) (*api.PostRealmClientScopesResponse, error)
-	DeleteRealmClientScopesIdWithResponse(ctx context.Context, realm string, id string,
+	DeleteRealmClientScopesIdWithResponse(ctx context.Context, realm, id string,
 		reqEditors ...api.RequestEditorFn) (*api.DeleteRealmClientScopesIdResponse, error)
 
 	// Protocol mapper operations on client scopes
-	PostRealmClientScopesIdProtocolMappersModelsWithResponse(ctx context.Context, realm string, id string, body api.PostRealmClientScopesIdProtocolMappersModelsJSONRequestBody,
+	PostRealmClientScopesIdProtocolMappersModelsWithResponse(ctx context.Context, realm, id string, body api.PostRealmClientScopesIdProtocolMappersModelsJSONRequestBody,
 		reqEditors ...api.RequestEditorFn) (*api.PostRealmClientScopesIdProtocolMappersModelsResponse, error)
-	PutRealmClientScopesId1ProtocolMappersModelsId2WithResponse(ctx context.Context, realm string, id1 string, id2 string, body api.PutRealmClientScopesId1ProtocolMappersModelsId2JSONRequestBody,
+	PutRealmClientScopesId1ProtocolMappersModelsId2WithResponse(ctx context.Context, realm, id1, id2 string, body api.PutRealmClientScopesId1ProtocolMappersModelsId2JSONRequestBody,
 		reqEditors ...api.RequestEditorFn) (*api.PutRealmClientScopesId1ProtocolMappersModelsId2Response, error)
-	DeleteRealmClientScopesId1ProtocolMappersModelsId2WithResponse(ctx context.Context, realm string, id1 string, id2 string,
+	DeleteRealmClientScopesId1ProtocolMappersModelsId2WithResponse(ctx context.Context, realm, id1, id2 string,
 		reqEditors ...api.RequestEditorFn) (*api.DeleteRealmClientScopesId1ProtocolMappersModelsId2Response, error)
 
 	// Realm default client scope assignment
 	GetRealmDefaultDefaultClientScopesWithResponse(ctx context.Context, realm string,
 		reqEditors ...api.RequestEditorFn) (*api.GetRealmDefaultDefaultClientScopesResponse, error)
-	PutRealmDefaultDefaultClientScopesClientScopeIdWithResponse(ctx context.Context, realm string, clientScopeId string,
+	PutRealmDefaultDefaultClientScopesClientScopeIdWithResponse(ctx context.Context, realm, clientScopeId string,
 		reqEditors ...api.RequestEditorFn) (*api.PutRealmDefaultDefaultClientScopesClientScopeIdResponse, error)
-	DeleteRealmDefaultDefaultClientScopesClientScopeIdWithResponse(ctx context.Context, realm string, clientScopeId string,
+	DeleteRealmDefaultDefaultClientScopesClientScopeIdWithResponse(ctx context.Context, realm, clientScopeId string,
 		reqEditors ...api.RequestEditorFn) (*api.DeleteRealmDefaultDefaultClientScopesClientScopeIdResponse, error)
 }
 
@@ -139,7 +140,7 @@ func (k *keycloakService) getClient(ctx context.Context, realmName string, clien
 
 	log := logr.FromContextOrDiscard(ctx)
 
-	if len(clientUid) > 0 {
+	if clientUid != "" {
 		clientRes, err := k.Client.GetRealmClientsIdWithResponse(ctx, realmName, clientUid)
 		if err != nil {
 			return nil, fmt.Errorf("unexpected error when fetching client by UID: %w", err)
@@ -234,7 +235,7 @@ func resourceIDFromResponse(resp *http.Response) (string, error) {
 	segments := strings.Split(strings.TrimRight(locURL.Path, "/"), "/")
 	id := segments[len(segments)-1]
 	if id == "" {
-		return "", fmt.Errorf("Location header %q did not contain a resource ID", location)
+		return "", fmt.Errorf("location header %q did not contain a resource ID", location)
 	}
 	return id, nil
 }
@@ -325,9 +326,9 @@ func (k *keycloakService) CreateOrReplaceRealm(ctx context.Context, realm *ident
 		}
 		merged := util.MergeRealmRepresentation(existing, &desired)
 		body := *merged
-		res, err := k.Client.PutRealmWithResponse(ctx, realm.Name, body)
-		if err != nil {
-			return fmt.Errorf("error updating realm: %w", err)
+		res, putErr := k.Client.PutRealmWithResponse(ctx, realm.Name, body)
+		if putErr != nil {
+			return fmt.Errorf("error updating realm: %w", putErr)
 		}
 		if responseErr := CheckHTTPStatus(res.StatusCode(), 204); responseErr != nil {
 			return fmt.Errorf("updating realm: %w", responseErr)

--- a/identity/pkg/keycloak/keycloak_service_test.go
+++ b/identity/pkg/keycloak/keycloak_service_test.go
@@ -10,8 +10,6 @@ import (
 	"net/http"
 	"time"
 
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
 	"github.com/stretchr/testify/mock"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
@@ -20,6 +18,9 @@ import (
 	"github.com/telekom/controlplane/identity/pkg/api"
 	"github.com/telekom/controlplane/identity/pkg/keycloak"
 	"github.com/telekom/controlplane/identity/test/mocks/keycloakclient"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 )
 
 // helper to build a minimal http.Response with a given status code.
@@ -28,6 +29,8 @@ func httpResp(code int) *http.Response {
 }
 
 // helper to build a minimal http.Response with a Location header.
+//
+//nolint:unparam // Shared test helper keeps the status code argument for readability at call sites.
 func httpRespWithLocation(code int, location string) *http.Response {
 	return &http.Response{
 		StatusCode: code,
@@ -42,12 +45,14 @@ func newIdentityClient(clientId, secret string) *identityv1.Client {
 	}
 }
 
+//nolint:unparam // The helper mirrors the test data shape used throughout this suite.
 func newIdentityClientWithUID(clientId, secret, uid string) *identityv1.Client {
 	c := newIdentityClient(clientId, secret)
 	c.Status.ClientUid = uid
 	return c
 }
 
+//nolint:unparam // The name parameter keeps the helper flexible and self-documenting in tests.
 func newRealm(name string) *identityv1.Realm {
 	return &identityv1.Realm{
 		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default"},
@@ -56,12 +61,11 @@ func newRealm(name string) *identityv1.Realm {
 
 func newMockClient() *keycloakclient.MockKeycloakClient {
 	m := &keycloakclient.MockKeycloakClient{}
-	m.Mock.Test(GinkgoT())
+	m.Test(GinkgoT())
 	return m
 }
 
 var _ = Describe("KeycloakService", func() {
-
 	var (
 		mockClient *keycloakclient.MockKeycloakClient
 		svc        keycloak.KeycloakService
@@ -77,9 +81,7 @@ var _ = Describe("KeycloakService", func() {
 	// ── CreateOrReplaceClient ──────────────────────────────────────────
 
 	Describe("CreateOrReplaceClient", func() {
-
 		Context("when client does not exist (create path)", func() {
-
 			BeforeEach(func() {
 				// getClient returns empty list (no UID on client, search by clientId)
 				mockClient.EXPECT().GetRealmClientsWithResponse(mock.Anything, "realm1", mock.Anything).
@@ -135,7 +137,6 @@ var _ = Describe("KeycloakService", func() {
 		})
 
 		Context("when client exists (update path)", func() {
-
 			It("should update existing client and set UID in status", func() {
 				client := newIdentityClient("my-app", "new-secret")
 				existing := api.ClientRepresentation{
@@ -335,7 +336,6 @@ var _ = Describe("KeycloakService", func() {
 		})
 
 		Context("when client lookup by UID succeeds", func() {
-
 			It("should find client by UID and update", func() {
 				client := newIdentityClientWithUID("my-app", "new-secret", "uuid-123")
 				mockClient.EXPECT().GetRealmClientsIdWithResponse(mock.Anything, "realm1", "uuid-123").
@@ -371,7 +371,6 @@ var _ = Describe("KeycloakService", func() {
 		})
 
 		Context("when getClient fails", func() {
-
 			DescribeTable("should propagate error",
 				func(networkErr error, expectedSubstring string) {
 					client := newIdentityClient("my-app", "secret")
@@ -439,7 +438,6 @@ var _ = Describe("KeycloakService", func() {
 	// ── CreateOrReplaceRealm ───────────────────────────────────────────
 
 	Describe("CreateOrReplaceRealm", func() {
-
 		It("should create a new realm when it does not exist", func() {
 			realm := newRealm("my-realm")
 			mockClient.EXPECT().GetRealmWithResponse(mock.Anything, "my-realm").
@@ -510,7 +508,6 @@ var _ = Describe("KeycloakService", func() {
 	// ── DeleteClient ───────────────────────────────────────────────────
 
 	Describe("DeleteClient", func() {
-
 		It("should skip deletion when client does not exist", func() {
 			client := newIdentityClient("my-app", "secret")
 			mockClient.EXPECT().GetRealmClientsWithResponse(mock.Anything, "realm1", mock.Anything).
@@ -566,7 +563,6 @@ var _ = Describe("KeycloakService", func() {
 	// ── DeleteRealm ────────────────────────────────────────────────────
 
 	Describe("DeleteRealm", func() {
-
 		DescribeTable("should handle various status codes",
 			func(statusCode int, expectErr bool) {
 				mockClient.EXPECT().DeleteRealmWithResponse(mock.Anything, "realm1").
@@ -597,7 +593,6 @@ var _ = Describe("KeycloakService", func() {
 	// ── ConfigureSecretRotationPolicy ──────────────────────────────────
 
 	Describe("ConfigureSecretRotationPolicy", func() {
-
 		policy := &identityv1.SecretRotationConfig{
 			ExpirationPeriod:        metav1.Duration{Duration: 29 * 24 * time.Hour},
 			GracePeriod:             metav1.Duration{Duration: 1 * time.Hour},
@@ -605,7 +600,6 @@ var _ = Describe("KeycloakService", func() {
 		}
 
 		Context("when profiles and policies do not exist yet", func() {
-
 			It("should create both profile and policy", func() {
 				mockClient.EXPECT().GetRealmClientPoliciesProfilesWithResponse(mock.Anything, "realm1", mock.Anything).
 					Return(&api.GetRealmClientPoliciesProfilesResponse{
@@ -628,7 +622,6 @@ var _ = Describe("KeycloakService", func() {
 		})
 
 		Context("when profiles and policies already exist", func() {
-
 			It("should update existing profile and policy in place", func() {
 				existingProfile := api.ClientProfileRepresentation{
 					Name: ptr.To("controlplane-secret-rotation"),
@@ -662,7 +655,6 @@ var _ = Describe("KeycloakService", func() {
 		})
 
 		Context("when GET profiles returns nil JSON2XX", func() {
-
 			It("should handle nil response body gracefully", func() {
 				mockClient.EXPECT().GetRealmClientPoliciesProfilesWithResponse(mock.Anything, "realm1", mock.Anything).
 					Return(&api.GetRealmClientPoliciesProfilesResponse{
@@ -996,7 +988,6 @@ var _ = Describe("KeycloakService", func() {
 	// ── GetClientSecretRotationInfo ────────────────────────────────────
 
 	Describe("GetClientSecretRotationInfo", func() {
-
 		It("should return info with no rotated secret when 404", func() {
 			client := newIdentityClient("my-app", "secret")
 			mockClient.EXPECT().GetRealmClientsWithResponse(mock.Anything, "realm1", mock.Anything).

--- a/identity/pkg/keycloak/keycloak_service_test.go
+++ b/identity/pkg/keycloak/keycloak_service_test.go
@@ -769,9 +769,7 @@ var _ = Describe("KeycloakService", func() {
 	// ── DeleteSecretRotationPolicy ────────────────────────────────────
 
 	Describe("DeleteSecretRotationPolicy", func() {
-
 		Context("when profile and policy entries exist", func() {
-
 			It("should remove the profile and policy", func() {
 				existingProfile := api.ClientProfileRepresentation{
 					Name: ptr.To("controlplane-secret-rotation"),
@@ -822,7 +820,6 @@ var _ = Describe("KeycloakService", func() {
 		})
 
 		Context("when profile and policy entries do not exist (no-op)", func() {
-
 			It("should be a no-op when profiles list is nil", func() {
 				mockClient.EXPECT().GetRealmClientPoliciesProfilesWithResponse(mock.Anything, "realm1", mock.Anything).
 					Return(&api.GetRealmClientPoliciesProfilesResponse{

--- a/identity/pkg/keycloak/protocolmappers/client_id.go
+++ b/identity/pkg/keycloak/protocolmappers/client_id.go
@@ -18,12 +18,12 @@ func NewClientIdProtocolMapper() api.ProtocolMapperRepresentation {
 		Protocol:       toPtr("openid-connect"),
 		ProtocolMapper: toPtr("oidc-usersessionmodel-note-mapper"),
 		Config: &map[string]interface{}{
-			"user.session.note":    "clientId",
-			"id.token.claim":       "true",
-			"access.token.claim":   "true",
-			"userinfo.token.claim": "false",
-			"claim.name":           "clientId",
-			"jsonType.label":       "String",
+			"user.session.note":         "clientId",
+			idTokenClaimConfigKey:       stringTrue,
+			accessTokenClaimConfigKey:   stringTrue,
+			userInfoTokenClaimConfigKey: stringFalse,
+			claimNameConfigKey:          "clientId",
+			jsonTypeLabelConfigKey:      jsonTypeLabelString,
 		},
 	}
 }

--- a/identity/pkg/keycloak/protocolmappers/constants.go
+++ b/identity/pkg/keycloak/protocolmappers/constants.go
@@ -1,0 +1,17 @@
+// Copyright 2025 Deutsche Telekom IT GmbH
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package protocolmappers
+
+//nolint:gosec // These are protocol mapper config keys, not credentials.
+const (
+	claimNameConfigKey          = "claim.name"
+	jsonTypeLabelConfigKey      = "jsonType.label"
+	jsonTypeLabelString         = "String"
+	idTokenClaimConfigKey       = "id.token.claim"
+	accessTokenClaimConfigKey   = "access.token.claim"
+	userInfoTokenClaimConfigKey = "userinfo.token.claim"
+	stringTrue                  = "true"
+	stringFalse                 = "false"
+)

--- a/identity/pkg/keycloak/protocolmappers/hardcoded_claim.go
+++ b/identity/pkg/keycloak/protocolmappers/hardcoded_claim.go
@@ -19,12 +19,12 @@ func NewHardcodedClaimMapper(claimName, claimValue string) api.ProtocolMapperRep
 		Protocol:       toPtr("openid-connect"),
 		ProtocolMapper: toPtr("oidc-hardcoded-claim-mapper"),
 		Config: &map[string]interface{}{
-			"claim.name":           claimName,
-			"claim.value":          claimValue,
-			"jsonType.label":       "String",
-			"id.token.claim":       "true",
-			"access.token.claim":   "true",
-			"userinfo.token.claim": "false",
+			claimNameConfigKey:          claimName,
+			"claim.value":               claimValue,
+			jsonTypeLabelConfigKey:      jsonTypeLabelString,
+			idTokenClaimConfigKey:       stringTrue,
+			accessTokenClaimConfigKey:   stringTrue,
+			userInfoTokenClaimConfigKey: stringFalse,
 		},
 	}
 }

--- a/identity/pkg/keycloak/protocolmappers/session_note.go
+++ b/identity/pkg/keycloak/protocolmappers/session_note.go
@@ -25,12 +25,12 @@ func NewSessionNoteMapper(claimName, sessionNoteKey string) api.ProtocolMapperRe
 		Protocol:       toPtr("openid-connect"),
 		ProtocolMapper: toPtr("oidc-usersessionmodel-note-mapper"),
 		Config: &map[string]interface{}{
-			"user.session.note":    sessionNoteKey,
-			"claim.name":           claimName,
-			"jsonType.label":       "String",
-			"id.token.claim":       "true",
-			"access.token.claim":   "true",
-			"userinfo.token.claim": "false",
+			"user.session.note":         sessionNoteKey,
+			claimNameConfigKey:          claimName,
+			jsonTypeLabelConfigKey:      jsonTypeLabelString,
+			idTokenClaimConfigKey:       stringTrue,
+			accessTokenClaimConfigKey:   stringTrue,
+			userInfoTokenClaimConfigKey: stringFalse,
 		},
 	}
 }

--- a/identity/pkg/keycloak/util/client.go
+++ b/identity/pkg/keycloak/util/client.go
@@ -29,7 +29,10 @@ func GetClient(getRealmClients api.GetRealmClientsResponse) (*api.ClientRepresen
 // SecretRotationClientAttribute is the Keycloak client attribute key used by
 // the client-attributes policy condition to identify clients that opted into
 // graceful secret rotation.
-const SecretRotationClientAttribute = "controlplane.secret-rotation"
+const (
+	SecretRotationClientAttribute = "controlplane.secret-rotation"
+	stringTrue                    = "true"
+)
 
 func MapToClientRepresentation(client *identityv1.Client) api.ClientRepresentation {
 	rep := api.ClientRepresentation{
@@ -45,7 +48,7 @@ func MapToClientRepresentation(client *identityv1.Client) api.ClientRepresentati
 
 	if client.SupportsSecretRotation() {
 		rep.Attributes = &map[string]interface{}{
-			SecretRotationClientAttribute: "true",
+			SecretRotationClientAttribute: stringTrue,
 		}
 	}
 
@@ -93,8 +96,8 @@ func getSecretRotationAttr(c *api.ClientRepresentation) string {
 	if !ok {
 		return ""
 	}
-	if s, ok := v.(string); ok && s == "true" {
-		return "true"
+	if s, ok := v.(string); ok && s == stringTrue {
+		return stringTrue
 	}
 	return ""
 }
@@ -125,11 +128,9 @@ func MergeClientRepresentation(existingClient, newClient *api.ClientRepresentati
 			existingClient.Attributes = &map[string]interface{}{}
 		}
 		(*existingClient.Attributes)[SecretRotationClientAttribute] = (*newClient.Attributes)[SecretRotationClientAttribute]
-	} else {
+	} else if existingClient.Attributes != nil {
 		// New client doesn't set the attribute — remove it from existing if present.
-		if existingClient.Attributes != nil {
-			delete(*existingClient.Attributes, SecretRotationClientAttribute)
-		}
+		delete(*existingClient.Attributes, SecretRotationClientAttribute)
 	}
 
 	return existingClient

--- a/identity/pkg/keycloak/util/client_test.go
+++ b/identity/pkg/keycloak/util/client_test.go
@@ -7,10 +7,11 @@ package util
 import (
 	"testing"
 
-	identityv1 "github.com/telekom/controlplane/identity/api/v1"
-	"github.com/telekom/controlplane/identity/pkg/api"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
+
+	identityv1 "github.com/telekom/controlplane/identity/api/v1"
+	"github.com/telekom/controlplane/identity/pkg/api"
 )
 
 func TestMapToClientRepresentation_SetsAttributeByDefault(t *testing.T) {

--- a/identity/pkg/keycloak/util/protocolmapper.go
+++ b/identity/pkg/keycloak/util/protocolmapper.go
@@ -48,7 +48,8 @@ func CompareProtocolMapperRepresentation(existingMapper, newMapper *api.Protocol
 }
 
 func MergeProtocolMappers(existingMappers,
-	newMappers *[]api.ProtocolMapperRepresentation) *[]api.ProtocolMapperRepresentation {
+	newMappers *[]api.ProtocolMapperRepresentation,
+) *[]api.ProtocolMapperRepresentation {
 	if newMappers == nil {
 		return existingMappers
 	}
@@ -73,7 +74,8 @@ func MergeProtocolMappers(existingMappers,
 }
 
 func MergeProtocolMapperRepresentation(existingMapper,
-	newMapper *api.ProtocolMapperRepresentation) *api.ProtocolMapperRepresentation {
+	newMapper *api.ProtocolMapperRepresentation,
+) *api.ProtocolMapperRepresentation {
 	// ID stays the same
 	existingMapper.Name = newMapper.Name
 	existingMapper.Protocol = newMapper.Protocol

--- a/identity/test/utils/mocks.go
+++ b/identity/test/utils/mocks.go
@@ -19,10 +19,11 @@ import (
 )
 
 const (
-	Realm          = "test-realm"
-	RealmForClient = "realm-test-client"
-	ClientId       = "test-client"
-	ClientSecret   = "test-secret"
+	Realm              = "test-realm"
+	RealmForClient     = "realm-test-client"
+	ClientId           = "test-client"
+	ClientSecret       = "test-secret"
+	protocolMapperTrue = "true"
 )
 
 func NewKeycloakClientMock(testing ginkgo.FullGinkgoTInterface) *keycloakclient.MockKeycloakClient {
@@ -31,12 +32,15 @@ func NewKeycloakClientMock(testing ginkgo.FullGinkgoTInterface) *keycloakclient.
 	// DeferCleanup() in Ginkgo. When called from BeforeSuite, this creates a
 	// nested DeferCleanup-inside-DeferCleanup which Ginkgo forbids.
 	mockKeycloakClient := &keycloakclient.MockKeycloakClient{}
-	mockKeycloakClient.Mock.Test(testing)
+	mockKeycloakClient.Test(testing)
 	return mockKeycloakClient
 }
 
 func ConfigureKeycloakClientMock(mockedClient *keycloakclient.MockKeycloakClient) {
-	var mockedBody, _ = io.ReadAll(io.NopCloser(strings.NewReader(fmt.Sprintf(`{"realm":"%s"}`, Realm))))
+	mockedBody, err := io.ReadAll(io.NopCloser(strings.NewReader(fmt.Sprintf(`{"realm":%q}`, Realm))))
+	if err != nil {
+		panic(fmt.Sprintf("read mocked realm body: %v", err))
+	}
 
 	// The parameter "reqEditors ...RequestEditorFn" is not used in the implementation and therefore omitted
 	// in the mock configuration.
@@ -271,21 +275,21 @@ func mockPostResponse(body []byte) *api.PostResponse {
 }
 
 func mockGetRealmClientsWithResponse(body []byte, clientId, clientSecret string) *api.GetRealmClientsResponse {
-	var protocolMapper = api.ProtocolMapperRepresentation{
+	protocolMapper := api.ProtocolMapperRepresentation{
 		Name:           ptr.To("Client ID"),
 		Protocol:       ptr.To("openid-connect"),
 		ProtocolMapper: ptr.To("oidc-usersessionmodel-note-mapper"),
 		Config: &map[string]interface{}{
 			"user.session.note":    "clientId",
-			"id.token.claim":       "true",
-			"access.token.claim":   "true",
-			"userinfo.token.claim": "true",
+			"id.token.claim":       protocolMapperTrue,
+			"access.token.claim":   protocolMapperTrue,
+			"userinfo.token.claim": protocolMapperTrue,
 			"claim.name":           "clientId",
 			"jsonType.label":       "String",
 		},
 	}
 
-	var clientRepresentation = api.ClientRepresentation{
+	clientRepresentation := api.ClientRepresentation{
 		Id:                     ptr.To("mock-client-uuid"),
 		ClientId:               ptr.To(clientId),
 		Name:                   ptr.To(clientId),

--- a/identity/test/utils/mocks.go
+++ b/identity/test/utils/mocks.go
@@ -235,7 +235,6 @@ func ConfigureKeycloakClientMock(mockedClient *keycloakclient.MockKeycloakClient
 		Return(&api.PutRealmClientPoliciesPoliciesResponse{
 			HTTPResponse: ptr.To(http.Response{StatusCode: http.StatusNoContent}),
 		}, nil).Maybe()
-
 }
 
 func mockGetRealmResponse(realm string, body []byte) *api.GetRealmResponse {


### PR DESCRIPTION
This PR aims to resolve golangci-lint issues across the identity module, primarily via small refactors, error-handling cleanups, and consistent constant usage. It also tightens CI lint enforcement for the identity workflow.

Changes:
- Refactor identity Keycloak-related code to satisfy lint rules (errcheck/unparam/gocyclo, import grouping, reduced duplication). 
- Introduce shared constants for Keycloak protocol-mapper configuration keys/values and replace repeated string literals.
- Update CI and tooling configuration to fail the lint step on issues and install golangci-lint using the v2 module path.
