### PR TITLE
fix(secret-manager): invalidate cached children on parent update

### DIFF
--- a/secret-manager/pkg/backend/cache/backend.go
+++ b/secret-manager/pkg/backend/cache/backend.go
@@ -115,6 +115,20 @@ func (c *CachedBackend[T, S]) registerChild(id T) {
 	actual.(*sync.Map).Store(childKey, struct{}{})
 }
 
+// unregisterChild removes a sub-secret's cache key from its parent's tracking
+// set. This prevents unbounded growth of the children map when sub-secrets are
+// deleted without the parent being updated.
+func (c *CachedBackend[T, S]) unregisterChild(id T) {
+	if id.SubPath() == backend.NoSubPath {
+		return
+	}
+	parentKey := id.ParentId().CacheKey()
+	childKey := id.CacheKey()
+	if childMap, ok := c.children.Load(parentKey); ok {
+		childMap.(*sync.Map).Delete(childKey)
+	}
+}
+
 // invalidateChildren removes all cached sub-secret entries derived from a parent
 // secret when the parent is written or deleted. This prevents stale reads of
 // sub-secrets after the parent document is updated directly.
@@ -142,6 +156,7 @@ func (c *CachedBackend[T, S]) Delete(ctx context.Context, id T) error {
 	c.Cache.Del(cacheKey)
 	c.invalidateParent(id)
 	c.invalidateChildren(id)
+	c.unregisterChild(id)
 	return c.Backend.Delete(ctx, id)
 }
 
@@ -235,9 +250,9 @@ func (c *CachedBackend[T, S]) Set(ctx context.Context, id T, value backend.Secre
 		log.Info("Failed to add item to cache", "id", cacheKey)
 	}
 	c.group.Forget(cacheKey)
-	c.registerChild(id)
-	c.invalidateParent(id)
 	c.invalidateChildren(id)
+	c.invalidateParent(id)
+	c.registerChild(id)
 
 	return item, nil
 }

--- a/secret-manager/pkg/backend/cache/backend.go
+++ b/secret-manager/pkg/backend/cache/backend.go
@@ -6,6 +6,7 @@ package cache
 
 import (
 	"context"
+	"sync"
 	"time"
 
 	"github.com/dgraph-io/ristretto/v2"
@@ -18,10 +19,11 @@ import (
 var _ backend.Backend[backend.SecretId, backend.Secret[backend.SecretId]] = (*CachedBackend[backend.SecretId, backend.Secret[backend.SecretId]])(nil)
 
 type CachedBackend[T backend.SecretId, S backend.Secret[T]] struct {
-	Backend backend.Backend[T, S]
-	Cache   *ristretto.Cache[string, S]
-	ttl     time.Duration
-	group   singleflight.Group
+	Backend  backend.Backend[T, S]
+	Cache    *ristretto.Cache[string, S]
+	ttl      time.Duration
+	group    singleflight.Group
+	children sync.Map // parentCacheKey -> *sync.Map (childCacheKey -> struct{})
 }
 
 type CacheOptions struct {
@@ -101,12 +103,45 @@ func (c *CachedBackend[T, S]) invalidateParent(id T) {
 	}
 }
 
+// registerChild records a sub-secret's cache key under its parent so that
+// the sub-secret can be invalidated when the parent is updated.
+func (c *CachedBackend[T, S]) registerChild(id T) {
+	if id.SubPath() == backend.NoSubPath {
+		return
+	}
+	parentKey := id.ParentId().CacheKey()
+	childKey := id.CacheKey()
+	actual, _ := c.children.LoadOrStore(parentKey, &sync.Map{})
+	actual.(*sync.Map).Store(childKey, struct{}{})
+}
+
+// invalidateChildren removes all cached sub-secret entries derived from a parent
+// secret when the parent is written or deleted. This prevents stale reads of
+// sub-secrets after the parent document is updated directly.
+func (c *CachedBackend[T, S]) invalidateChildren(id T) {
+	if id.SubPath() != backend.NoSubPath {
+		return
+	}
+	parentKey := id.CacheKey()
+	childMap, ok := c.children.LoadAndDelete(parentKey)
+	if !ok {
+		return
+	}
+	childMap.(*sync.Map).Range(func(key, _ any) bool {
+		childKey := key.(string)
+		c.group.Forget(childKey)
+		c.Cache.Del(childKey)
+		return true
+	})
+}
+
 // Delete implements backend.Backend.
 func (c *CachedBackend[T, S]) Delete(ctx context.Context, id T) error {
 	cacheKey := id.CacheKey()
 	c.group.Forget(cacheKey)
 	c.Cache.Del(cacheKey)
 	c.invalidateParent(id)
+	c.invalidateChildren(id)
 	return c.Backend.Delete(ctx, id)
 }
 
@@ -152,6 +187,7 @@ func (c *CachedBackend[T, S]) Get(ctx context.Context, id T) (S, error) {
 	if !added {
 		log.Info("Failed to add item to cache", "id", cacheKey)
 	}
+	c.registerChild(id)
 	// Always return a copy since singleflight shares the result across callers
 	return item.Copy().(S), nil
 }
@@ -199,7 +235,9 @@ func (c *CachedBackend[T, S]) Set(ctx context.Context, id T, value backend.Secre
 		log.Info("Failed to add item to cache", "id", cacheKey)
 	}
 	c.group.Forget(cacheKey)
+	c.registerChild(id)
 	c.invalidateParent(id)
+	c.invalidateChildren(id)
 
 	return item, nil
 }

--- a/secret-manager/pkg/backend/cache/backend_test.go
+++ b/secret-manager/pkg/backend/cache/backend_test.go
@@ -55,6 +55,7 @@ var _ = Describe("Cached Backend cache", func() {
 			secretId := mocks.NewMockSecretId(GinkgoT())
 			secretId.EXPECT().CacheKey().Return("my-secret-id")
 			secretId.EXPECT().String().Return("my-secret-id").Maybe()
+			secretId.EXPECT().SubPath().Return("").Maybe()
 
 			secret := backend.NewDefaultSecret(secretId, "my-value")
 			mockBackend.On("Get", mock.Anything, secretId).Return(secret, nil).Once()
@@ -163,6 +164,7 @@ var _ = Describe("Cached Backend cache", func() {
 			secretId := mocks.NewMockSecretId(GinkgoT())
 			secretId.EXPECT().CacheKey().Return("my-secret-id")
 			secretId.EXPECT().String().Return("my-secret-id").Maybe()
+			secretId.EXPECT().SubPath().Return("").Maybe()
 
 			mockBackend := &mocks.MockBackend[*mocks.MockSecretId, backend.DefaultSecret[*mocks.MockSecretId]]{}
 			mockBackend.Test(GinkgoT())
@@ -304,6 +306,7 @@ var _ = Describe("Cached Backend cache", func() {
 			secretId := mocks.NewMockSecretId(GinkgoT())
 			secretId.EXPECT().CacheKey().Return("ctx-cancel-id")
 			secretId.EXPECT().String().Return("ctx-cancel-id").Maybe()
+			secretId.EXPECT().SubPath().Return("").Maybe()
 
 			mockBackend := &mocks.MockBackend[*mocks.MockSecretId, backend.DefaultSecret[*mocks.MockSecretId]]{}
 			mockBackend.Test(GinkgoT())
@@ -466,6 +469,115 @@ var _ = Describe("Cached Backend cache", func() {
 			Expect(found).To(BeFalse(), "parent cache entry should be invalidated after sub-secret Delete")
 		})
 
+		It("should invalidate sub-secret cache entries when setting the parent secret", func() {
+			ctx := context.Background()
+
+			// Create the parent secret ID (no sub-path)
+			parentSecretId := mocks.NewMockSecretId(GinkgoT())
+			parentSecretId.EXPECT().CacheKey().Return("env:team:app:externalSecrets")
+			parentSecretId.EXPECT().String().Return("env:team:app:externalSecrets:").Maybe()
+			parentSecretId.EXPECT().Copy().Return(parentSecretId).Once()
+			parentSecretId.EXPECT().SubPath().Return("")
+
+			// Create two sub-secret IDs
+			subSecretId1 := mocks.NewMockSecretId(GinkgoT())
+			subSecretId1.EXPECT().CacheKey().Return("env:team:app:externalSecrets/key1")
+			subSecretId1.EXPECT().String().Return("env:team:app:externalSecrets/key1:abc").Maybe()
+			subSecretId1.EXPECT().SubPath().Return("key1")
+			subSecretId1.EXPECT().ParentId().Return(parentSecretId)
+
+			subSecretId2 := mocks.NewMockSecretId(GinkgoT())
+			subSecretId2.EXPECT().CacheKey().Return("env:team:app:externalSecrets/key2")
+			subSecretId2.EXPECT().String().Return("env:team:app:externalSecrets/key2:def").Maybe()
+			subSecretId2.EXPECT().SubPath().Return("key2")
+			subSecretId2.EXPECT().ParentId().Return(parentSecretId)
+
+			mockBackend := &mocks.MockBackend[*mocks.MockSecretId, backend.DefaultSecret[*mocks.MockSecretId]]{}
+			mockBackend.Test(GinkgoT())
+			GinkgoT().Cleanup(func() { mockBackend.AssertExpectations(GinkgoT()) })
+
+			cachedBackend := cache.NewCachedBackend(mockBackend, cache.WithTTL(10*time.Second))
+
+			// Simulate sub-secrets being cached via Get
+			mockBackend.On("Get", mock.Anything, subSecretId1).
+				Return(backend.NewDefaultSecret(subSecretId1, "old-value1"), nil).Once()
+			mockBackend.On("Get", mock.Anything, subSecretId2).
+				Return(backend.NewDefaultSecret(subSecretId2, "old-value2"), nil).Once()
+
+			_, err := cachedBackend.Get(ctx, subSecretId1)
+			Expect(err).NotTo(HaveOccurred())
+			_, err = cachedBackend.Get(ctx, subSecretId2)
+			Expect(err).NotTo(HaveOccurred())
+			cachedBackend.Cache.Wait()
+
+			// Verify both sub-secrets are cached
+			_, found := cachedBackend.Cache.Get("env:team:app:externalSecrets/key1")
+			Expect(found).To(BeTrue(), "sub-secret key1 should be in cache")
+			_, found = cachedBackend.Cache.Get("env:team:app:externalSecrets/key2")
+			Expect(found).To(BeTrue(), "sub-secret key2 should be in cache")
+
+			// Now update the parent secret directly
+			newParentValue := backend.String(`{"key1":"new-value1","key2":"new-value2"}`)
+			mockBackend.EXPECT().Set(ctx, parentSecretId, newParentValue).
+				Return(backend.NewDefaultSecret(parentSecretId, `{"key1":"new-value1","key2":"new-value2"}`), nil).Once()
+
+			_, err = cachedBackend.Set(ctx, parentSecretId, newParentValue)
+			Expect(err).NotTo(HaveOccurred())
+			cachedBackend.Cache.Wait()
+
+			// Both sub-secret cache entries should have been invalidated
+			_, found = cachedBackend.Cache.Get("env:team:app:externalSecrets/key1")
+			Expect(found).To(BeFalse(), "sub-secret key1 should be invalidated after parent Set")
+			_, found = cachedBackend.Cache.Get("env:team:app:externalSecrets/key2")
+			Expect(found).To(BeFalse(), "sub-secret key2 should be invalidated after parent Set")
+		})
+
+		It("should invalidate sub-secret cache entries when deleting the parent secret", func() {
+			ctx := context.Background()
+
+			// Create the parent secret ID (no sub-path)
+			parentSecretId := mocks.NewMockSecretId(GinkgoT())
+			parentSecretId.EXPECT().CacheKey().Return("env:team:app:externalSecrets")
+			parentSecretId.EXPECT().String().Return("env:team:app:externalSecrets:").Maybe()
+			parentSecretId.EXPECT().SubPath().Return("")
+
+			// Create a sub-secret ID
+			subSecretId := mocks.NewMockSecretId(GinkgoT())
+			subSecretId.EXPECT().CacheKey().Return("env:team:app:externalSecrets/key1")
+			subSecretId.EXPECT().String().Return("env:team:app:externalSecrets/key1:abc").Maybe()
+			subSecretId.EXPECT().SubPath().Return("key1")
+			subSecretId.EXPECT().ParentId().Return(parentSecretId)
+
+			mockBackend := &mocks.MockBackend[*mocks.MockSecretId, backend.DefaultSecret[*mocks.MockSecretId]]{}
+			mockBackend.Test(GinkgoT())
+			GinkgoT().Cleanup(func() { mockBackend.AssertExpectations(GinkgoT()) })
+
+			cachedBackend := cache.NewCachedBackend(mockBackend, cache.WithTTL(10*time.Second))
+
+			// Simulate sub-secret being cached via Get
+			mockBackend.On("Get", mock.Anything, subSecretId).
+				Return(backend.NewDefaultSecret(subSecretId, "old-value"), nil).Once()
+
+			_, err := cachedBackend.Get(ctx, subSecretId)
+			Expect(err).NotTo(HaveOccurred())
+			cachedBackend.Cache.Wait()
+
+			// Verify sub-secret is cached
+			_, found := cachedBackend.Cache.Get("env:team:app:externalSecrets/key1")
+			Expect(found).To(BeTrue(), "sub-secret should be in cache")
+
+			// Delete the parent secret
+			mockBackend.EXPECT().Delete(ctx, parentSecretId).Return(nil).Once()
+
+			err = cachedBackend.Delete(ctx, parentSecretId)
+			Expect(err).NotTo(HaveOccurred())
+			cachedBackend.Cache.Wait()
+
+			// Sub-secret cache entry should have been invalidated
+			_, found = cachedBackend.Cache.Get("env:team:app:externalSecrets/key1")
+			Expect(found).To(BeFalse(), "sub-secret should be invalidated after parent Delete")
+		})
+
 		It("should use stable cache key regardless of checksum", func() {
 			ctx := context.Background()
 
@@ -473,10 +585,12 @@ var _ = Describe("Cached Backend cache", func() {
 			secretId1 := mocks.NewMockSecretId(GinkgoT())
 			secretId1.EXPECT().CacheKey().Return("env:team:app:path")
 			secretId1.EXPECT().String().Return("env:team:app:path:checksum1").Maybe()
+			secretId1.EXPECT().SubPath().Return("").Maybe()
 
 			secretId2 := mocks.NewMockSecretId(GinkgoT())
 			secretId2.EXPECT().CacheKey().Return("env:team:app:path")
 			secretId2.EXPECT().String().Return("env:team:app:path:checksum2").Maybe()
+			secretId2.EXPECT().SubPath().Return("").Maybe()
 
 			mockBackend := &mocks.MockBackend[*mocks.MockSecretId, backend.DefaultSecret[*mocks.MockSecretId]]{}
 			mockBackend.Test(GinkgoT())

--- a/secret-manager/pkg/backend/cache/backend_test.go
+++ b/secret-manager/pkg/backend/cache/backend_test.go
@@ -54,7 +54,7 @@ var _ = Describe("Cached Backend cache", func() {
 
 			secretId := mocks.NewMockSecretId(GinkgoT())
 			secretId.EXPECT().CacheKey().Return("my-secret-id")
-			secretId.EXPECT().String().Return("my-secret-id").Maybe()
+			secretId.EXPECT().String().Return("my-secret-id")
 			secretId.EXPECT().SubPath().Return("").Maybe()
 
 			secret := backend.NewDefaultSecret(secretId, "my-value")
@@ -71,7 +71,7 @@ var _ = Describe("Cached Backend cache", func() {
 
 			secretId := mocks.NewMockSecretId(GinkgoT())
 			secretId.EXPECT().CacheKey().Return("my-secret-id")
-			secretId.EXPECT().String().Return("my-secret-id").Maybe()
+			secretId.EXPECT().String().Return("my-secret-id")
 
 			mockBackend.On("Get", mock.Anything, secretId).Return(backend.DefaultSecret[*mocks.MockSecretId]{}, backend.ErrSecretNotFound(secretId)).Once()
 
@@ -87,7 +87,7 @@ var _ = Describe("Cached Backend cache", func() {
 			secretValue := backend.String("my-value")
 			secretId := mocks.NewMockSecretId(GinkgoT())
 			secretId.EXPECT().CacheKey().Return("my-secret-id")
-			secretId.EXPECT().String().Return("my-secret-id").Maybe()
+			secretId.EXPECT().String().Return("my-secret-id")
 			secretId.EXPECT().Copy().Return(secretId).Once()
 			secretId.EXPECT().SubPath().Return("")
 
@@ -104,7 +104,7 @@ var _ = Describe("Cached Backend cache", func() {
 			ctx := context.Background()
 			secretId := mocks.NewMockSecretId(GinkgoT())
 			secretId.EXPECT().CacheKey().Return("my-secret-id")
-			secretId.EXPECT().String().Return("my-secret-id").Maybe()
+			secretId.EXPECT().String().Return("my-secret-id")
 			secretId.EXPECT().SubPath().Return("")
 
 			mockBackend.EXPECT().Delete(ctx, secretId).Return(nil).Once()
@@ -117,7 +117,7 @@ var _ = Describe("Cached Backend cache", func() {
 			ctx := context.Background()
 			secretId := mocks.NewMockSecretId(GinkgoT())
 			secretId.EXPECT().CacheKey().Return("empty-value-id")
-			secretId.EXPECT().String().Return("empty-value-id").Maybe()
+			secretId.EXPECT().String().Return("empty-value-id")
 			secretId.EXPECT().Copy().Return(secretId).Once()
 
 			emptyValue := backend.String("")
@@ -137,7 +137,7 @@ var _ = Describe("Cached Backend cache", func() {
 			ctx := context.Background()
 			secretId := mocks.NewMockSecretId(GinkgoT())
 			secretId.EXPECT().CacheKey().Return("size-test-id")
-			secretId.EXPECT().String().Return("size-test-id").Maybe()
+			secretId.EXPECT().String().Return("size-test-id")
 			secretId.EXPECT().Copy().Return(secretId).Once()
 			secretId.EXPECT().SubPath().Return("")
 
@@ -163,7 +163,7 @@ var _ = Describe("Cached Backend cache", func() {
 
 			secretId := mocks.NewMockSecretId(GinkgoT())
 			secretId.EXPECT().CacheKey().Return("my-secret-id")
-			secretId.EXPECT().String().Return("my-secret-id").Maybe()
+			secretId.EXPECT().String().Return("my-secret-id")
 			secretId.EXPECT().SubPath().Return("").Maybe()
 
 			mockBackend := &mocks.MockBackend[*mocks.MockSecretId, backend.DefaultSecret[*mocks.MockSecretId]]{}
@@ -218,7 +218,7 @@ var _ = Describe("Cached Backend cache", func() {
 
 			secretId := mocks.NewMockSecretId(GinkgoT())
 			secretId.EXPECT().CacheKey().Return("err-secret-id")
-			secretId.EXPECT().String().Return("err-secret-id").Maybe()
+			secretId.EXPECT().String().Return("err-secret-id")
 
 			mockBackend := &mocks.MockBackend[*mocks.MockSecretId, backend.DefaultSecret[*mocks.MockSecretId]]{}
 			mockBackend.Test(GinkgoT())
@@ -266,7 +266,7 @@ var _ = Describe("Cached Backend cache", func() {
 
 			secretId := mocks.NewMockSecretId(GinkgoT())
 			secretId.EXPECT().CacheKey().Return("forget-secret-id")
-			secretId.EXPECT().String().Return("forget-secret-id").Maybe()
+			secretId.EXPECT().String().Return("forget-secret-id")
 			secretId.EXPECT().SubPath().Return("").Maybe()
 			secretId.EXPECT().Copy().Return(secretId).Maybe()
 
@@ -305,7 +305,7 @@ var _ = Describe("Cached Backend cache", func() {
 
 			secretId := mocks.NewMockSecretId(GinkgoT())
 			secretId.EXPECT().CacheKey().Return("ctx-cancel-id")
-			secretId.EXPECT().String().Return("ctx-cancel-id").Maybe()
+			secretId.EXPECT().String().Return("ctx-cancel-id")
 			secretId.EXPECT().SubPath().Return("").Maybe()
 
 			mockBackend := &mocks.MockBackend[*mocks.MockSecretId, backend.DefaultSecret[*mocks.MockSecretId]]{}
@@ -384,12 +384,11 @@ var _ = Describe("Cached Backend cache", func() {
 			// Create the parent secret ID
 			parentSecretId := mocks.NewMockSecretId(GinkgoT())
 			parentSecretId.EXPECT().CacheKey().Return("env:team:app:externalSecrets")
-			parentSecretId.EXPECT().String().Return("env:team:app:externalSecrets:").Maybe()
 
 			// Create the sub-secret ID
 			subSecretId := mocks.NewMockSecretId(GinkgoT())
 			subSecretId.EXPECT().CacheKey().Return("env:team:app:externalSecrets/key1")
-			subSecretId.EXPECT().String().Return("env:team:app:externalSecrets/key1:abc123").Maybe()
+			subSecretId.EXPECT().String().Return("env:team:app:externalSecrets/key1")
 			subSecretId.EXPECT().Copy().Return(subSecretId).Once()
 			subSecretId.EXPECT().SubPath().Return("key1")
 			subSecretId.EXPECT().ParentId().Return(parentSecretId)
@@ -431,12 +430,11 @@ var _ = Describe("Cached Backend cache", func() {
 			// Create the parent secret ID
 			parentSecretId := mocks.NewMockSecretId(GinkgoT())
 			parentSecretId.EXPECT().CacheKey().Return("env:team:app:externalSecrets")
-			parentSecretId.EXPECT().String().Return("env:team:app:externalSecrets:").Maybe()
 
 			// Create the sub-secret ID
 			subSecretId := mocks.NewMockSecretId(GinkgoT())
 			subSecretId.EXPECT().CacheKey().Return("env:team:app:externalSecrets/key1")
-			subSecretId.EXPECT().String().Return("env:team:app:externalSecrets/key1:abc123").Maybe()
+			subSecretId.EXPECT().String().Return("env:team:app:externalSecrets/key1")
 			subSecretId.EXPECT().SubPath().Return("key1")
 			subSecretId.EXPECT().ParentId().Return(parentSecretId)
 
@@ -475,20 +473,20 @@ var _ = Describe("Cached Backend cache", func() {
 			// Create the parent secret ID (no sub-path)
 			parentSecretId := mocks.NewMockSecretId(GinkgoT())
 			parentSecretId.EXPECT().CacheKey().Return("env:team:app:externalSecrets")
-			parentSecretId.EXPECT().String().Return("env:team:app:externalSecrets:").Maybe()
+			parentSecretId.EXPECT().String().Return("env:team:app:externalSecrets")
 			parentSecretId.EXPECT().Copy().Return(parentSecretId).Once()
 			parentSecretId.EXPECT().SubPath().Return("")
 
 			// Create two sub-secret IDs
 			subSecretId1 := mocks.NewMockSecretId(GinkgoT())
 			subSecretId1.EXPECT().CacheKey().Return("env:team:app:externalSecrets/key1")
-			subSecretId1.EXPECT().String().Return("env:team:app:externalSecrets/key1:abc").Maybe()
+			subSecretId1.EXPECT().String().Return("env:team:app:externalSecrets/key1")
 			subSecretId1.EXPECT().SubPath().Return("key1")
 			subSecretId1.EXPECT().ParentId().Return(parentSecretId)
 
 			subSecretId2 := mocks.NewMockSecretId(GinkgoT())
 			subSecretId2.EXPECT().CacheKey().Return("env:team:app:externalSecrets/key2")
-			subSecretId2.EXPECT().String().Return("env:team:app:externalSecrets/key2:def").Maybe()
+			subSecretId2.EXPECT().String().Return("env:team:app:externalSecrets/key2")
 			subSecretId2.EXPECT().SubPath().Return("key2")
 			subSecretId2.EXPECT().ParentId().Return(parentSecretId)
 
@@ -538,13 +536,13 @@ var _ = Describe("Cached Backend cache", func() {
 			// Create the parent secret ID (no sub-path)
 			parentSecretId := mocks.NewMockSecretId(GinkgoT())
 			parentSecretId.EXPECT().CacheKey().Return("env:team:app:externalSecrets")
-			parentSecretId.EXPECT().String().Return("env:team:app:externalSecrets:").Maybe()
+			parentSecretId.EXPECT().String().Return("env:team:app:externalSecrets")
 			parentSecretId.EXPECT().SubPath().Return("")
 
 			// Create a sub-secret ID
 			subSecretId := mocks.NewMockSecretId(GinkgoT())
 			subSecretId.EXPECT().CacheKey().Return("env:team:app:externalSecrets/key1")
-			subSecretId.EXPECT().String().Return("env:team:app:externalSecrets/key1:abc").Maybe()
+			subSecretId.EXPECT().String().Return("env:team:app:externalSecrets/key1")
 			subSecretId.EXPECT().SubPath().Return("key1")
 			subSecretId.EXPECT().ParentId().Return(parentSecretId)
 
@@ -584,12 +582,11 @@ var _ = Describe("Cached Backend cache", func() {
 			// Two secret IDs with different checksums but same logical identity
 			secretId1 := mocks.NewMockSecretId(GinkgoT())
 			secretId1.EXPECT().CacheKey().Return("env:team:app:path")
-			secretId1.EXPECT().String().Return("env:team:app:path:checksum1").Maybe()
+			secretId1.EXPECT().String().Return("env:team:app:path:checksum1")
 			secretId1.EXPECT().SubPath().Return("").Maybe()
 
 			secretId2 := mocks.NewMockSecretId(GinkgoT())
 			secretId2.EXPECT().CacheKey().Return("env:team:app:path")
-			secretId2.EXPECT().String().Return("env:team:app:path:checksum2").Maybe()
 			secretId2.EXPECT().SubPath().Return("").Maybe()
 
 			mockBackend := &mocks.MockBackend[*mocks.MockSecretId, backend.DefaultSecret[*mocks.MockSecretId]]{}


### PR DESCRIPTION
This PR adds the fix in the secret-manager cached backend to invalidate all **known** children on parent change. A child in known if it has been requested via Get or Set previously. 

This implementation assumes the amount of children is small as it will allocate a new entry in a sync.Map for each.