### PR TITLE
ci(file-manager): enable lint_fail_on_issues

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -95,6 +95,7 @@ jobs:
       run_check_generated_files: false
       ko_build_path: "cmd/server/server.go"
       coverage_threshold: 61
+      lint_fail_on_issues: true
 
   gateway:
     name: Gateway


### PR DESCRIPTION
Enable lint_fail_on_issues for the file-manager domain. The module already passes golangci-lint with 0 issues