### PR TITLE
fix(api): resolve all golangci-lint issues

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -153,6 +153,7 @@ jobs:
       module: api
       run_check_generated_files: true
       ko_build_path: "cmd/main.go"
+      lint_fail_on_issues: true
 
   rover:
     name: Rover

--- a/api/Makefile
+++ b/api/Makefile
@@ -158,7 +158,7 @@ $(ENVTEST): $(LOCALBIN)
 .PHONY: golangci-lint
 golangci-lint: $(GOLANGCI_LINT) ## Download golangci-lint locally if necessary.
 $(GOLANGCI_LINT): $(LOCALBIN)
-	$(call go-install-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/cmd/golangci-lint,$(GOLANGCI_LINT_VERSION))
+	$(call go-install-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/v2/cmd/golangci-lint,$(GOLANGCI_LINT_VERSION))
 
 # go-install-tool will 'go install' any package with custom target and name of binary, if it doesn't exist
 # $1 - target path with name of binary

--- a/api/cmd/main.go
+++ b/api/cmd/main.go
@@ -9,14 +9,11 @@ import (
 	"flag"
 	"os"
 
-	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
-	// to ensure that exec-entrypoint and run can make use of them.
-	"go.uber.org/zap/zapcore"
-	_ "k8s.io/client-go/plugin/pkg/client/auth"
-	"sigs.k8s.io/controller-runtime/pkg/client/config"
 
+	"go.uber.org/zap/zapcore"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/filters"
@@ -25,6 +22,10 @@ import (
 
 	"github.com/telekom/controlplane/api/internal/controller"
 	"github.com/telekom/controlplane/api/internal/handler/remoteapisubscription/syncer"
+
+    // Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
+    // to ensure that exec-entrypoint and run can make use of them.
+	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	// +kubebuilder:scaffold:imports
 )
 

--- a/api/cmd/main.go
+++ b/api/cmd/main.go
@@ -9,7 +9,6 @@ import (
 	"flag"
 	"os"
 
-
 	"go.uber.org/zap/zapcore"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -23,8 +22,8 @@ import (
 	"github.com/telekom/controlplane/api/internal/controller"
 	"github.com/telekom/controlplane/api/internal/handler/remoteapisubscription/syncer"
 
-    // Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
-    // to ensure that exec-entrypoint and run can make use of them.
+	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
+	// to ensure that exec-entrypoint and run can make use of them.
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	// +kubebuilder:scaffold:imports
 )

--- a/api/internal/controller/api_controller.go
+++ b/api/internal/controller/api_controller.go
@@ -7,10 +7,6 @@ package controller
 import (
 	"context"
 
-	apiapi "github.com/telekom/controlplane/api/api/v1"
-	"github.com/telekom/controlplane/api/internal/handler/api"
-	cconfig "github.com/telekom/controlplane/common/pkg/config"
-	cc "github.com/telekom/controlplane/common/pkg/controller"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -21,6 +17,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	apiapi "github.com/telekom/controlplane/api/api/v1"
+	"github.com/telekom/controlplane/api/internal/handler/api"
+	cconfig "github.com/telekom/controlplane/common/pkg/config"
+	cc "github.com/telekom/controlplane/common/pkg/controller"
 )
 
 // ApiReconciler reconciles a Api object
@@ -59,31 +60,33 @@ func (r *ApiReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Complete(r)
 }
 
+//nolint:dupl // controller map helpers intentionally mirror each other
 func (r *ApiReconciler) MapApiToApi(ctx context.Context, obj client.Object) []reconcile.Request {
-	log := log.FromContext(ctx)
+	logger := log.FromContext(ctx)
 
-	api, ok := obj.(*apiapi.Api)
+	apiObj, ok := obj.(*apiapi.Api)
 	if !ok {
-		log.Info("object is not an API")
+		logger.Info("object is not an API")
 		return nil
 	}
 
 	list := &apiapi.ApiList{}
-	err := r.Client.List(ctx, list, client.MatchingLabels{
-		cconfig.EnvironmentLabelKey: api.Labels[cconfig.EnvironmentLabelKey],
-		apiapi.BasePathLabelKey:     api.Labels[apiapi.BasePathLabelKey],
+	err := r.List(ctx, list, client.MatchingLabels{
+		cconfig.EnvironmentLabelKey: apiObj.Labels[cconfig.EnvironmentLabelKey],
+		apiapi.BasePathLabelKey:     apiObj.Labels[apiapi.BasePathLabelKey],
 	})
 	if err != nil {
-		log.Error(err, "failed to list API-Subscriptions")
+		logger.Error(err, "failed to list API-Subscriptions")
 		return nil
 	}
 
 	reqs := make([]reconcile.Request, 0, len(list.Items))
-	for _, item := range list.Items {
-		if api.UID == item.UID {
+	for i := range list.Items {
+		item := &list.Items[i]
+		if apiObj.UID == item.UID {
 			continue
 		}
-		reqs = append(reqs, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(&item)})
+		reqs = append(reqs, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(item)})
 	}
 
 	return reqs

--- a/api/internal/controller/api_controller_test.go
+++ b/api/internal/controller/api_controller_test.go
@@ -6,14 +6,15 @@ package controller
 import (
 	"time"
 
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
 	apiv1 "github.com/telekom/controlplane/api/api/v1"
 	"github.com/telekom/controlplane/common/pkg/condition"
 	"github.com/telekom/controlplane/common/pkg/config"
 	"github.com/telekom/controlplane/common/pkg/test/testutil"
 	"github.com/telekom/controlplane/common/pkg/util/labelutil"
-	"k8s.io/apimachinery/pkg/api/meta"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -41,10 +42,8 @@ func NewApi(apiBasePath string) *apiv1.Api {
 }
 
 var _ = Describe("Api Controller", Ordered, func() {
-
 	Context("Creating, Updating and ActiveSwitch", Ordered, func() {
-
-		var apiBasePath = "/apictrl/test/v1"
+		apiBasePath := "/apictrl/test/v1"
 		var firstApi *apiv1.Api
 		var secondApi *apiv1.Api
 
@@ -71,7 +70,6 @@ var _ = Describe("Api Controller", Ordered, func() {
 				g.Expect(err).ToNot(HaveOccurred())
 				g.Expect(firstApi.Status.Active).To(BeTrue())
 				testutil.ExpectConditionToBeTrue(g, meta.FindStatusCondition(firstApi.GetConditions(), condition.ConditionTypeReady), "ApiActive")
-
 			}, timeout, interval).Should(Succeed())
 		})
 
@@ -89,7 +87,6 @@ var _ = Describe("Api Controller", Ordered, func() {
 				g.Expect(err).ToNot(HaveOccurred())
 				testutil.ExpectConditionToBeFalse(g, meta.FindStatusCondition(secondApi.GetConditions(), condition.ConditionTypeReady), "ApiNotActive")
 				g.Expect(secondApi.Status.Active).To(BeFalse())
-
 			}, timeout, interval).Should(Succeed())
 		})
 
@@ -104,15 +101,12 @@ var _ = Describe("Api Controller", Ordered, func() {
 				g.Expect(err).ToNot(HaveOccurred())
 				g.Expect(secondApi.Status.Active).To(BeTrue())
 				testutil.ExpectConditionToBeTrue(g, meta.FindStatusCondition(secondApi.GetConditions(), condition.ConditionTypeReady), "ApiActive")
-
 			}, timeout, interval).Should(Succeed())
 		})
-
 	})
 
 	Context("Validating the basePath", Ordered, func() {
-
-		var apiBasePath = "/apictrl/test1/v1"
+		apiBasePath := "/apictrl/test1/v1"
 		var firstApi *apiv1.Api
 		var secondApi *apiv1.Api
 
@@ -142,7 +136,6 @@ var _ = Describe("Api Controller", Ordered, func() {
 				g.Expect(err).ToNot(HaveOccurred())
 				g.Expect(firstApi.Status.Active).To(BeTrue())
 				testutil.ExpectConditionToBeTrue(g, meta.FindStatusCondition(firstApi.GetConditions(), condition.ConditionTypeReady), "ApiActive")
-
 			}, timeout, interval).Should(Succeed())
 		})
 
@@ -160,9 +153,7 @@ var _ = Describe("Api Controller", Ordered, func() {
 				g.Expect(err).ToNot(HaveOccurred())
 				testutil.ExpectConditionToBeFalse(g, meta.FindStatusCondition(secondApi.GetConditions(), condition.ConditionTypeReady), "ApiNotActiveCaseConflict")
 				g.Expect(secondApi.Status.Active).To(BeFalse())
-
 			}, timeout, interval).Should(Succeed())
 		})
-
 	})
 })

--- a/api/internal/controller/apicategory_controller_test.go
+++ b/api/internal/controller/apicategory_controller_test.go
@@ -5,15 +5,15 @@
 package controller
 
 import (
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	apiv1 "github.com/telekom/controlplane/api/api/v1"
 	"github.com/telekom/controlplane/common/pkg/config"
 	"github.com/telekom/controlplane/common/pkg/util/labelutil"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 )
 
 func NewApiCategory(name string) *apiv1.ApiCategory {
@@ -39,9 +39,7 @@ func NewApiCategory(name string) *apiv1.ApiCategory {
 }
 
 var _ = Describe("ApiCategory Controller", func() {
-
 	Context("Creating", func() {
-
 		apiCategory := NewApiCategory("test-category")
 
 		It("should successfully provision the API category resource", func() {
@@ -57,7 +55,6 @@ var _ = Describe("ApiCategory Controller", func() {
 				g.Expect(fetchedCategory.Spec.Active).To(BeTrue())
 
 				g.Expect(fetchedCategory.Status.Conditions).To(HaveLen(2))
-
 			}, timeout, interval).Should(Succeed())
 		})
 	})

--- a/api/internal/controller/apiexposure_controller.go
+++ b/api/internal/controller/apiexposure_controller.go
@@ -7,12 +7,6 @@ package controller
 import (
 	"context"
 
-	adminv1 "github.com/telekom/controlplane/admin/api/v1"
-	apiv1 "github.com/telekom/controlplane/api/api/v1"
-	"github.com/telekom/controlplane/api/internal/handler/apiexposure"
-	cconfig "github.com/telekom/controlplane/common/pkg/config"
-	cc "github.com/telekom/controlplane/common/pkg/controller"
-	gatewayv1 "github.com/telekom/controlplane/gateway/api/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -23,6 +17,13 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	adminv1 "github.com/telekom/controlplane/admin/api/v1"
+	apiv1 "github.com/telekom/controlplane/api/api/v1"
+	"github.com/telekom/controlplane/api/internal/handler/apiexposure"
+	cconfig "github.com/telekom/controlplane/common/pkg/config"
+	cc "github.com/telekom/controlplane/common/pkg/controller"
+	gatewayv1 "github.com/telekom/controlplane/gateway/api/v1"
 )
 
 // ApiExposureReconciler reconciles a ApiExposure object
@@ -81,63 +82,68 @@ func (r *ApiExposureReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		).
 		WithOptions(controller.Options{
 			MaxConcurrentReconciles: cconfig.MaxConcurrentReconciles,
-			RateLimiter:             cc.NewRateLimiter()}).
+			RateLimiter:             cc.NewRateLimiter(),
+		}).
 		Complete(r)
 }
 
+//nolint:dupl // controller map helpers intentionally mirror each other
 func (r *ApiExposureReconciler) MapApiToApiExposure(ctx context.Context, obj client.Object) []reconcile.Request {
-	log := log.FromContext(ctx)
-	api, ok := obj.(*apiv1.Api)
+	logger := log.FromContext(ctx)
+	apiObj, ok := obj.(*apiv1.Api)
 	if !ok {
-		log.Info("object is not an API")
+		logger.Info("object is not an API")
 		return nil
 	}
 
 	list := &apiv1.ApiExposureList{}
-	err := r.Client.List(ctx, list, client.MatchingLabels{
-		cconfig.EnvironmentLabelKey: api.Labels[cconfig.EnvironmentLabelKey],
-		apiv1.BasePathLabelKey:      api.Labels[apiv1.BasePathLabelKey],
+	err := r.List(ctx, list, client.MatchingLabels{
+		cconfig.EnvironmentLabelKey: apiObj.Labels[cconfig.EnvironmentLabelKey],
+		apiv1.BasePathLabelKey:      apiObj.Labels[apiv1.BasePathLabelKey],
 	})
 	if err != nil {
-		log.Error(err, "failed to list API-Exposures")
+		logger.Error(err, "failed to list API-Exposures")
 		return nil
 	}
 
 	reqs := make([]reconcile.Request, 0, len(list.Items))
-	for _, item := range list.Items {
-		if api.UID == item.UID {
+	for i := range list.Items {
+		item := &list.Items[i]
+		if apiObj.UID == item.UID {
 			continue
 		}
-		reqs = append(reqs, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(&item)})
+		reqs = append(reqs, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(item)})
 	}
 
 	return reqs
 }
 
+//nolint:dupl // controller map helpers intentionally mirror each other
 func (r *ApiExposureReconciler) MapApiExposureToApiExposure(ctx context.Context, obj client.Object) []reconcile.Request {
-	log := log.FromContext(ctx)
+	logger := log.FromContext(ctx)
 	apiExposure, ok := obj.(*apiv1.ApiExposure)
 	if !ok {
-		log.Info("object is not an ApiExposure")
+		logger.Info("object is not an ApiExposure")
 		return nil
 	}
 
 	list := &apiv1.ApiExposureList{}
-	err := r.Client.List(ctx, list, client.MatchingLabels{
+	err := r.List(ctx, list, client.MatchingLabels{
 		cconfig.EnvironmentLabelKey: apiExposure.Labels[cconfig.EnvironmentLabelKey],
 		apiv1.BasePathLabelKey:      apiExposure.Labels[apiv1.BasePathLabelKey],
 	})
 	if err != nil {
-		log.Error(err, "failed to list API-Exposures")
+		logger.Error(err, "failed to list API-Exposures")
 		return nil
 	}
 
 	reqs := make([]reconcile.Request, 0, len(list.Items))
-	for _, item := range list.Items {
+	for i := range list.Items {
+		item := &list.Items[i]
 		if apiExposure.UID == item.UID {
 			continue
 		}
-		reqs = append(reqs, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(&item)})
+		reqs = append(reqs, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(item)})
 	}
 
 	return reqs
@@ -154,26 +160,27 @@ func (r *ApiExposureReconciler) MapZoneToApiExposure(ctx context.Context, obj cl
 // MapApiSubscriptionToApiExposure triggers re-reconciliation of ApiExposures when ApiSubscriptions change.
 // This ensures that the real route's DefaultConsumers is updated when cross-zone subscriptions are created or deleted.
 func (r *ApiExposureReconciler) MapApiSubscriptionToApiExposure(ctx context.Context, obj client.Object) []reconcile.Request {
-	log := log.FromContext(ctx)
+	logger := log.FromContext(ctx)
 	apiSub, ok := obj.(*apiv1.ApiSubscription)
 	if !ok {
-		log.Info("object is not an ApiSubscription")
+		logger.Info("object is not an ApiSubscription")
 		return nil
 	}
 
 	list := &apiv1.ApiExposureList{}
-	err := r.Client.List(ctx, list, client.MatchingLabels{
+	err := r.List(ctx, list, client.MatchingLabels{
 		cconfig.EnvironmentLabelKey: apiSub.Labels[cconfig.EnvironmentLabelKey],
 		apiv1.BasePathLabelKey:      apiSub.Labels[apiv1.BasePathLabelKey],
 	})
 	if err != nil {
-		log.Error(err, "failed to list API-Exposures for ApiSubscription")
+		logger.Error(err, "failed to list API-Exposures for ApiSubscription")
 		return nil
 	}
 
 	reqs := make([]reconcile.Request, 0, len(list.Items))
-	for _, item := range list.Items {
-		reqs = append(reqs, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(&item)})
+	for i := range list.Items {
+		item := &list.Items[i]
+		reqs = append(reqs, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(item)})
 	}
 
 	return reqs

--- a/api/internal/controller/apiexposure_controller_test.go
+++ b/api/internal/controller/apiexposure_controller_test.go
@@ -7,22 +7,21 @@ package controller
 import (
 	"fmt"
 
-	"github.com/telekom/controlplane/api/internal/handler/util"
-	applicationapi "github.com/telekom/controlplane/application/api/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	adminapi "github.com/telekom/controlplane/admin/api/v1"
-	apiapi "github.com/telekom/controlplane/api/api/v1"
 	apiv1 "github.com/telekom/controlplane/api/api/v1"
+	"github.com/telekom/controlplane/api/internal/handler/util"
+	applicationapi "github.com/telekom/controlplane/application/api/v1"
 	"github.com/telekom/controlplane/common/pkg/condition"
 	"github.com/telekom/controlplane/common/pkg/config"
 	"github.com/telekom/controlplane/common/pkg/test/testutil"
 	"github.com/telekom/controlplane/common/pkg/types"
 	"github.com/telekom/controlplane/common/pkg/util/labelutil"
 	gatewayapi "github.com/telekom/controlplane/gateway/api/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/api/meta"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -93,7 +92,7 @@ func NewRealm(name, zoneName string) *gatewayapi.Realm {
 	return realm
 }
 
-func NewApiExposure(apiBasePath, zoneName string, appName string) *apiv1.ApiExposure {
+func NewApiExposure(apiBasePath, zoneName, appName string) *apiv1.ApiExposure {
 	return &apiv1.ApiExposure{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      labelutil.NormalizeValue(apiBasePath),
@@ -153,13 +152,13 @@ func NewApiExposure(apiBasePath, zoneName string, appName string) *apiv1.ApiExpo
 					},
 				},
 			},
-			Security: &apiapi.Security{
-				M2M: &apiapi.Machine2MachineAuthentication{
-					ExternalIDP: &apiapi.ExternalIdentityProvider{
+			Security: &apiv1.Security{
+				M2M: &apiv1.Machine2MachineAuthentication{
+					ExternalIDP: &apiv1.ExternalIdentityProvider{
 						TokenEndpoint: "https://example.com/token",
-						TokenRequest:  apiapi.TokenRequestClientSecretBasic,
+						TokenRequest:  apiv1.TokenRequestClientSecretBasic,
 						GrantType:     "client_credentials",
-						Client: &apiapi.OAuth2ClientCredentials{
+						Client: &apiv1.OAuth2ClientCredentials{
 							ClientId:  "client-id",
 							ClientKey: "******",
 						},
@@ -169,7 +168,7 @@ func NewApiExposure(apiBasePath, zoneName string, appName string) *apiv1.ApiExpo
 				},
 			},
 			Visibility: apiv1.VisibilityWorld,
-			Approval:   apiv1.Approval{Strategy: apiapi.ApprovalStrategyAuto},
+			Approval:   apiv1.Approval{Strategy: apiv1.ApprovalStrategyAuto},
 			Zone: types.ObjectRef{
 				Name:      zoneName,
 				Namespace: testEnvironment,
@@ -180,14 +179,14 @@ func NewApiExposure(apiBasePath, zoneName string, appName string) *apiv1.ApiExpo
 }
 
 var _ = Describe("ApiExposure Controller", Ordered, func() {
-	var apiBasePath = "/apiexpctrl/test/v1"
-	var zoneName = "apiexp-test"
+	apiBasePath := "/apiexpctrl/test/v1"
+	zoneName := "apiexp-test"
 
 	var apiExposure *apiv1.ApiExposure
 	var api *apiv1.Api
 	var zone *adminapi.Zone
 
-	var appName = "api-exposure-app-2"
+	appName := "api-exposure-app-2"
 	var apiExpApplication *applicationapi.Application
 
 	BeforeAll(func() {
@@ -216,7 +215,6 @@ var _ = Describe("ApiExposure Controller", Ordered, func() {
 	})
 
 	Context("Creating and Updating ApiExposures", Ordered, func() {
-
 		It("should block until an API is registered", func() {
 			By("Creating the resource")
 			err := k8sClient.Create(ctx, apiExposure)
@@ -227,9 +225,7 @@ var _ = Describe("ApiExposure Controller", Ordered, func() {
 				err := k8sClient.Get(ctx, client.ObjectKeyFromObject(apiExposure), apiExposure)
 				g.Expect(err).ToNot(HaveOccurred())
 				g.Expect(apiExposure.Status.Active).To(BeFalse())
-
 			}, timeout, interval).Should(Succeed())
-
 		})
 
 		It("should automatically progress when an API is registered", func() {
@@ -242,9 +238,7 @@ var _ = Describe("ApiExposure Controller", Ordered, func() {
 				err := k8sClient.Get(ctx, client.ObjectKeyFromObject(apiExposure), apiExposure)
 				g.Expect(err).ToNot(HaveOccurred())
 				g.Expect(apiExposure.Status.Active).To(BeTrue())
-
 			}, timeout, interval).Should(Succeed())
-
 		})
 
 		It("should create the real-route", func() {
@@ -258,9 +252,7 @@ var _ = Describe("ApiExposure Controller", Ordered, func() {
 				err = k8sClient.Get(ctx, apiExposure.Status.Route.K8s(), route)
 				g.Expect(err).ToNot(HaveOccurred())
 				g.Expect(route.Spec.Transformation.Request.Headers.Remove).To(ContainElement("X-Remove-Header"))
-
 			}, timeout, interval).Should(Succeed())
-
 		})
 
 		It("should pass rate limit configuration from ApiExposure to Route", func() {
@@ -288,15 +280,13 @@ var _ = Describe("ApiExposure Controller", Ordered, func() {
 				// Verify that the provider rate limit options are correctly passed
 				g.Expect(route.Spec.Traffic.RateLimit.Options.HideClientHeaders).To(Equal(apiExposure.Spec.Traffic.RateLimit.Provider.Options.HideClientHeaders))
 				g.Expect(route.Spec.Traffic.RateLimit.Options.FaultTolerant).To(Equal(apiExposure.Spec.Traffic.RateLimit.Provider.Options.FaultTolerant))
-
 			}, timeout, interval).Should(Succeed())
 		})
 	})
 
 	Context("Deleting and Switching the Active ApiExposure", Ordered, func() {
-
 		var secondApiExposure *apiv1.ApiExposure
-		var appName = "api-exposure-app-3"
+		appName := "api-exposure-app-3"
 		var apiExpApplication *applicationapi.Application
 
 		BeforeAll(func() {
@@ -324,7 +314,6 @@ var _ = Describe("ApiExposure Controller", Ordered, func() {
 				err := k8sClient.Get(ctx, client.ObjectKeyFromObject(secondApiExposure), secondApiExposure)
 				g.Expect(err).ToNot(HaveOccurred())
 				g.Expect(secondApiExposure.Status.Active).To(BeFalse())
-
 			}, timeout, interval).Should(Succeed())
 		})
 
@@ -338,7 +327,6 @@ var _ = Describe("ApiExposure Controller", Ordered, func() {
 				err := k8sClient.Get(ctx, client.ObjectKeyFromObject(secondApiExposure), secondApiExposure)
 				g.Expect(err).ToNot(HaveOccurred())
 				g.Expect(secondApiExposure.Status.Active).To(BeTrue())
-
 			}, timeout, interval).Should(Succeed())
 		})
 
@@ -351,16 +339,13 @@ var _ = Describe("ApiExposure Controller", Ordered, func() {
 			Eventually(func(g Gomega) {
 				err := k8sClient.Get(ctx, client.ObjectKeyFromObject(secondApiExposure), secondApiExposure)
 				g.Expect(err).To(HaveOccurred())
-
 			}, timeout, interval).Should(Succeed())
-
 		})
 	})
 
 	Context("ApiExposure with ExternalIDPConfig Configured", Ordered, func() {
-
 		var thirdApiExposure *apiv1.ApiExposure
-		var appName = "api-exposure-app-4"
+		appName := "api-exposure-app-4"
 		var apiExpApplication *applicationapi.Application
 
 		BeforeAll(func() {
@@ -444,13 +429,11 @@ var _ = Describe("ApiExposure Controller", Ordered, func() {
 				g.Expect(route.Spec.Security.M2M.ExternalIDP.GrantType).To(Equal("client_credentials"))
 			}, timeout, interval).Should(Succeed())
 		})
-
 	})
 
 	Context("Validating the basePath", Ordered, func() {
-
-		var apiBasePath = "/ApiExpctrl/Test/v1"
-		var appName = "api-exposure-app-5"
+		apiBasePath := "/ApiExpctrl/Test/v1"
+		appName := "api-exposure-app-5"
 		var apiExpApplication *applicationapi.Application
 
 		var secondApiExposure *apiv1.ApiExposure
@@ -482,18 +465,15 @@ var _ = Describe("ApiExposure Controller", Ordered, func() {
 				readyCond := meta.FindStatusCondition(secondApiExposure.GetConditions(), condition.ConditionTypeReady)
 				testutil.ExpectConditionToBeFalse(g, readyCond, "ApiCaseConflict")
 				Expect(readyCond.Message).To(ContainSubstring(`API is registered but the case does not match (got="/ApiExpctrl/Test/v1", found="/apiexpctrl/test/v1").`))
-
 			}, timeout, interval).Should(Succeed())
 		})
-
 	})
-
 })
 
 var _ = Describe("ApiExposure Controller with failover scenario", Ordered, func() {
-	var apiBasePath = "/apiexpctrl/failovertest/v1"
-	var zoneName = "apiexp-failovertest"
-	var failoverZoneName = "failover-zone"
+	apiBasePath := "/apiexpctrl/failovertest/v1"
+	zoneName := "apiexp-failovertest"
+	failoverZoneName := "failover-zone"
 
 	var apiExposure *apiv1.ApiExposure
 	var api *apiv1.Api
@@ -528,9 +508,9 @@ var _ = Describe("ApiExposure Controller with failover scenario", Ordered, func(
 		err := k8sClient.Delete(ctx, apiExposure)
 		Expect(err).ToNot(HaveOccurred())
 		Eventually(func(g Gomega) {
-			err := k8sClient.Get(ctx, client.ObjectKeyFromObject(apiExposure), apiExposure)
-			g.Expect(err).To(HaveOccurred())
-			g.Expect(apierrors.IsNotFound(err)).To(BeTrue(), "ApiExposure should be deleted")
+			getErr := k8sClient.Get(ctx, client.ObjectKeyFromObject(apiExposure), apiExposure)
+			g.Expect(getErr).To(HaveOccurred())
+			g.Expect(apierrors.IsNotFound(getErr)).To(BeTrue(), "ApiExposure should be deleted")
 		}, timeout, interval).Should(Succeed())
 
 		By("Cleaning up all the created Routes")
@@ -550,8 +530,7 @@ var _ = Describe("ApiExposure Controller with failover scenario", Ordered, func(
 	})
 
 	Context("Creating and Updating ApiExposures", Ordered, func() {
-
-		var appName = "api-exposure-app-6"
+		appName := "api-exposure-app-6"
 		var apiExpApplication *applicationapi.Application
 
 		BeforeAll(func() {
@@ -627,15 +606,12 @@ var _ = Describe("ApiExposure Controller with failover scenario", Ordered, func(
 				Expect(failoverRoute.Spec.Traffic.Failover.Upstreams[0].Path).To(Equal("/api/v1"))
 				Expect(failoverRoute.Spec.Traffic.Failover.Upstreams[0].Scheme).To(Equal("http"))
 				Expect(failoverRoute.Spec.Traffic.Failover.TargetZoneName).To(Equal(providerZone.Name))
-
 			}, timeout, interval).Should(Succeed())
-
 		})
 	})
 
 	Context("Creating and Updating ApiExposures with Security", Ordered, func() {
-
-		var secondAppName = "api-exposure-app-7"
+		secondAppName := "api-exposure-app-7"
 		var secondApiExpApplication *applicationapi.Application
 
 		BeforeAll(func() {
@@ -719,24 +695,22 @@ var _ = Describe("ApiExposure Controller with failover scenario", Ordered, func(
 				Expect(failoverRoute.Spec.Traffic.Failover.Security.M2M.ExternalIDP.GrantType).To(Equal("password"))
 				Expect(failoverRoute.Spec.Traffic.Failover.Security.M2M.ExternalIDP.Basic.Username).To(Equal("my-username"))
 				Expect(failoverRoute.Spec.Traffic.Failover.Security.M2M.ExternalIDP.Basic.Password).To(Equal("my-password"))
-
 			}, timeout, interval).Should(Succeed())
-
 		})
 	})
 })
 
 var _ = Describe("ApiExposure Controller cross-zone proxy target ACL", Ordered, func() {
-	var apiBasePath = "/apiexpctrl/crosszone/v1"
-	var zoneName = "crosszone-exp-zone"
-	var otherZoneName = "crosszone-sub-zone"
+	apiBasePath := "/apiexpctrl/crosszone/v1"
+	zoneName := "crosszone-exp-zone"
+	otherZoneName := "crosszone-sub-zone"
 
 	var apiExposure *apiv1.ApiExposure
 	var api *apiv1.Api
 
-	var appName = "crosszone-app"
+	appName := "crosszone-app"
 
-	var crossZoneSub *apiapi.ApiSubscription
+	var crossZoneSub *apiv1.ApiSubscription
 
 	BeforeAll(func() {
 		By("Creating the Application")
@@ -761,7 +735,6 @@ var _ = Describe("ApiExposure Controller cross-zone proxy target ACL", Ordered, 
 	})
 
 	Context("Gateway consumer management based on cross-zone subscriptions", Ordered, func() {
-
 		It("should NOT have gateway consumer in DefaultConsumers when no cross-zone subscriptions exist", func() {
 			By("Creating the ApiExposure")
 			apiExposure = NewApiExposure(apiBasePath, zoneName, appName)

--- a/api/internal/controller/apisubscription_controller.go
+++ b/api/internal/controller/apisubscription_controller.go
@@ -20,14 +20,12 @@ import (
 
 	adminv1 "github.com/telekom/controlplane/admin/api/v1"
 	apiapi "github.com/telekom/controlplane/api/api/v1"
+	"github.com/telekom/controlplane/api/internal/handler/apisubscription"
 	applicationapi "github.com/telekom/controlplane/application/api/v1"
 	approvalapi "github.com/telekom/controlplane/approval/api/v1"
 	cconfig "github.com/telekom/controlplane/common/pkg/config"
 	cc "github.com/telekom/controlplane/common/pkg/controller"
 	gatewayapi "github.com/telekom/controlplane/gateway/api/v1"
-	gatewayv1 "github.com/telekom/controlplane/gateway/api/v1"
-
-	"github.com/telekom/controlplane/api/internal/handler/apisubscription"
 )
 
 // ApiSubscriptionReconciler reconciles a ApiSubscription object
@@ -84,11 +82,11 @@ func (r *ApiSubscriptionReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			handler.EnqueueRequestsFromMapFunc(r.MapApplicationToApiSubscription),
 			builder.WithPredicates(predicate.ResourceVersionChangedPredicate{}),
 		).
-		Watches(&gatewayv1.Route{},
+		Watches(&gatewayapi.Route{},
 			handler.EnqueueRequestsFromMapFunc(r.MapRouteToApiSubscription),
 			builder.WithPredicates(cc.DeleteOnlyPredicate{}),
 		).
-		Watches(&gatewayv1.ConsumeRoute{},
+		Watches(&gatewayapi.ConsumeRoute{},
 			handler.EnqueueRequestsFromMapFunc(r.MapConsumeRouteToApiSubscription),
 			builder.WithPredicates(cc.DeleteOnlyPredicate{}),
 		).
@@ -98,92 +96,98 @@ func (r *ApiSubscriptionReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		).
 		WithOptions(controller.Options{
 			MaxConcurrentReconciles: cconfig.MaxConcurrentReconciles,
-			RateLimiter:             cc.NewRateLimiter()}).
+			RateLimiter:             cc.NewRateLimiter(),
+		}).
 		Complete(r)
 }
 
+//nolint:dupl // controller map helpers intentionally mirror each other
 func (r *ApiSubscriptionReconciler) MapApiToApiSubscription(ctx context.Context, obj client.Object) []reconcile.Request {
-	log := log.FromContext(ctx)
+	logger := log.FromContext(ctx)
 
-	api, ok := obj.(*apiapi.Api)
+	apiObj, ok := obj.(*apiapi.Api)
 	if !ok {
-		log.Info("object is not an API")
+		logger.Info("object is not an API")
 		return nil
 	}
 
 	list := &apiapi.ApiSubscriptionList{}
-	err := r.Client.List(ctx, list, client.MatchingLabels{
-		cconfig.EnvironmentLabelKey: api.Labels[cconfig.EnvironmentLabelKey],
-		apiapi.BasePathLabelKey:     api.Labels[apiapi.BasePathLabelKey],
+	err := r.List(ctx, list, client.MatchingLabels{
+		cconfig.EnvironmentLabelKey: apiObj.Labels[cconfig.EnvironmentLabelKey],
+		apiapi.BasePathLabelKey:     apiObj.Labels[apiapi.BasePathLabelKey],
 	})
 	if err != nil {
-		log.Error(err, "failed to list API-Subscriptions")
+		logger.Error(err, "failed to list API-Subscriptions")
 		return nil
 	}
 
 	reqs := make([]reconcile.Request, 0, len(list.Items))
-	for _, item := range list.Items {
-		if api.UID == item.UID {
+	for i := range list.Items {
+		item := &list.Items[i]
+		if apiObj.UID == item.UID {
 			continue
 		}
-		reqs = append(reqs, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(&item)})
+		reqs = append(reqs, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(item)})
 	}
 
 	return reqs
 }
 
+//nolint:dupl // controller map helpers intentionally mirror each other
 func (r *ApiSubscriptionReconciler) MapApiExposureToApiSubscription(ctx context.Context, obj client.Object) []reconcile.Request {
-	log := log.FromContext(ctx)
+	logger := log.FromContext(ctx)
 
 	apiExposure, ok := obj.(*apiapi.ApiExposure)
 	if !ok {
-		log.Info("object is not an API-Exposure")
+		logger.Info("object is not an API-Exposure")
 		return nil
 	}
 
 	list := &apiapi.ApiSubscriptionList{}
-	err := r.Client.List(ctx, list, client.MatchingLabels{
+	err := r.List(ctx, list, client.MatchingLabels{
 		cconfig.EnvironmentLabelKey: apiExposure.Labels[cconfig.EnvironmentLabelKey],
 		apiapi.BasePathLabelKey:     apiExposure.Labels[apiapi.BasePathLabelKey],
 	})
 	if err != nil {
-		log.Error(err, "failed to list API-Subscriptions")
+		logger.Error(err, "failed to list API-Subscriptions")
 		return nil
 	}
 
 	reqs := make([]reconcile.Request, 0, len(list.Items))
-	for _, item := range list.Items {
+	for i := range list.Items {
+		item := &list.Items[i]
 		if apiExposure.UID == item.UID {
 			continue
 		}
-		reqs = append(reqs, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(&item)})
+		reqs = append(reqs, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(item)})
 	}
 
 	return reqs
 }
 
 func (r *ApiSubscriptionReconciler) MapApplicationToApiSubscription(ctx context.Context, obj client.Object) []reconcile.Request {
-	log := log.FromContext(ctx)
+	logger := log.FromContext(ctx)
 
 	application, ok := obj.(*applicationapi.Application)
 	if !ok {
-		log.Info("object is not an Application")
+		logger.Info("object is not an Application")
 		return nil
 	}
 
 	list := &apiapi.ApiSubscriptionList{}
-	err := r.Client.List(ctx, list, client.MatchingLabels{
+	err := r.List(ctx, list, client.MatchingLabels{
 		cconfig.EnvironmentLabelKey:          application.Labels[cconfig.EnvironmentLabelKey],
 		cconfig.BuildLabelKey("application"): application.Labels[cconfig.BuildLabelKey("application")],
 	}, client.InNamespace(application.Namespace))
 	if err != nil {
-		log.Error(err, "failed to list API-Subscriptions")
+		logger.Error(err, "failed to list API-Subscriptions")
 		return nil
 	}
 
 	reqs := make([]reconcile.Request, 0, len(list.Items))
-	for _, item := range list.Items {
-		reqs = append(reqs, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(&item)})
+	for i := range list.Items {
+		item := &list.Items[i]
+		reqs = append(reqs, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(item)})
 	}
 
 	return reqs

--- a/api/internal/controller/apisubscription_controller_failover_test.go
+++ b/api/internal/controller/apisubscription_controller_failover_test.go
@@ -5,8 +5,10 @@
 package controller
 
 import (
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
 	adminapi "github.com/telekom/controlplane/admin/api/v1"
 	apiapi "github.com/telekom/controlplane/api/api/v1"
 	"github.com/telekom/controlplane/api/internal/handler/util"
@@ -18,9 +20,9 @@ import (
 	"github.com/telekom/controlplane/common/pkg/types"
 	"github.com/telekom/controlplane/common/pkg/util/labelutil"
 	gatewayapi "github.com/telekom/controlplane/gateway/api/v1"
-	"k8s.io/apimachinery/pkg/api/meta"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("ApiSubscription Controller with failover scenario", Ordered, func() {
@@ -39,22 +41,22 @@ var _ = Describe("ApiSubscription Controller with failover scenario", Ordered, f
 	// ApiSubscription in different zone as ApiExposure and ApiExposure failover zones
 	// ApiSubscription failover zone is the same as the ApiExposure zone
 
-	var apiBasePath = "/apisub/failovertest/v1"
+	apiBasePath := "/apisub/failovertest/v1"
 
 	// Provider side
 	var api *apiapi.Api
 	var apiExposure *apiapi.ApiExposure
 
 	// Provider/Exposure zone
-	var providerZoneName = "provider-zone"
+	providerZoneName := "provider-zone"
 	var providerZone *adminapi.Zone
 
 	// Failover zone for Provider
-	var failoverZoneName = "apisub-failover-zone"
+	failoverZoneName := "apisub-failover-zone"
 	var failoverZone *adminapi.Zone
 
 	// Consumer side
-	var appName = "failover-test-app"
+	appName := "failover-test-app"
 	var application *applicationapi.Application
 
 	BeforeAll(func() {
@@ -159,7 +161,6 @@ var _ = Describe("ApiSubscription Controller with failover scenario", Ordered, f
 				g.Expect(route.Spec.Traffic.Failover.TargetZoneName).To(Equal(providerZone.Name))
 				g.Expect(route.Spec.Traffic.Failover.Upstreams[0].IssuerUrl).To(Equal(""))
 				g.Expect(route.Spec.Traffic.Failover.Upstreams[0].Url()).To(Equal("http://my-provider-api:8080/api/v1"))
-
 			}, timeout, interval).Should(Succeed())
 		})
 
@@ -180,7 +181,7 @@ var _ = Describe("ApiSubscription Controller with failover scenario", Ordered, f
 	})
 
 	Context("Different Zone than ApiExposure Failover Zone", func() {
-		var differentZoneName = "different-zone"
+		differentZoneName := "different-zone"
 		var differentZone *adminapi.Zone
 		var differentZoneSubscription *apiapi.ApiSubscription
 
@@ -266,8 +267,8 @@ var _ = Describe("ApiSubscription Controller with failover scenario", Ordered, f
 	})
 
 	Context("ApiSubscription with Multiple Failover Zones", func() {
-		var multiFailoverZoneName1 = "multi-failover-zone1"
-		var multiFailoverZoneName2 = "multi-failover-zone2"
+		multiFailoverZoneName1 := "multi-failover-zone1"
+		multiFailoverZoneName2 := "multi-failover-zone2"
 		var multiFailoverZone1, multiFailoverZone2 *adminapi.Zone
 		var multiFailoverSubscription *apiapi.ApiSubscription
 
@@ -403,12 +404,12 @@ var _ = Describe("ApiSubscription Controller with failover scenario", Ordered, f
 	})
 
 	Context("ApiSubscription with Failover Zone same as ApiExposure Zone", func() {
-		var differentZoneName = "another-different-zone"
+		differentZoneName := "another-different-zone"
 		var differentZone *adminapi.Zone
 		var subscription *apiapi.ApiSubscription
 
-		var appName = "same-sub-failover-zone-exp-zone"
-		var application *applicationapi.Application
+		sameZoneAppName := "same-sub-failover-zone-exp-zone"
+		var sameZoneApplication *applicationapi.Application
 
 		BeforeAll(func() {
 			By("Creating a different zone")
@@ -416,13 +417,13 @@ var _ = Describe("ApiSubscription Controller with failover scenario", Ordered, f
 			CreateGatewayClient(differentZone)
 
 			By("Creating the Application")
-			application = CreateApplication(appName)
+			sameZoneApplication = CreateApplication(sameZoneAppName)
 
 			By("Creating the Realm for different zone")
 			CreateRealm(testEnvironment, differentZone.Name)
 
 			By("Creating ApiSubscription in different zone with provider zone as failover")
-			subscription = NewApiSubscription(apiBasePath, differentZoneName, appName)
+			subscription = NewApiSubscription(apiBasePath, differentZoneName, sameZoneAppName)
 			// Configure failover zone to be the same as ApiExposure zone
 			subscription.Spec.Traffic = apiapi.SubscriberTraffic{
 				Failover: &apiapi.Failover{
@@ -469,7 +470,7 @@ var _ = Describe("ApiSubscription Controller with failover scenario", Ordered, f
 				proxyConsumeRoute := &gatewayapi.ConsumeRoute{}
 				err = k8sClient.Get(ctx, subscription.Status.ConsumeRoute.K8s(), proxyConsumeRoute)
 				g.Expect(err).ToNot(HaveOccurred())
-				g.Expect(proxyConsumeRoute.Spec.ConsumerName).To(Equal(application.Status.ClientId))
+				g.Expect(proxyConsumeRoute.Spec.ConsumerName).To(Equal(sameZoneApplication.Status.ClientId))
 				g.Expect(proxyConsumeRoute.Spec.Route).To(Equal(*subscription.Status.Route)) // should be the proxy route
 
 				// Check failover consume route
@@ -487,7 +488,7 @@ var _ = Describe("ApiSubscription Controller with failover scenario", Ordered, f
 	})
 
 	Context("Approval Denial and Revocation", func() {
-		var denialZoneName = "approval-denial-zone"
+		denialZoneName := "approval-denial-zone"
 		var denialZone *adminapi.Zone
 		var denialSubscription *apiapi.ApiSubscription
 
@@ -584,7 +585,7 @@ var _ = Describe("ApiSubscription Controller with failover scenario", Ordered, f
 	})
 
 	Context("Subscriber Failover to Provider Failover Zone", func() {
-		var subFailoverToProviderZoneName = "sub-failover-provider-collision-zone"
+		subFailoverToProviderZoneName := "sub-failover-provider-collision-zone"
 		var subFailoverToProviderZone *adminapi.Zone
 		var subFailoverToProviderSubscription *apiapi.ApiSubscription
 
@@ -723,7 +724,7 @@ var _ = Describe("ApiSubscription Controller with failover scenario", Ordered, f
 	})
 
 	Context("Same-Zone Subscription with Cross-Zone Failover", func() {
-		var sameZoneFailoverZoneName = "same-zone-sub-failover-zone"
+		sameZoneFailoverZoneName := "same-zone-sub-failover-zone"
 		var sameZoneFailoverZone *adminapi.Zone
 		var sameZoneWithFailoverSubscription *apiapi.ApiSubscription
 
@@ -864,9 +865,9 @@ var _ = Describe("ApiSubscription Controller with failover scenario", Ordered, f
 	})
 
 	Context("Multiple Subscriptions Sharing Zone with Different Failover Configs", func() {
-		var sharedZoneName = "multi-sub-shared-zone"
+		sharedZoneName := "multi-sub-shared-zone"
 		var sharedZone *adminapi.Zone
-		var sharedFailoverZoneName = "multi-sub-failover-zone"
+		sharedFailoverZoneName := "multi-sub-failover-zone"
 		var sharedFailoverZone *adminapi.Zone
 		var subscription1 *apiapi.ApiSubscription // No failover
 		var subscription2 *apiapi.ApiSubscription // With failover
@@ -1042,13 +1043,13 @@ var _ = Describe("ApiSubscription Controller with failover scenario", Ordered, f
 // Test #5: All Subscriptions in Same Zone as Exposure (Isolated)
 var _ = Describe("ApiSubscription Controller - All Subscriptions Same Zone", Ordered, func() {
 	// ISOLATED TEST: Uses unique apiBasePath to avoid pollution from other tests
-	var apiBasePath = "/apisub/samezone/v1"
+	apiBasePath := "/apisub/samezone/v1"
 
 	var api *apiapi.Api
 	var apiExposure *apiapi.ApiExposure
-	var providerZoneName = "samezone-provider"
+	providerZoneName := "samezone-provider"
 	var providerZone *adminapi.Zone
-	var appName = "samezone-app"
+	appName := "samezone-app"
 
 	var sameZoneSub1 *apiapi.ApiSubscription
 	var sameZoneSub2 *apiapi.ApiSubscription
@@ -1077,8 +1078,8 @@ var _ = Describe("ApiSubscription Controller - All Subscriptions Same Zone", Ord
 
 		By("Waiting for ApiExposure to be ready")
 		Eventually(func(g Gomega) {
-			err := k8sClient.Get(ctx, client.ObjectKeyFromObject(apiExposure), apiExposure)
-			g.Expect(err).ToNot(HaveOccurred())
+			getErr := k8sClient.Get(ctx, client.ObjectKeyFromObject(apiExposure), apiExposure)
+			g.Expect(getErr).ToNot(HaveOccurred())
 			testutil.ExpectConditionToBeTrue(g, meta.FindStatusCondition(apiExposure.GetConditions(), condition.ConditionTypeReady), "Provisioned")
 		}, timeout, interval).Should(Succeed())
 
@@ -1241,17 +1242,17 @@ var _ = Describe("ApiSubscription Controller - Provider Failover Reuse", Ordered
 	// Scenario: ApiExposure has provider failover zone B
 	//           Subscription in zone A with subscriber failover to zone B
 	//           Expectation: No duplicate proxy route created, subscriber reuses provider failover route
-	var apiBasePath = "/apisub/provfailover/v1"
+	apiBasePath := "/apisub/provfailover/v1"
 
 	var api *apiapi.Api
 	var apiExposure *apiapi.ApiExposure
-	var providerZoneName = "provfailover-main"
+	providerZoneName := "provfailover-main"
 	var providerZone *adminapi.Zone
-	var providerFailoverZoneName = "provfailover-secondary"
+	providerFailoverZoneName := "provfailover-secondary"
 	var providerFailoverZone *adminapi.Zone
-	var subscriberZoneName = "provfailover-subscriber"
+	subscriberZoneName := "provfailover-subscriber"
 	var subscriberZone *adminapi.Zone
-	var appName = "provfailover-app"
+	appName := "provfailover-app"
 
 	var subscription *apiapi.ApiSubscription
 
@@ -1294,8 +1295,8 @@ var _ = Describe("ApiSubscription Controller - Provider Failover Reuse", Ordered
 
 		By("Waiting for ApiExposure to be ready")
 		Eventually(func(g Gomega) {
-			err := k8sClient.Get(ctx, client.ObjectKeyFromObject(apiExposure), apiExposure)
-			g.Expect(err).ToNot(HaveOccurred())
+			getErr := k8sClient.Get(ctx, client.ObjectKeyFromObject(apiExposure), apiExposure)
+			g.Expect(getErr).ToNot(HaveOccurred())
 			testutil.ExpectConditionToBeTrue(g, meta.FindStatusCondition(apiExposure.GetConditions(), condition.ConditionTypeReady), "Provisioned")
 		}, timeout, interval).Should(Succeed())
 

--- a/api/internal/controller/apisubscription_controller_ratelimiting_test.go
+++ b/api/internal/controller/apisubscription_controller_ratelimiting_test.go
@@ -5,8 +5,10 @@
 package controller
 
 import (
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
 	adminapi "github.com/telekom/controlplane/admin/api/v1"
 	apiapi "github.com/telekom/controlplane/api/api/v1"
 	"github.com/telekom/controlplane/api/internal/handler/util"
@@ -18,15 +20,15 @@ import (
 	"github.com/telekom/controlplane/common/pkg/types"
 	"github.com/telekom/controlplane/common/pkg/util/labelutil"
 	gatewayapi "github.com/telekom/controlplane/gateway/api/v1"
-	"k8s.io/apimachinery/pkg/api/meta"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 )
 
 // Helper functions for creating test resources with rate limits
 
 // NewApiExposureWithRateLimit creates an ApiExposure with both provider and consumer rate limits
-func NewApiExposureWithRateLimit(apiBasePath, zoneName, consumerClientId string, appName string) *apiapi.ApiExposure {
+func NewApiExposureWithRateLimit(apiBasePath, zoneName, consumerClientId, appName string) *apiapi.ApiExposure {
 	return &apiapi.ApiExposure{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      labelutil.NormalizeValue(apiBasePath),
@@ -106,14 +108,14 @@ func NewApiExposureWithRateLimit(apiBasePath, zoneName, consumerClientId string,
 }
 
 // NewApiExposureWithConsumerOnlyRateLimit creates an ApiExposure with only consumer rate limits (no provider rate limits)
-func NewApiExposureWithConsumerOnlyRateLimit(apiBasePath, zoneName, consumerClientId string, appName string) *apiapi.ApiExposure {
+func NewApiExposureWithConsumerOnlyRateLimit(apiBasePath, zoneName, consumerClientId, appName string) *apiapi.ApiExposure {
 	apiExposure := NewApiExposureWithRateLimit(apiBasePath, zoneName, consumerClientId, appName)
 	apiExposure.Spec.Traffic.RateLimit.Provider = nil
 	return apiExposure
 }
 
 // NewApiExposureWithProviderOnlyRateLimit creates an ApiExposure with only provider rate limits (no consumer rate limits)
-func NewApiExposureWithProviderOnlyRateLimit(apiBasePath, zoneName string, appName string) *apiapi.ApiExposure {
+func NewApiExposureWithProviderOnlyRateLimit(apiBasePath, zoneName, appName string) *apiapi.ApiExposure {
 	apiExposure := NewApiExposureWithRateLimit(apiBasePath, zoneName, "", appName)
 	apiExposure.Spec.Traffic.RateLimit.SubscriberRateLimit = nil
 	return apiExposure
@@ -134,8 +136,8 @@ func createAndApproveSubscription(apiBasePath, zoneName, appName string, zoneRef
 
 	// Wait for approval request
 	Eventually(func(g Gomega) {
-		err := k8sClient.Get(ctx, client.ObjectKeyFromObject(subscription), subscription)
-		g.Expect(err).ToNot(HaveOccurred())
+		getErr := k8sClient.Get(ctx, client.ObjectKeyFromObject(subscription), subscription)
+		g.Expect(getErr).ToNot(HaveOccurred())
 		testutil.ExpectConditionToBeFalse(g, meta.FindStatusCondition(subscription.GetConditions(), condition.ConditionTypeReady), "ApprovalPending")
 
 		g.Expect(subscription.Status.ApprovalRequest).ToNot(BeNil())
@@ -206,29 +208,29 @@ func verifyRouteRateLimits(route *types.ObjectRef, providerRateLimit *apiapi.Rat
 
 var _ = Describe("ApiSubscription Rate Limiting", Ordered, func() {
 	// API that is used for the tests
-	var apiBasePath = "/ratelimit/test/v1"
+	apiBasePath := "/ratelimit/test/v1"
 
 	// Provider side
 	var api *apiapi.Api
 	var apiExposure *apiapi.ApiExposure
 
 	// Provider/Exposure zone
-	var zoneName = "ratelimit-test"
-	var secondZoneName = "ratelimit-test-2"
+	zoneName := "ratelimit-test"
+	secondZoneName := "ratelimit-test-2"
 	var zone *adminapi.Zone
 	var secondZone *adminapi.Zone
 
 	// Consumer side
-	var appName = "rate-limit-app"
+	appName := "rate-limit-app"
 	var application *applicationapi.Application
 	var apiSubscription *apiapi.ApiSubscription
 
 	// Second consumer for default rate limit test
-	var defaultAppName = "default-rate-limit-app"
+	defaultAppName := "default-rate-limit-app"
 	var defaultApplication *applicationapi.Application
 	var defaultApiSubscription *apiapi.ApiSubscription
 
-	var apiExpAppName = "api-exposure-app"
+	apiExpAppName := "api-exposure-app"
 	var apiExpApplication *applicationapi.Application
 
 	BeforeAll(func() {
@@ -340,8 +342,8 @@ var _ = Describe("ApiSubscription Rate Limiting", Ordered, func() {
 
 			By("Verifying the ProxyRoute is created with provider rate limits")
 			Eventually(func(g Gomega) {
-				err := k8sClient.Get(ctx, client.ObjectKeyFromObject(proxyApiSubscription), proxyApiSubscription)
-				g.Expect(err).ToNot(HaveOccurred())
+				getErr := k8sClient.Get(ctx, client.ObjectKeyFromObject(proxyApiSubscription), proxyApiSubscription)
+				g.Expect(getErr).ToNot(HaveOccurred())
 				g.Expect(proxyApiSubscription.Status.Route).ToNot(BeNil())
 			}, timeout, interval).Should(Succeed())
 
@@ -374,8 +376,8 @@ var _ = Describe("ApiSubscription Rate Limiting", Ordered, func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			Eventually(func(g Gomega) {
-				err := k8sClient.Get(ctx, client.ObjectKeyFromObject(consumerOnlyApiExposure), consumerOnlyApiExposure)
-				g.Expect(err).ToNot(HaveOccurred())
+				getErr := k8sClient.Get(ctx, client.ObjectKeyFromObject(consumerOnlyApiExposure), consumerOnlyApiExposure)
+				g.Expect(getErr).ToNot(HaveOccurred())
 				g.Expect(consumerOnlyApiExposure.Status.Active).To(BeTrue())
 			}, timeout, interval).Should(Succeed())
 
@@ -389,8 +391,8 @@ var _ = Describe("ApiSubscription Rate Limiting", Ordered, func() {
 
 			By("Verifying the Route has no rate limits")
 			Eventually(func(g Gomega) {
-				err := k8sClient.Get(ctx, client.ObjectKeyFromObject(consumerOnlyApiExposure), consumerOnlyApiExposure)
-				g.Expect(err).ToNot(HaveOccurred())
+				getErr := k8sClient.Get(ctx, client.ObjectKeyFromObject(consumerOnlyApiExposure), consumerOnlyApiExposure)
+				g.Expect(getErr).ToNot(HaveOccurred())
 				g.Expect(consumerOnlyApiExposure.Status.Route).ToNot(BeNil())
 
 				// Get the Route
@@ -426,8 +428,8 @@ var _ = Describe("ApiSubscription Rate Limiting", Ordered, func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			Eventually(func(g Gomega) {
-				err := k8sClient.Get(ctx, client.ObjectKeyFromObject(providerOnlyApiExposure), providerOnlyApiExposure)
-				g.Expect(err).ToNot(HaveOccurred())
+				getErr := k8sClient.Get(ctx, client.ObjectKeyFromObject(providerOnlyApiExposure), providerOnlyApiExposure)
+				g.Expect(getErr).ToNot(HaveOccurred())
 				g.Expect(providerOnlyApiExposure.Status.Active).To(BeTrue())
 			}, timeout, interval).Should(Succeed())
 
@@ -436,8 +438,8 @@ var _ = Describe("ApiSubscription Rate Limiting", Ordered, func() {
 
 			By("Verifying the Route has provider rate limits")
 			Eventually(func(g Gomega) {
-				err := k8sClient.Get(ctx, client.ObjectKeyFromObject(providerOnlyApiExposure), providerOnlyApiExposure)
-				g.Expect(err).ToNot(HaveOccurred())
+				getErr := k8sClient.Get(ctx, client.ObjectKeyFromObject(providerOnlyApiExposure), providerOnlyApiExposure)
+				g.Expect(getErr).ToNot(HaveOccurred())
 				g.Expect(providerOnlyApiExposure.Status.Route).ToNot(BeNil())
 			}, timeout, interval).Should(Succeed())
 
@@ -445,8 +447,8 @@ var _ = Describe("ApiSubscription Rate Limiting", Ordered, func() {
 
 			By("Verifying the ConsumeRoute has no rate limits")
 			Eventually(func(g Gomega) {
-				err := k8sClient.Get(ctx, client.ObjectKeyFromObject(providerOnlySubscription), providerOnlySubscription)
-				g.Expect(err).ToNot(HaveOccurred())
+				getErr := k8sClient.Get(ctx, client.ObjectKeyFromObject(providerOnlySubscription), providerOnlySubscription)
+				g.Expect(getErr).ToNot(HaveOccurred())
 				g.Expect(providerOnlySubscription.Status.ConsumeRoute).ToNot(BeNil())
 
 				// Get the ConsumeRoute

--- a/api/internal/controller/apisubscription_controller_test.go
+++ b/api/internal/controller/apisubscription_controller_test.go
@@ -344,7 +344,7 @@ var _ = Describe("ApiSubscription Controller", Ordered, func() {
 
 		BeforeAll(func() {
 			By("Initializing the ApiSubscription")
-			apiSubscription = NewApiSubscription(apiBasePath, otherZoneName, apiSubAppName)
+			meshingApiSubscription = NewApiSubscription(apiBasePath, otherZoneName, apiSubAppName)
 
 			By("Creating the Zone")
 			otherZone = CreateZone(otherZoneName)
@@ -355,7 +355,7 @@ var _ = Describe("ApiSubscription Controller", Ordered, func() {
 
 		It("should create a proxy-route if on a different zone as the API-Exposure", func() {
 			By("Creating the resource")
-			err := k8sClient.Create(ctx, apiSubscription)
+			err := k8sClient.Create(ctx, meshingApiSubscription)
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Checking if the resource has the expected state")
@@ -390,7 +390,7 @@ var _ = Describe("ApiSubscription Controller", Ordered, func() {
 				proxyRouteRef := apiExposure.Status.ProxyRoutes[0]
 
 				By("Checking the ApiSubscription")
-				err = k8sClient.Get(ctx, client.ObjectKeyFromObject(apiSubscription), apiSubscription)
+				err = k8sClient.Get(ctx, client.ObjectKeyFromObject(meshingApiSubscription), meshingApiSubscription)
 				g.Expect(err).ToNot(HaveOccurred())
 				testutil.ExpectConditionToBeFalse(g, meta.FindStatusCondition(meshingApiSubscription.GetConditions(), condition.ConditionTypeProcessing), "Done")
 				testutil.ExpectConditionToBeTrue(g, meta.FindStatusCondition(meshingApiSubscription.GetConditions(), condition.ConditionTypeReady), "Provisioned")

--- a/api/internal/controller/apisubscription_controller_test.go
+++ b/api/internal/controller/apisubscription_controller_test.go
@@ -8,8 +8,11 @@ import (
 	"encoding/json"
 	"fmt"
 
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
 	adminapi "github.com/telekom/controlplane/admin/api/v1"
 	apiapi "github.com/telekom/controlplane/api/api/v1"
 	applicationapi "github.com/telekom/controlplane/application/api/v1"
@@ -21,10 +24,9 @@ import (
 	"github.com/telekom/controlplane/common/pkg/util/labelutil"
 	gatewayapi "github.com/telekom/controlplane/gateway/api/v1"
 	identityapi "github.com/telekom/controlplane/identity/api/v1"
-	"k8s.io/apimachinery/pkg/api/meta"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 )
 
 func CreateApplication(name string) *applicationapi.Application {
@@ -151,7 +153,6 @@ func ProgressApproval(apiSub *apiapi.ApiSubscription, state approvalapi.Approval
 		},
 	}
 	_, err := controllerutil.CreateOrUpdate(ctx, k8sClient, approval, func() error {
-
 		err := controllerutil.SetControllerReference(apiSub, approval, k8sClient.Scheme())
 		Expect(err).ToNot(HaveOccurred())
 
@@ -177,23 +178,23 @@ func ProgressApproval(apiSub *apiapi.ApiSubscription, state approvalapi.Approval
 
 var _ = Describe("ApiSubscription Controller", Ordered, func() {
 	// API that is used for the tests
-	var apiBasePath = "/apisubctrl/test/v1"
+	apiBasePath := "/apisubctrl/test/v1"
 
 	// Provider side
 	var api *apiapi.Api
 	var apiExposure *apiapi.ApiExposure
 
 	// Provider/Exposure zone
-	var zoneName = "apisub-test"
+	zoneName := "apisub-test"
 	var zone *adminapi.Zone
 
 	// Consumer/Subscription zone
-	var otherZoneName = "other-zone"
+	otherZoneName := "other-zone"
 	var otherZone *adminapi.Zone
 
 	// Consumer side
-	var apiSubAppName = "my-test-app-sub"
-	var apiExpAppName = "my-test-app-exp"
+	apiSubAppName := "my-test-app-sub"
+	apiExpAppName := "my-test-app-exp"
 	var apiSubApplication *applicationapi.Application
 	var apiExpApplication *applicationapi.Application
 	var apiSubscription *apiapi.ApiSubscription
@@ -233,7 +234,6 @@ var _ = Describe("ApiSubscription Controller", Ordered, func() {
 	})
 
 	Context("Creating and Updating", func() {
-
 		It("should block until an API is exposed", func() {
 			By("Creating the resource")
 			err := k8sClient.Create(ctx, apiSubscription)
@@ -247,9 +247,7 @@ var _ = Describe("ApiSubscription Controller", Ordered, func() {
 				g.Expect(processingCondition).ToNot(BeNil())
 				g.Expect(processingCondition.Status).To(Equal(metav1.ConditionFalse))
 				g.Expect(processingCondition.Reason).To(Equal("Blocked"))
-
 			}, timeout, interval).Should(Succeed())
-
 		})
 
 		It("should automatically progress when an API is exposed", func() {
@@ -271,9 +269,7 @@ var _ = Describe("ApiSubscription Controller", Ordered, func() {
 
 				By("Checking the conditions")
 				testutil.ExpectConditionToBeFalse(g, meta.FindStatusCondition(apiSubscription.GetConditions(), condition.ConditionTypeProcessing), "Blocked")
-
 			}, timeout, interval).Should(Succeed())
-
 		})
 
 		It("should correctly use the approval-workflow", func() {
@@ -299,7 +295,6 @@ var _ = Describe("ApiSubscription Controller", Ordered, func() {
 				err = json.Unmarshal(approvalRequest.Spec.Requester.Properties.Raw, &propertiesMap)
 				g.Expect(err).ToNot(HaveOccurred())
 				g.Expect(propertiesMap["scopes"]).To(HaveLen(2))
-
 			}, timeout, interval).Should(Succeed())
 		})
 
@@ -323,7 +318,6 @@ var _ = Describe("ApiSubscription Controller", Ordered, func() {
 				By("Checking if the route is the real-route")
 				g.Expect(apiSubRoute.Name).To(Equal(apiExpRoute.Name))
 				g.Expect(apiSubRoute.Namespace).To(Equal(apiExpRoute.Namespace))
-
 			}, timeout, interval).Should(Succeed())
 		})
 
@@ -341,14 +335,12 @@ var _ = Describe("ApiSubscription Controller", Ordered, func() {
 				g.Expect(consumeRoute.Spec.Security.M2M.Scopes[0]).To(Equal("scope1"))
 				g.Expect(consumeRoute.Spec.Security.M2M.Scopes[1]).To(Equal("scope2"))
 				g.Expect(consumeRoute.Spec.Security.M2M.Scopes).To(ConsistOf("scope1", "scope2"))
-
 			}, timeout, interval).Should(Succeed())
 		})
 	})
 
 	Context("Meshing", func() {
-
-		var apiSubscription *apiapi.ApiSubscription
+		var meshingApiSubscription *apiapi.ApiSubscription
 
 		BeforeAll(func() {
 			By("Initializing the ApiSubscription")
@@ -362,31 +354,28 @@ var _ = Describe("ApiSubscription Controller", Ordered, func() {
 		})
 
 		It("should create a proxy-route if on a different zone as the API-Exposure", func() {
-
 			By("Creating the resource")
 			err := k8sClient.Create(ctx, apiSubscription)
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Checking if the resource has the expected state")
 			Eventually(func(g Gomega) {
-				err := k8sClient.Get(ctx, client.ObjectKeyFromObject(apiSubscription), apiSubscription)
-				g.Expect(err).ToNot(HaveOccurred())
+				getErr := k8sClient.Get(ctx, client.ObjectKeyFromObject(meshingApiSubscription), meshingApiSubscription)
+				g.Expect(getErr).ToNot(HaveOccurred())
 				By("Checking the conditions")
-				readyCondition := meta.FindStatusCondition(apiSubscription.Status.Conditions, condition.ConditionTypeReady)
+				readyCondition := meta.FindStatusCondition(meshingApiSubscription.Status.Conditions, condition.ConditionTypeReady)
 				g.Expect(readyCondition).ToNot(BeNil())
 				g.Expect(readyCondition.Status).To(Equal(metav1.ConditionFalse))
 				g.Expect(readyCondition.Reason).To(Equal("ApprovalPending"))
-
 			}, timeout, interval).Should(Succeed())
 
 			By("Progressing the Approval resources")
-			approvalReq := ProgressApprovalRequest(apiSubscription.Status.ApprovalRequest, approvalapi.ApprovalStateGranted)
-			approval := ProgressApproval(apiSubscription, approvalapi.ApprovalStateGranted, approvalReq)
+			approvalReq := ProgressApprovalRequest(meshingApiSubscription.Status.ApprovalRequest, approvalapi.ApprovalStateGranted)
+			approval := ProgressApproval(meshingApiSubscription, approvalapi.ApprovalStateGranted, approvalReq)
 			Expect(approval).ToNot(BeNil())
 		})
 
 		It("should create a proxy-route", func() {
-
 			By("Checking if the resource has the expected state")
 			Eventually(func(g Gomega) {
 				By("Getting the ApiExposure")
@@ -403,10 +392,10 @@ var _ = Describe("ApiSubscription Controller", Ordered, func() {
 				By("Checking the ApiSubscription")
 				err = k8sClient.Get(ctx, client.ObjectKeyFromObject(apiSubscription), apiSubscription)
 				g.Expect(err).ToNot(HaveOccurred())
-				testutil.ExpectConditionToBeFalse(g, meta.FindStatusCondition(apiSubscription.GetConditions(), condition.ConditionTypeProcessing), "Done")
-				testutil.ExpectConditionToBeTrue(g, meta.FindStatusCondition(apiSubscription.GetConditions(), condition.ConditionTypeReady), "Provisioned")
-				g.Expect(apiSubscription.Status.Route).ToNot(BeNil())
-				apiSubRoute := apiSubscription.Status.Route
+				testutil.ExpectConditionToBeFalse(g, meta.FindStatusCondition(meshingApiSubscription.GetConditions(), condition.ConditionTypeProcessing), "Done")
+				testutil.ExpectConditionToBeTrue(g, meta.FindStatusCondition(meshingApiSubscription.GetConditions(), condition.ConditionTypeReady), "Provisioned")
+				g.Expect(meshingApiSubscription.Status.Route).ToNot(BeNil())
+				apiSubRoute := meshingApiSubscription.Status.Route
 
 				By("Verifying the subscription references the proxy route")
 				g.Expect(apiSubRoute).ToNot(Equal(apiExpRoute), "Subscription route should be different from the real route")
@@ -419,22 +408,19 @@ var _ = Describe("ApiSubscription Controller", Ordered, func() {
 				g.Expect(err).ToNot(HaveOccurred())
 
 				g.Expect(route.Spec.Upstreams[0].IssuerUrl).To(Equal("http://my-issuer.apisub-test:8080/auth/realms/test"))
-
 			}, timeout, interval).Should(Succeed())
 		})
-
 	})
 
 	Context("Prevent deletion of underlying Routes if multiple Api-Subscriptions exist", func() {
-
-		apiSubAppName := "my-second-app"
+		secondApiSubAppName := "my-second-app"
 		var secondApiSubscription *apiapi.ApiSubscription
 
 		BeforeAll(func() {
 			By("Initializing the second ApiSubscription")
-			secondApiSubscription = NewApiSubscription(apiBasePath, otherZoneName, apiSubAppName)
+			secondApiSubscription = NewApiSubscription(apiBasePath, otherZoneName, secondApiSubAppName)
 			By("Creating the Application")
-			CreateApplication(apiSubAppName)
+			CreateApplication(secondApiSubAppName)
 
 			By("Setting up a second ApiSubscription")
 			err := k8sClient.Create(ctx, secondApiSubscription)
@@ -449,7 +435,6 @@ var _ = Describe("ApiSubscription Controller", Ordered, func() {
 				g.Expect(readyCondition).ToNot(BeNil())
 				g.Expect(readyCondition.Status).To(Equal(metav1.ConditionFalse))
 				g.Expect(readyCondition.Reason).To(Equal("ApprovalPending"))
-
 			}, timeout, interval).Should(Succeed())
 
 			By("Progressing the Approval resources")
@@ -458,7 +443,6 @@ var _ = Describe("ApiSubscription Controller", Ordered, func() {
 		})
 
 		It("should never remove the proxy-route if there is another active API-Subscription", func() {
-
 			By("Ensuring that both Api-Subscription are actually ready and active")
 			Eventually(func(g Gomega) {
 				By("Checking the first ApiSubscription")
@@ -469,7 +453,6 @@ var _ = Describe("ApiSubscription Controller", Ordered, func() {
 				err = k8sClient.Get(ctx, client.ObjectKeyFromObject(secondApiSubscription), secondApiSubscription)
 				g.Expect(err).ToNot(HaveOccurred())
 				g.Expect(secondApiSubscription.Status.Route).ToNot(BeNil())
-
 			}, timeout, interval).Should(Succeed())
 
 			By("Deleting the first ApiSubscription")
@@ -481,7 +464,6 @@ var _ = Describe("ApiSubscription Controller", Ordered, func() {
 				route := &gatewayapi.Route{}
 				err := k8sClient.Get(ctx, apiSubscription.Status.Route.K8s(), route)
 				g.Expect(err).ToNot(HaveOccurred())
-
 			}, timeout, interval).Should(Succeed())
 		})
 	})
@@ -492,7 +474,7 @@ var _ = Describe("ApiSubscription Controller", Ordered, func() {
 
 			BeforeEach(func() {
 				apiSubscription = NewApiSubscription(apiBasePath, otherZoneName, apiSubAppName)
-				apiSubscription.ObjectMeta.Name = apiSubscription.Name + "-security"
+				apiSubscription.Name += "-security"
 			})
 
 			AfterEach(func() {
@@ -514,8 +496,8 @@ var _ = Describe("ApiSubscription Controller", Ordered, func() {
 
 				By("Checking if the resource the approval is pending")
 				Eventually(func(g Gomega) {
-					err := k8sClient.Get(ctx, client.ObjectKeyFromObject(apiSubscription), apiSubscription)
-					g.Expect(err).ToNot(HaveOccurred())
+					getErr := k8sClient.Get(ctx, client.ObjectKeyFromObject(apiSubscription), apiSubscription)
+					g.Expect(getErr).ToNot(HaveOccurred())
 					By("checking that the resource is in the BLOCKED state")
 					testutil.ExpectConditionToBeFalse(g, meta.FindStatusCondition(apiSubscription.Status.Conditions, condition.ConditionTypeProcessing), "Blocked")
 				}, timeout, interval).Should(Succeed())
@@ -547,7 +529,6 @@ var _ = Describe("ApiSubscription Controller", Ordered, func() {
 					g.Expect(consumeRoute.Spec.Security.M2M.Client.ClientSecret).To(Equal("******"))
 					g.Expect(consumeRoute.Spec.Security.M2M.Scopes).To(Equal([]string{"scope1", "scope2"}))
 					g.Expect(consumeRoute.Spec.Route).To(Equal(*apiSubscription.Status.Route))
-
 				}, timeout, interval).Should(Succeed())
 			})
 		})
@@ -568,7 +549,6 @@ var _ = Describe("Remote Organisation Flow", Ordered, func() {
 	var remoteApiSubscription *apiapi.RemoteApiSubscription
 
 	Context("Remote Subscription Flow", func() {
-
 		BeforeAll(func() {
 			By("Creating the RemoteOrganisation")
 			remoteOrganisation = CreateRemoteOrganisation(remoteOrgId, remoteZoneName)
@@ -615,9 +595,7 @@ var _ = Describe("Remote Organisation Flow", Ordered, func() {
 				g.Expect(err).ToNot(HaveOccurred())
 
 				Expect(remoteApiSubscription.Spec.TargetOrganization).To(Equal(remoteOrgId))
-
 			}, timeout, interval).Should(Succeed())
-
 		})
 
 		It("should progress when the RemoteApiSubscription has been approved and is ready", func() {
@@ -650,12 +628,10 @@ var _ = Describe("Remote Organisation Flow", Ordered, func() {
 				route := &gatewayapi.Route{}
 				err = k8sClient.Get(ctx, apiSubscription.Status.Route.K8s(), route)
 				g.Expect(err).ToNot(HaveOccurred())
-
 			}, timeout, interval).Should(Succeed())
 		})
 
 		It("should re-use the Route created by the RemoteApiSubscription and not create a proxy-route", func() {
-
 			By("Checking if the resource has the expected state")
 			Eventually(func(g Gomega) {
 				err := k8sClient.Get(ctx, client.ObjectKeyFromObject(apiSubscription), apiSubscription)
@@ -672,13 +648,10 @@ var _ = Describe("Remote Organisation Flow", Ordered, func() {
 				By("Checking that the route is the same as the RemoteApiSubscription")
 				g.Expect(apiSubscription.Status.Route.Name).To(Equal("esp--apisubctrl-remotetest-v1"))
 				g.Expect(apiSubscription.Status.Route.Namespace).To(Equal("test--remote-zone"))
-
 			}, timeout, interval).Should(Succeed())
-
 		})
 
 		It("should create a proxy-route if the RemoteApiSubscription is in a different zone", func() {
-
 			By("Changing the zone of the ApiSubscription")
 			apiSubscription.Spec.Zone = types.ObjectRef{
 				Name:      consumerZoneName,
@@ -690,15 +663,12 @@ var _ = Describe("Remote Organisation Flow", Ordered, func() {
 
 			By("Checking if the resource has the expected state")
 			Eventually(func(g Gomega) {
-
 				err := k8sClient.Get(ctx, client.ObjectKeyFromObject(apiSubscription), apiSubscription)
 				g.Expect(err).ToNot(HaveOccurred())
 
 				g.Expect(apiSubscription.Status.Route.Name).To(Equal("esp--apisubctrl-remotetest-v1"))
 				g.Expect(apiSubscription.Status.Route.Namespace).To(Equal("test--consumer-zone"))
-
 			}, timeout, interval).Should(Succeed())
-
 		})
 	})
 })

--- a/api/internal/controller/apisubscription_trusted_teams_test.go
+++ b/api/internal/controller/apisubscription_trusted_teams_test.go
@@ -5,18 +5,19 @@
 package controller
 
 import (
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
 	adminapi "github.com/telekom/controlplane/admin/api/v1"
 	apiapi "github.com/telekom/controlplane/api/api/v1"
-	apiv1 "github.com/telekom/controlplane/api/api/v1"
 	applicationv1 "github.com/telekom/controlplane/application/api/v1"
 	approvalapi "github.com/telekom/controlplane/approval/api/v1"
 	"github.com/telekom/controlplane/common/pkg/condition"
 	"github.com/telekom/controlplane/common/pkg/test/testutil"
 	"github.com/telekom/controlplane/common/pkg/types"
-	"k8s.io/apimachinery/pkg/api/meta"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 )
 
 func createTeam(teamName, groupName, env string) types.ObjectRef {
@@ -27,6 +28,8 @@ func createTeam(teamName, groupName, env string) types.ObjectRef {
 }
 
 // Helper function to create an application with a specific team and verify it exists
+//
+//nolint:unparam // helper return is kept for callers that need the created app later.
 func setupAppWithTeam(appName, teamName string) *applicationv1.Application {
 	app := CreateApplication(appName)
 	app.Spec.Team = teamName
@@ -63,15 +66,15 @@ func verifyApprovalStrategy(subscription *apiapi.ApiSubscription, expectedStrate
 }
 
 var _ = Describe("ApiSubscription Controller with Trusted Teams", Ordered, func() {
-	var apiBasePath = "/apiexpctrl/trustedteams/v1"
-	var zoneName = "apiexp-trustedteams"
+	apiBasePath := "/apiexpctrl/trustedteams/v1"
+	zoneName := "apiexp-trustedteams"
 
-	var apiExposure *apiv1.ApiExposure
-	var api *apiv1.Api
+	var apiExposure *apiapi.ApiExposure
+	var api *apiapi.Api
 	var zone *adminapi.Zone
 	var team1, team2, team3 types.ObjectRef
 
-	var apiExpAppName = "api-exposure-app"
+	apiExpAppName := "api-exposure-app"
 	var apiExpApplication *applicationv1.Application
 
 	BeforeAll(func() {
@@ -108,7 +111,7 @@ var _ = Describe("ApiSubscription Controller with Trusted Teams", Ordered, func(
 		It("should create ApiExposure with trusted teams correctly", func() {
 			By("Creating an ApiExposure with trusted teams")
 			apiExposure = NewApiExposure(apiBasePath, zoneName, apiExpAppName)
-			apiExposure.Spec.Approval = apiv1.Approval{
+			apiExposure.Spec.Approval = apiapi.Approval{
 				Strategy: apiapi.ApprovalStrategyFourEyes,
 				TrustedTeams: []string{
 					team1.GetName(), team2.GetName(),
@@ -209,7 +212,7 @@ var _ = Describe("ApiSubscription Controller with Trusted Teams", Ordered, func(
 
 			By("Verifying the ApiExposure was updated with new trusted teams")
 			Eventually(func(g Gomega) {
-				updatedExposure := &apiv1.ApiExposure{}
+				updatedExposure := &apiapi.ApiExposure{}
 				err := k8sClient.Get(ctx, client.ObjectKeyFromObject(apiExposure), updatedExposure)
 				g.Expect(err).ToNot(HaveOccurred())
 
@@ -229,9 +232,7 @@ var _ = Describe("ApiSubscription Controller with Trusted Teams", Ordered, func(
 
 				// Team3 should now be auto-approved
 				verifyApprovalStrategy(team3Sub, approvalapi.ApprovalStrategyAuto)
-
 			}, timeout*3, interval).Should(Succeed())
-
 		})
 	})
 })

--- a/api/internal/controller/index.go
+++ b/api/internal/controller/index.go
@@ -8,14 +8,14 @@ import (
 	"context"
 	"os"
 
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
 	apiapi "github.com/telekom/controlplane/api/api/v1"
 	applicationapi "github.com/telekom/controlplane/application/api/v1"
 	approvalapi "github.com/telekom/controlplane/approval/api/v1"
 	"github.com/telekom/controlplane/common/pkg/controller/index"
 	gatewayapi "github.com/telekom/controlplane/gateway/api/v1"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-
-	ctrl "sigs.k8s.io/controller-runtime"
 )
 
 func RegisterIndecesOrDie(ctx context.Context, mgr ctrl.Manager) {
@@ -87,5 +87,4 @@ func RegisterIndecesOrDie(ctx context.Context, mgr ctrl.Manager) {
 		ctrl.Log.Error(err, "unable to create field-indexer")
 		os.Exit(1)
 	}
-
 }

--- a/api/internal/controller/remoteapisubscription_controller.go
+++ b/api/internal/controller/remoteapisubscription_controller.go
@@ -7,8 +7,6 @@ package controller
 import (
 	"context"
 
-	cconfig "github.com/telekom/controlplane/common/pkg/config"
-	cc "github.com/telekom/controlplane/common/pkg/controller"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -19,6 +17,8 @@ import (
 	"github.com/telekom/controlplane/api/internal/handler/remoteapisubscription"
 	"github.com/telekom/controlplane/api/internal/handler/remoteapisubscription/syncer"
 	applicationapi "github.com/telekom/controlplane/application/api/v1"
+	cconfig "github.com/telekom/controlplane/common/pkg/config"
+	cc "github.com/telekom/controlplane/common/pkg/controller"
 )
 
 // RemoteApiSubscriptionReconciler reconciles a RemoteApiSubscription object

--- a/api/internal/controller/remoteapisubscription_controller_test.go
+++ b/api/internal/controller/remoteapisubscription_controller_test.go
@@ -7,11 +7,12 @@ package controller
 import (
 	"fmt"
 
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
 	adminapi "github.com/telekom/controlplane/admin/api/v1"
 	apiapi "github.com/telekom/controlplane/api/api/v1"
-	apiv1 "github.com/telekom/controlplane/api/api/v1"
 	applicationapi "github.com/telekom/controlplane/application/api/v1"
 	approvalapi "github.com/telekom/controlplane/approval/api/v1"
 	"github.com/telekom/controlplane/common/pkg/condition"
@@ -20,9 +21,9 @@ import (
 	"github.com/telekom/controlplane/common/pkg/types"
 	"github.com/telekom/controlplane/common/pkg/util/labelutil"
 	gatewayapi "github.com/telekom/controlplane/gateway/api/v1"
-	"k8s.io/apimachinery/pkg/api/meta"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 )
 
 func CreateRemoteOrganisation(orgId, zoneName string) *adminapi.RemoteOrganization {
@@ -67,7 +68,7 @@ func NewRemoteApiSubscription(apiBasePath, appName string) *apiapi.RemoteApiSubs
 			Namespace: testNamespace,
 			Labels: map[string]string{
 				config.EnvironmentLabelKey: testEnvironment,
-				apiv1.BasePathLabelKey:     labelutil.NormalizeLabelValue(apiBasePath),
+				apiapi.BasePathLabelKey:    labelutil.NormalizeLabelValue(apiBasePath),
 			},
 		},
 		Spec: apiapi.RemoteApiSubscriptionSpec{
@@ -108,10 +109,10 @@ func ProgressApplication(appName string) *applicationapi.Application {
 }
 
 var _ = Describe("RemoteApiSubscription Controller - Provider Scenario", Ordered, func() {
-	var apiBasePath = "/remoteapisubctrl/testprov/v1"
-	var zoneName = "remoteapisub-test"
-	var remoteOrgId = "ger"
-	var appName = "my-remote-test-app"
+	apiBasePath := "/remoteapisubctrl/testprov/v1"
+	zoneName := "remoteapisub-test"
+	remoteOrgId := "ger"
+	appName := "my-remote-test-app"
 
 	var api *apiapi.Api
 	var apiExposure *apiapi.ApiExposure
@@ -121,7 +122,7 @@ var _ = Describe("RemoteApiSubscription Controller - Provider Scenario", Ordered
 
 	var remoteApiSubscription *apiapi.RemoteApiSubscription
 
-	var apiExpAppName = "api-exposure-app"
+	apiExpAppName := "api-exposure-app"
 	var apiExpApplication *applicationapi.Application
 
 	BeforeAll(func() {
@@ -163,7 +164,6 @@ var _ = Describe("RemoteApiSubscription Controller - Provider Scenario", Ordered
 	})
 
 	Context("We are the target of the remote API subscription", func() {
-
 		It("should block until an API is registered", func() {
 			By("Creating the resource")
 			err := k8sClient.Create(ctx, remoteApiSubscription)
@@ -174,14 +174,12 @@ var _ = Describe("RemoteApiSubscription Controller - Provider Scenario", Ordered
 				err := k8sClient.Get(ctx, client.ObjectKeyFromObject(remoteApiSubscription), remoteApiSubscription)
 				g.Expect(err).ToNot(HaveOccurred())
 				testutil.ExpectConditionToBeFalse(g, meta.FindStatusCondition(remoteApiSubscription.GetConditions(), condition.ConditionTypeReady), "NoApi")
-
 			}, timeout, interval).Should(Succeed())
 
 			By("Progressing the application")
 			ProgressApplication(appName)
 
 			// TODO: test if syncClient was called
-
 		})
 
 		It("should automatically progress when an API is exposed", func() {
@@ -192,10 +190,9 @@ var _ = Describe("RemoteApiSubscription Controller - Provider Scenario", Ordered
 			Eventually(func(g Gomega) {
 				By("Checking the conditions on Api")
 				apiRes := &apiapi.Api{}
-				err := k8sClient.Get(ctx, client.ObjectKeyFromObject(api), apiRes)
-				g.Expect(err).ToNot(HaveOccurred())
+				getErr := k8sClient.Get(ctx, client.ObjectKeyFromObject(api), apiRes)
+				g.Expect(getErr).ToNot(HaveOccurred())
 				testutil.ExpectConditionToBeTrue(g, meta.FindStatusCondition(apiRes.GetConditions(), condition.ConditionTypeReady), "ApiActive")
-
 			}, timeout, interval).Should(Succeed())
 
 			By("Creating the APIExposure resource")
@@ -210,17 +207,15 @@ var _ = Describe("RemoteApiSubscription Controller - Provider Scenario", Ordered
 				g.Expect(err).ToNot(HaveOccurred())
 				testutil.ExpectConditionToBeTrue(g, meta.FindStatusCondition(apiExp.GetConditions(), condition.ConditionTypeReady), "Provisioned")
 				g.Expect(apiExp.Status.Active).To(BeTrue())
-				g.Expect(apiExp.GetLabels()[apiv1.BasePathLabelKey]).To(Equal(labelutil.NormalizeLabelValue(apiBasePath)))
+				g.Expect(apiExp.GetLabels()[apiapi.BasePathLabelKey]).To(Equal(labelutil.NormalizeLabelValue(apiBasePath)))
 
 				By("Checking the conditions on RemoteApiSubscription")
 				err = k8sClient.Get(ctx, client.ObjectKeyFromObject(remoteApiSubscription), remoteApiSubscription)
 				g.Expect(err).ToNot(HaveOccurred())
 				testutil.ExpectConditionToBeFalse(g, meta.FindStatusCondition(remoteApiSubscription.GetConditions(), condition.ConditionTypeReady), "ApprovalPending")
-
 			}, timeout, interval).Should(Succeed())
 
 			// TODO: test if syncClient was called
-
 		})
 
 		It("should create the application", func() {
@@ -234,7 +229,6 @@ var _ = Describe("RemoteApiSubscription Controller - Provider Scenario", Ordered
 				g.Expect(application.Spec.NeedsClient).To(BeFalse())
 				g.Expect(application.Spec.NeedsConsumer).To(BeTrue())
 				g.Expect(application.Spec.Zone.Name).To(Equal(remoteZone.Name))
-
 			}, timeout, interval).Should(Succeed())
 		})
 
@@ -261,7 +255,6 @@ var _ = Describe("RemoteApiSubscription Controller - Provider Scenario", Ordered
 				g.Expect(readyCondition).ToNot(BeNil())
 				g.Expect(readyCondition.Status).To(Equal(metav1.ConditionFalse))
 				g.Expect(readyCondition.Reason).To(Equal("ApprovalPending"))
-
 			}, timeout, interval).Should(Succeed())
 		})
 
@@ -281,18 +274,16 @@ var _ = Describe("RemoteApiSubscription Controller - Provider Scenario", Ordered
 
 				By("checking that the route-info is filled")
 				g.Expect(remoteApiSubscription.Status.GatewayUrl).To(Equal("https://ger.gateway.es/remoteapisubctrl/testprov/v1"))
-
 			}, timeout, interval).Should(Succeed())
 		})
-
 	})
 })
 
 var _ = Describe("RemoteApiSubscription Controller - Consumer Scenario", Ordered, func() {
-	var apiBasePath = "/remoteapisubctrl/testcons/v1"
-	var zoneName = "remoteapisub-test-cons"
-	var appName = "my-remote-test-cons-app"
-	var remoteOrgId = "pol"
+	apiBasePath := "/remoteapisubctrl/testcons/v1"
+	zoneName := "remoteapisub-test-cons"
+	appName := "my-remote-test-cons-app"
+	remoteOrgId := "pol"
 
 	var zone *adminapi.Zone
 	var remoteOrg *adminapi.RemoteOrganization
@@ -312,7 +303,6 @@ var _ = Describe("RemoteApiSubscription Controller - Consumer Scenario", Ordered
 
 		By("Creating the RemoteOrganization")
 		remoteOrg = CreateRemoteOrganisation(remoteOrgId, zoneName)
-
 	})
 
 	AfterAll(func() {
@@ -322,7 +312,6 @@ var _ = Describe("RemoteApiSubscription Controller - Consumer Scenario", Ordered
 	})
 
 	Context("We are the consumer of the remote API subscription", func() {
-
 		It("should send the RemoteApiSubscription to the target", func() {
 			By("Creating the resource")
 			err := k8sClient.Create(ctx, remoteApiSubscription)
@@ -338,9 +327,7 @@ var _ = Describe("RemoteApiSubscription Controller - Consumer Scenario", Ordered
 				readyCondition := meta.FindStatusCondition(remoteApiSubscription.Status.Conditions, condition.ConditionTypeReady)
 				g.Expect(readyCondition).ToNot(BeNil())
 				g.Expect(readyCondition.Status).To(Equal(metav1.ConditionUnknown))
-
 			}, timeout, interval).Should(Succeed())
-
 		})
 
 		It("should progress the RemoteApiSubscription if the sync was successful and approved", func() {
@@ -369,7 +356,6 @@ var _ = Describe("RemoteApiSubscription Controller - Consumer Scenario", Ordered
 				testutil.ExpectConditionToMatch(g, meta.FindStatusCondition(remoteApiSubscription.Status.Conditions, condition.ConditionTypeReady), "RemoteApiSubscriptionReady", true)
 
 				g.Expect(remoteApiSubscription.Status.Route).ToNot(BeNil())
-
 			}, timeout, interval).Should(Succeed())
 		})
 	})
@@ -388,8 +374,6 @@ var _ = Describe("RemoteApiSubscription Controller - Consumer Scenario", Ordered
 			g.Expect(err).To(HaveOccurred())
 
 			// TODO: test if syncClient was called
-
 		}, timeout, interval).Should(Succeed())
 	})
-
 })

--- a/api/internal/controller/schema.go
+++ b/api/internal/controller/schema.go
@@ -5,15 +5,16 @@
 package controller
 
 import (
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+
 	adminapi "github.com/telekom/controlplane/admin/api/v1"
 	apiapi "github.com/telekom/controlplane/api/api/v1"
 	applicationapi "github.com/telekom/controlplane/application/api/v1"
 	approvalapi "github.com/telekom/controlplane/approval/api/v1"
 	gatewayapi "github.com/telekom/controlplane/gateway/api/v1"
 	identityapi "github.com/telekom/controlplane/identity/api/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 )
 
 func RegisterSchemesOrDie(scheme *runtime.Scheme) {

--- a/api/internal/controller/suite_test.go
+++ b/api/internal/controller/suite_test.go
@@ -13,24 +13,23 @@ import (
 	"testing"
 	"time"
 
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
-
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
-	"github.com/telekom/controlplane/common/pkg/test/mock"
-	ctrl "sigs.k8s.io/controller-runtime"
-
 	apiv1 "github.com/telekom/controlplane/api/api/v1"
 	"github.com/telekom/controlplane/api/internal/handler/remoteapisubscription/syncer"
+	"github.com/telekom/controlplane/common/pkg/test/mock"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 	// +kubebuilder:scaffold:imports
 )
 
@@ -44,11 +43,13 @@ const (
 	testEnvironment = "test"
 )
 
-var cfg *rest.Config
-var k8sClient client.Client
-var testEnv *envtest.Environment
-var ctx context.Context
-var cancel context.CancelFunc
+var (
+	cfg       *rest.Config
+	k8sClient client.Client
+	testEnv   *envtest.Environment
+	ctx       context.Context
+	cancel    context.CancelFunc
+)
 
 var syncerFactoryMock = syncer.NewSyncerFactoryMock()
 

--- a/api/internal/handler/api/handler.go
+++ b/api/internal/handler/api/handler.go
@@ -10,14 +10,15 @@ import (
 	"slices"
 
 	"github.com/pkg/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
 	api "github.com/telekom/controlplane/api/api/v1"
 	cclient "github.com/telekom/controlplane/common/pkg/client"
 	"github.com/telekom/controlplane/common/pkg/condition"
 	"github.com/telekom/controlplane/common/pkg/errors/ctrlerrors"
 	"github.com/telekom/controlplane/common/pkg/handler"
 	"github.com/telekom/controlplane/common/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 var _ handler.Handler[*api.Api] = (*ApiHandler)(nil)
@@ -25,7 +26,7 @@ var _ handler.Handler[*api.Api] = (*ApiHandler)(nil)
 type ApiHandler struct{}
 
 func (h *ApiHandler) CreateOrUpdate(ctx context.Context, obj *api.Api) error {
-	log := log.FromContext(ctx)
+	logger := log.FromContext(ctx)
 
 	scopedClient, ok := cclient.ClientFromContext(ctx)
 	if !ok {
@@ -58,28 +59,28 @@ func (h *ApiHandler) CreateOrUpdate(ctx context.Context, obj *api.Api) error {
 	}
 
 	slices.SortStableFunc(apiList.Items, sortByCreationTime)
-	api := apiList.Items[0]
+	activeAPI := apiList.Items[0]
 
-	if types.Equals(&api, obj) {
+	if types.Equals(&activeAPI, obj) {
 		// the oldest api is the same as the one we are trying to create
 		obj.Status.Active = true
 		obj.SetCondition(condition.NewReadyCondition("ApiActive", "Api is active"))
 		obj.SetCondition(condition.NewDoneProcessingCondition("Api is processed"))
-		log.Info("✅ Api is processed")
+		logger.Info("✅ Api is processed")
 
 	} else {
 		// there is already a different api active with the same BasePathLabelKey
 		// the new api will be blocked until the other is deleted
 		obj.Status.Active = false
 
-		if obj.Spec.BasePath == api.Spec.BasePath {
+		if obj.Spec.BasePath == activeAPI.Spec.BasePath {
 			// The exact same API (case matches)
 			obj.SetCondition(condition.NewNotReadyCondition("ApiNotActive", "Api is not active"))
 			obj.SetCondition(condition.NewBlockedCondition(
 				"Api is blocked, another Api with the same BasePath is active. " +
 					"It will be automatically processed, if the other Api will be deleted.",
 			))
-			log.Info("❌ Api is blocked, another Api with the same BasePath is already active.")
+			logger.Info("❌ Api is blocked, another Api with the same BasePath is already active.")
 
 		} else {
 			// The same API is exposed but it has a different case (e.g. /MyApi vs /myapi)
@@ -88,7 +89,7 @@ func (h *ApiHandler) CreateOrUpdate(ctx context.Context, obj *api.Api) error {
 				"Api is blocked, another Api with the same BasePath but different case is active. " +
 					"Please resolve the conflict by changing the BasePath of one of the Apis.",
 			))
-			log.Info("❌ Api is blocked, another Api with the same BasePath but different case is already active.")
+			logger.Info("❌ Api is blocked, another Api with the same BasePath but different case is already active.")
 		}
 
 	}

--- a/api/internal/handler/apicategory/handler.go
+++ b/api/internal/handler/apicategory/handler.go
@@ -7,10 +7,9 @@ package apicategory
 import (
 	"context"
 
+	apiv1 "github.com/telekom/controlplane/api/api/v1"
 	"github.com/telekom/controlplane/common/pkg/condition"
 	"github.com/telekom/controlplane/common/pkg/handler"
-
-	apiv1 "github.com/telekom/controlplane/api/api/v1"
 )
 
 var _ handler.Handler[*apiv1.ApiCategory] = (*ApiCategoryHandler)(nil)

--- a/api/internal/handler/apiexposure/conditions.go
+++ b/api/internal/handler/apiexposure/conditions.go
@@ -5,8 +5,9 @@
 package apiexposure
 
 import (
-	apiv1 "github.com/telekom/controlplane/api/api/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	apiv1 "github.com/telekom/controlplane/api/api/v1"
 )
 
 // NewApiCondition creates a condition indicating whether the corresponding API exists and is active.

--- a/api/internal/handler/apiexposure/handler.go
+++ b/api/internal/handler/apiexposure/handler.go
@@ -10,6 +10,9 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
 	apiapi "github.com/telekom/controlplane/api/api/v1"
 	"github.com/telekom/controlplane/api/internal/handler/util"
 	cclient "github.com/telekom/controlplane/common/pkg/client"
@@ -18,16 +21,15 @@ import (
 	"github.com/telekom/controlplane/common/pkg/types"
 	"github.com/telekom/controlplane/common/pkg/util/contextutil"
 	gatewayapi "github.com/telekom/controlplane/gateway/api/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 var _ handler.Handler[*apiapi.ApiExposure] = (*ApiExposureHandler)(nil)
 
 type ApiExposureHandler struct{}
 
+//nolint:gocyclo,nestif // Reconciliation validates API state and provisions several dependent routes.
 func (h *ApiExposureHandler) CreateOrUpdate(ctx context.Context, apiExp *apiapi.ApiExposure) error {
-	log := log.FromContext(ctx)
+	logger := log.FromContext(ctx)
 
 	// For an ApiExposure to be valid, two conditions need to be met:
 	// 1. There must be a corresponding active Api.
@@ -46,7 +48,8 @@ func (h *ApiExposureHandler) CreateOrUpdate(ctx context.Context, apiExp *apiapi.
 	}
 
 	// check if there is already a different active apiExposure with same basepath
-	if err := ApiExposureMustNotAlreadyExist(ctx, apiExp); err != nil {
+	err = ApiExposureMustNotAlreadyExist(ctx, apiExp)
+	if err != nil {
 		return errors.Wrapf(err, "failed to validate uniqueness of ApiExposure: %s in namespace: %s", apiExp.Name, apiExp.Namespace)
 	}
 
@@ -70,7 +73,7 @@ func (h *ApiExposureHandler) CreateOrUpdate(ctx context.Context, apiExp *apiapi.
 			} else {
 				scopesExist, invalidScopes := util.IsSubsetOfScopes(api.Spec.Oauth2Scopes, apiExp.Spec.Security.M2M.Scopes)
 				if !scopesExist {
-					var message = fmt.Sprintf("Some defined scopes are not available. Available scopes: \"%s\". Unsupported scopes: \"%s\"",
+					message := fmt.Sprintf("Some defined scopes are not available. Available scopes: %q. Unsupported scopes: %q",
 						strings.Join(api.Spec.Oauth2Scopes, ", "),
 						strings.Join(invalidScopes, ", "),
 					)
@@ -80,7 +83,7 @@ func (h *ApiExposureHandler) CreateOrUpdate(ctx context.Context, apiExp *apiapi.
 				}
 			}
 
-			log.V(1).Info("✅ Scopes are valid and exist")
+			logger.V(1).Info("✅ Scopes are valid and exist")
 		}
 	}
 
@@ -111,27 +114,27 @@ func (h *ApiExposureHandler) CreateOrUpdate(ctx context.Context, apiExp *apiapi.
 			options = append(options, util.WithServiceRateLimit(apiExp.Spec.Traffic.RateLimit.Provider))
 		}
 
-		proxyRoute, err := util.CreateProxyRoute(ctx, subscriberZoneRef, apiExp.Spec.Zone, apiExp.Spec.ApiBasePath,
+		proxyRoute, createErr := util.CreateProxyRoute(ctx, subscriberZoneRef, apiExp.Spec.Zone, apiExp.Spec.ApiBasePath,
 			contextutil.EnvFromContextOrDie(ctx),
 			options...,
 		)
-		if err != nil {
-			return errors.Wrapf(err, "failed to create proxy route for zone %s", subscriberZoneRef.Name)
+		if createErr != nil {
+			return errors.Wrapf(createErr, "failed to create proxy route for zone %s", subscriberZoneRef.Name)
 		}
 		apiExp.Status.ProxyRoutes = append(apiExp.Status.ProxyRoutes, *types.ObjectRefFromObject(proxyRoute))
-		log.V(1).Info("Proxy route created/updated", "zone", subscriberZoneRef.Name, "route", proxyRoute.Name)
+		logger.V(1).Info("Proxy route created/updated", "zone", subscriberZoneRef.Name, "route", proxyRoute.Name)
 	}
 
 	// Create provider failover route if configured (must be before cleanup to prevent deletion)
 	if apiExp.HasFailover() {
 		failoverZone := apiExp.Spec.Traffic.Failover.Zones[0] // currently only one failover zone is supported
-		failoverRoute, err := util.CreateProxyRoute(ctx, failoverZone, apiExp.Spec.Zone, apiExp.Spec.ApiBasePath,
+		failoverRoute, createErr := util.CreateProxyRoute(ctx, failoverZone, apiExp.Spec.Zone, apiExp.Spec.ApiBasePath,
 			contextutil.EnvFromContextOrDie(ctx),
 			util.WithFailoverUpstreams(apiExp.Spec.Upstreams...),
 			util.WithFailoverSecurity(apiExp.Spec.Security),
 		)
-		if err != nil {
-			return errors.Wrapf(err, "unable to create failover route for apiExposure: %s in namespace: %s", apiExp.Name, apiExp.Namespace)
+		if createErr != nil {
+			return errors.Wrapf(createErr, "unable to create failover route for apiExposure: %s in namespace: %s", apiExp.Name, apiExp.Namespace)
 		}
 		apiExp.Status.FailoverRoute = types.ObjectRefFromObject(failoverRoute)
 	}
@@ -142,7 +145,7 @@ func (h *ApiExposureHandler) CreateOrUpdate(ctx context.Context, apiExp *apiapi.
 		return errors.Wrap(err, "failed to cleanup stale proxy routes")
 	}
 	if deleted > 0 {
-		log.V(1).Info("Cleaned up stale proxy routes", "deleted", deleted)
+		logger.V(1).Info("Cleaned up stale proxy routes", "deleted", deleted)
 	}
 
 	// Create real route with proxy target flag if there are cross-zone subscribers
@@ -164,14 +167,14 @@ func (h *ApiExposureHandler) CreateOrUpdate(ctx context.Context, apiExp *apiapi.
 	apiExp.SetCondition(condition.NewReadyCondition("Provisioned", "Successfully provisioned subresources"))
 	apiExp.SetCondition(condition.NewDoneProcessingCondition("Successfully provisioned subresources"))
 	apiExp.Status.Route = types.ObjectRefFromObject(realRoute)
-	log.Info("✅ ApiExposure is processed")
+	logger.Info("✅ ApiExposure is processed")
 
 	return nil
 }
 
 func (h *ApiExposureHandler) Delete(ctx context.Context, obj *apiapi.ApiExposure) error {
 	scopedClient := cclient.ClientFromContextOrDie(ctx)
-	log := log.FromContext(ctx)
+	logger := log.FromContext(ctx)
 
 	// Clean up proxy routes
 	for i := range obj.Status.ProxyRoutes {
@@ -184,7 +187,7 @@ func (h *ApiExposureHandler) Delete(ctx context.Context, obj *apiapi.ApiExposure
 			}
 			return errors.Wrapf(err, "failed to get proxy route %s", ref.String())
 		}
-		log.Info("🧹 Deleting proxy route of exposure", "route", ref.String())
+		logger.Info("🧹 Deleting proxy route of exposure", "route", ref.String())
 		err = scopedClient.Delete(ctx, proxyRoute)
 		if err != nil {
 			return errors.Wrapf(err, "failed to delete proxy route %s", ref.String())
@@ -202,12 +205,12 @@ func (h *ApiExposureHandler) Delete(ctx context.Context, obj *apiapi.ApiExposure
 			return errors.Wrap(err, "failed to get route")
 		}
 
-		log.Info("🧹 Deleting real route of exposure")
+		logger.Info("🧹 Deleting real route of exposure")
 		err = scopedClient.Delete(ctx, route)
 		if err != nil {
 			return errors.Wrapf(err, "failed to delete route")
 		}
-		log.Info("✅ Successfully deleted obsolete route")
+		logger.Info("✅ Successfully deleted obsolete route")
 	}
 
 	if obj.Status.FailoverRoute != nil {
@@ -219,12 +222,12 @@ func (h *ApiExposureHandler) Delete(ctx context.Context, obj *apiapi.ApiExposure
 			}
 			return errors.Wrap(err, "failed to get failover route")
 		}
-		log.Info("🧹 Deleting failover proxy route of exposure")
+		logger.Info("🧹 Deleting failover proxy route of exposure")
 		err = scopedClient.Delete(ctx, failoverRoute)
 		if err != nil {
 			return errors.Wrapf(err, "failed to delete failover route")
 		}
-		log.Info("✅ Successfully deleted obsolete failover route")
+		logger.Info("✅ Successfully deleted obsolete failover route")
 	}
 
 	return nil

--- a/api/internal/handler/apiexposure/handler.go
+++ b/api/internal/handler/apiexposure/handler.go
@@ -27,7 +27,6 @@ var _ handler.Handler[*apiapi.ApiExposure] = (*ApiExposureHandler)(nil)
 
 type ApiExposureHandler struct{}
 
-//nolint:gocyclo,nestif // Reconciliation validates API state and provisions several dependent routes.
 func (h *ApiExposureHandler) CreateOrUpdate(ctx context.Context, apiExp *apiapi.ApiExposure) error {
 	logger := log.FromContext(ctx)
 
@@ -61,37 +60,14 @@ func (h *ApiExposureHandler) CreateOrUpdate(ctx context.Context, apiExp *apiapi.
 
 	// Core Validations are done, can continue
 
-	// Scopes
-	// check if scopes exist and scopes are subset from api
-	if apiExp.HasM2M() {
-		// If scopes are set and its not externalIDP (here its allowed to have unknown/external scopes)
-		if apiExp.Spec.Security.M2M.Scopes != nil && !apiExp.HasExternalIdp() {
-			if len(api.Spec.Oauth2Scopes) == 0 {
-				apiExp.SetCondition(condition.NewNotReadyCondition("ScopesNotDefined", "Api does not define any Oauth2 scopes"))
-				apiExp.SetCondition(condition.NewBlockedCondition("Api does not define any Oauth2 scopes. ApiExposure will be automatically processed, if the API will be updated with scopes"))
-				return nil
-			} else {
-				scopesExist, invalidScopes := util.IsSubsetOfScopes(api.Spec.Oauth2Scopes, apiExp.Spec.Security.M2M.Scopes)
-				if !scopesExist {
-					message := fmt.Sprintf("Some defined scopes are not available. Available scopes: %q. Unsupported scopes: %q",
-						strings.Join(api.Spec.Oauth2Scopes, ", "),
-						strings.Join(invalidScopes, ", "),
-					)
-					apiExp.SetCondition(condition.NewNotReadyCondition("InvalidScopes", "One or more scopes which are defined in ApiExposure are not defined in the ApiSpecification"))
-					apiExp.SetCondition(condition.NewBlockedCondition(message))
-					return nil
-				}
-			}
-
-			logger.V(1).Info("✅ Scopes are valid and exist")
-		}
-	}
-
+	// Scopes: check if scopes exist and are a valid subset of the Api's scopes.
 	// TODO: further validations (currently contained in the old code)
 	// - validate if team category allows exposure of api category
+	if !validateExposureScopes(ctx, api, apiExp) {
+		return nil
+	}
 
 	// --- Proxy Route Management ---
-	// Query cross-zone subscription zones (exposure-driven pattern)
 	crossZoneRefs, err := util.FindCrossZoneApiSubscriptionZones(ctx, apiExp)
 	if err != nil {
 		return errors.Wrapf(err, "failed to find cross-zone subscription zones for apiExposure: %s", apiExp.Name)
@@ -231,4 +207,29 @@ func (h *ApiExposureHandler) Delete(ctx context.Context, obj *apiapi.ApiExposure
 	}
 
 	return nil
+}
+
+// validateExposureScopes checks that the M2M scopes in apiExp are a valid subset of the Api's scopes.
+// It sets blocking conditions on apiExp and returns false if processing should stop.
+func validateExposureScopes(ctx context.Context, api *apiapi.Api, apiExp *apiapi.ApiExposure) bool {
+	if !apiExp.HasM2M() || apiExp.Spec.Security.M2M.Scopes == nil || apiExp.HasExternalIdp() {
+		return true
+	}
+	if len(api.Spec.Oauth2Scopes) == 0 {
+		apiExp.SetCondition(condition.NewNotReadyCondition("ScopesNotDefined", "Api does not define any Oauth2 scopes"))
+		apiExp.SetCondition(condition.NewBlockedCondition("Api does not define any Oauth2 scopes. ApiExposure will be automatically processed, if the API will be updated with scopes"))
+		return false
+	}
+	scopesExist, invalidScopes := util.IsSubsetOfScopes(api.Spec.Oauth2Scopes, apiExp.Spec.Security.M2M.Scopes)
+	if !scopesExist {
+		message := fmt.Sprintf("Some defined scopes are not available. Available scopes: %q. Unsupported scopes: %q",
+			strings.Join(api.Spec.Oauth2Scopes, ", "),
+			strings.Join(invalidScopes, ", "),
+		)
+		apiExp.SetCondition(condition.NewNotReadyCondition("InvalidScopes", "One or more scopes which are defined in ApiExposure are not defined in the ApiSpecification"))
+		apiExp.SetCondition(condition.NewBlockedCondition(message))
+		return false
+	}
+	log.FromContext(ctx).V(1).Info("✅ Scopes are valid and exist")
+	return true
 }

--- a/api/internal/handler/apiexposure/util.go
+++ b/api/internal/handler/apiexposure/util.go
@@ -10,17 +10,17 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
 	apiv1 "github.com/telekom/controlplane/api/api/v1"
 	"github.com/telekom/controlplane/api/internal/handler/util"
 	cclient "github.com/telekom/controlplane/common/pkg/client"
 	"github.com/telekom/controlplane/common/pkg/condition"
 	"github.com/telekom/controlplane/common/pkg/config"
+	"github.com/telekom/controlplane/common/pkg/controller"
 	"github.com/telekom/controlplane/common/pkg/types"
 	"github.com/telekom/controlplane/common/pkg/util/labelutil"
 	gatewayapi "github.com/telekom/controlplane/gateway/api/v1"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-
-	"github.com/telekom/controlplane/common/pkg/controller"
 )
 
 // setAlreadyExposedConditions sets NotReady and Blocked conditions on the new ApiExposure
@@ -28,48 +28,48 @@ import (
 // It will include information about the team and application that owns the existing ApiExposure.
 // e.g. 'API is already exposed by Team "team-a" and their Application "app-1"' or
 // 'API is already exposed by your Application "app-1"'
-func setAlreadyExposedConditions(existing, new *apiv1.ApiExposure) {
+func setAlreadyExposedConditions(existing, candidate *apiv1.ApiExposure) {
 	sb := strings.Builder{}
 	sb.WriteString("API is already exposed ")
 
 	applicationName := existing.GetLabels()[config.BuildLabelKey("application")]
 
-	if existing.Namespace != new.Namespace {
+	if existing.Namespace != candidate.Namespace {
 		teamName := existing.Namespace // TODO: should probably be a label
 		str := fmt.Sprintf("by Team %q and their Application %q", teamName, applicationName)
 		sb.WriteString(str)
 	} else {
-		sb.WriteString(fmt.Sprintf("by your Application %q", applicationName))
+		fmt.Fprintf(&sb, "by your Application %q", applicationName)
 	}
 
 	msg := sb.String()
 
-	new.SetCondition(condition.NewNotReadyCondition("ApiExposureNotActive", msg))
-	new.SetCondition(condition.NewBlockedCondition(msg))
+	candidate.SetCondition(condition.NewNotReadyCondition("ApiExposureNotActive", msg))
+	candidate.SetCondition(condition.NewBlockedCondition(msg))
 }
 
 // ApiExposureMustNotAlreadyExist ensures that there is no other active ApiExposure with the same base path.
 // If there is, it sets appropriate conditions on the new ApiExposure.
-func ApiExposureMustNotAlreadyExist(ctx context.Context, new *apiv1.ApiExposure) error {
-	found, existingApiExp, err := util.FindActiveAPIExposure(ctx, new.Spec.ApiBasePath)
+func ApiExposureMustNotAlreadyExist(ctx context.Context, candidate *apiv1.ApiExposure) error {
+	found, existingApiExp, err := util.FindActiveAPIExposure(ctx, candidate.Spec.ApiBasePath)
 	if existingApiExp == nil && err != nil {
 		return err
 	}
 	if !found {
 		// no other active apiExposure found with same basepath
-		new.Status.Active = true
+		candidate.Status.Active = true
 		return nil
 	}
 
-	if types.Equals(existingApiExp, new) {
+	if types.Equals(existingApiExp, candidate) {
 		// the oldest apiExposure is the same as the one we are trying to handle
-		new.Status.Active = true
+		candidate.Status.Active = true
 	} else {
 		// there is already a different apiExposure active with the same BasePathLabelKey
 		// the new one will be blocked until the other is deleted
-		new.Status.Active = false
+		candidate.Status.Active = false
 
-		setAlreadyExposedConditions(existingApiExp, new)
+		setAlreadyExposedConditions(existingApiExp, candidate)
 		return nil
 	}
 

--- a/api/internal/handler/apisubscription/conditions.go
+++ b/api/internal/handler/apisubscription/conditions.go
@@ -8,9 +8,12 @@ import (
 	"fmt"
 	"strings"
 
-	apiv1 "github.com/telekom/controlplane/api/api/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	apiv1 "github.com/telekom/controlplane/api/api/v1"
 )
+
+const stateAllowed = "Allowed"
 
 // NewApiCondition creates a condition indicating whether the corresponding API exists and is active.
 func NewApiCondition(apiSub *apiv1.ApiSubscription, found bool) metav1.Condition {
@@ -57,7 +60,7 @@ func NewVisibilityAllowedCondition(apiSub *apiv1.ApiSubscription, visibility str
 	}
 	if allowed {
 		cond.Status = metav1.ConditionTrue
-		cond.Reason = "Allowed"
+		cond.Reason = stateAllowed
 		cond.Message = fmt.Sprintf("ApiSubscription visibility %q is allowed by the ApiExposure", visibility)
 	}
 	return cond
@@ -77,11 +80,11 @@ func NewScopesAllowedCondition(apiSub *apiv1.ApiSubscription, scopes []string, a
 	}
 	if allowed && len(scopes) > 0 {
 		cond.Status = metav1.ConditionTrue
-		cond.Reason = "Allowed"
+		cond.Reason = stateAllowed
 		cond.Message = "ApiSubscription scopes are allowed by the ApiExposure: " + strings.Join(scopes, ", ")
 	} else if allowed {
 		cond.Status = metav1.ConditionTrue
-		cond.Reason = "Allowed"
+		cond.Reason = stateAllowed
 		cond.Message = "ApiSubscription has no scopes defined, so they are allowed by default"
 	}
 	return cond

--- a/api/internal/handler/apisubscription/handler.go
+++ b/api/internal/handler/apisubscription/handler.go
@@ -10,9 +10,13 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
 	apiapi "github.com/telekom/controlplane/api/api/v1"
 	"github.com/telekom/controlplane/api/internal/handler/apisubscription/remote"
 	"github.com/telekom/controlplane/api/internal/handler/util"
+	approvalapi "github.com/telekom/controlplane/approval/api/v1"
+	"github.com/telekom/controlplane/approval/api/v1/builder"
 	cclient "github.com/telekom/controlplane/common/pkg/client"
 	"github.com/telekom/controlplane/common/pkg/condition"
 	"github.com/telekom/controlplane/common/pkg/errors/ctrlerrors"
@@ -20,24 +24,21 @@ import (
 	"github.com/telekom/controlplane/common/pkg/types"
 	"github.com/telekom/controlplane/common/pkg/util/contextutil"
 	gatewayapi "github.com/telekom/controlplane/gateway/api/v1"
-	"sigs.k8s.io/controller-runtime/pkg/log"
-
-	approvalapi "github.com/telekom/controlplane/approval/api/v1"
-	"github.com/telekom/controlplane/approval/api/v1/builder"
 )
 
 var _ handler.Handler[*apiapi.ApiSubscription] = (*ApiSubscriptionHandler)(nil)
 
 type ApiSubscriptionHandler struct{}
 
+//nolint:gocyclo,nestif // Reconciliation coordinates validation, approvals, and route provisioning.
 func (h *ApiSubscriptionHandler) CreateOrUpdate(ctx context.Context, apiSub *apiapi.ApiSubscription) error {
-	log := log.FromContext(ctx)
+	logger := log.FromContext(ctx)
 
 	scopedClient := cclient.ClientFromContextOrDie(ctx)
 
 	// Remote ApiSubscription handling
 	if remote.IsRemoteApiSubscription(apiSub) {
-		log.Info("ApiSubscription is remote")
+		logger.Info("ApiSubscription is remote")
 		return remote.HandleRemoteApiSubscription(ctx, apiSub)
 	}
 
@@ -123,7 +124,7 @@ func (h *ApiSubscriptionHandler) CreateOrUpdate(ctx context.Context, apiSub *api
 			} else {
 				scopesExist, invalidScopes := util.IsSubsetOfScopes(api.Spec.Oauth2Scopes, apiSub.Spec.Security.M2M.Scopes)
 				if !scopesExist {
-					var message = fmt.Sprintf("Some defined scopes are not available. Available scopes: \"%s\". Unsupported scopes: \"%s\"",
+					message := fmt.Sprintf("Some defined scopes are not available. Available scopes: %q. Unsupported scopes: %q",
 						strings.Join(api.Spec.Oauth2Scopes, ", "),
 						strings.Join(invalidScopes, ", "),
 					)
@@ -135,7 +136,7 @@ func (h *ApiSubscriptionHandler) CreateOrUpdate(ctx context.Context, apiSub *api
 			}
 		}
 
-		log.V(1).Info("✅ Scopes are valid and exist")
+		logger.V(1).Info("✅ Scopes are valid and exist")
 		apiSub.SetCondition(NewScopesAllowedCondition(apiSub, apiSub.Spec.Security.M2M.Scopes, true))
 		properties["scopes"] = apiSub.Spec.Security.M2M.Scopes
 	}
@@ -176,12 +177,12 @@ func (h *ApiSubscriptionHandler) CreateOrUpdate(ctx context.Context, apiSub *api
 
 	switch res {
 	case builder.ApprovalResultRequestDenied:
-		log.Info("🛑 ApprovalRequest was denied. In this case we will not touch child resources")
+		logger.Info("🛑 ApprovalRequest was denied. In this case we will not touch child resources")
 		apiSub.SetCondition(condition.NewNotReadyCondition("ApprovalRequestDenied", "ApprovalRequest has been denied"))
 		apiSub.SetCondition(condition.NewDoneProcessingCondition("ApprovalRequest has been denied"))
 		return nil
 	case builder.ApprovalResultPending:
-		log.Info("🫷 Approval is pending and we will wait for it")
+		logger.Info("🫷 Approval is pending and we will wait for it")
 		apiSub.SetCondition(condition.NewNotReadyCondition("ApprovalPending", "Approval has not been approved"))
 		apiSub.SetCondition(condition.NewBlockedCondition("Approval has not been approved"))
 		return nil
@@ -189,21 +190,21 @@ func (h *ApiSubscriptionHandler) CreateOrUpdate(ctx context.Context, apiSub *api
 		apiSub.SetCondition(condition.NewNotReadyCondition("ApprovalDenied", "Approval has been denied"))
 		apiSub.SetCondition(condition.NewDoneProcessingCondition("Approval has been denied"))
 
-		deleted, err := scopedClient.Cleanup(ctx, &gatewayapi.ConsumeRouteList{}, cclient.OwnedBy(apiSub))
-		if err != nil {
-			return errors.Wrapf(err, "Unable to cleanup consume routes for ApiSubscription:  %q in namespace: %q",
+		deleted, cleanupErr := scopedClient.Cleanup(ctx, &gatewayapi.ConsumeRouteList{}, cclient.OwnedBy(apiSub))
+		if cleanupErr != nil {
+			return errors.Wrapf(cleanupErr, "Unable to cleanup consume routes for ApiSubscription:  %q in namespace: %q",
 				apiSub.Name, apiSub.Namespace)
 		}
-		log.Info("🧹 Approval was denied. Cleaning up Consumer of ApiSubscription", "deleted", deleted)
+		logger.Info("🧹 Approval was denied. Cleaning up Consumer of ApiSubscription", "deleted", deleted)
 
 		err = util.CleanupProxyRoute(ctx, apiSub.Status.Route)
 		if err != nil {
 			return errors.Wrapf(err, "failed to delete route")
 		}
-		log.Info("🧹 Approval was denied. Cleaning up ProxyRoute of ApiSubscription")
+		logger.Info("🧹 Approval was denied. Cleaning up ProxyRoute of ApiSubscription")
 		return nil
 	case builder.ApprovalResultGranted:
-		log.Info("👌 Approval is granted and will continue with processing")
+		logger.Info("👌 Approval is granted and will continue with processing")
 	default:
 		return errors.Errorf("unknown approval-builder result %q", res)
 	}
@@ -219,35 +220,32 @@ func (h *ApiSubscriptionHandler) CreateOrUpdate(ctx context.Context, apiSub *api
 
 	var routeRef *types.ObjectRef
 
-	if sameZoneAsExposure {
-		// Same zone: reference the real route from ApiExposure status
+	switch {
+	case sameZoneAsExposure:
 		if apiExposure.Status.Route == nil {
 			apiSub.SetCondition(condition.NewBlockedCondition("Waiting for ApiExposure to create the route"))
 			return nil
 		}
 		routeRef = apiExposure.Status.Route
-		log.V(1).Info("Referencing real route from ApiExposure", "route", routeRef.String())
-	} else if inProviderFailoverZone {
-		// Provider failover zone: reference the failover route from ApiExposure status
+		logger.V(1).Info("Referencing real route from ApiExposure", "route", routeRef.String())
+	case inProviderFailoverZone:
 		if apiExposure.Status.FailoverRoute == nil {
 			apiSub.SetCondition(condition.NewBlockedCondition("Waiting for ApiExposure to create the failover route"))
 			return nil
 		}
 		routeRef = apiExposure.Status.FailoverRoute
-		log.V(1).Info("Referencing provider failover route from ApiExposure", "route", routeRef.String())
-	} else {
-		// Cross-zone: find the proxy route for this subscriber zone in ApiExposure status
-		// Get the subscription zone to find the correct proxy route by namespace
-		zone, err := util.GetZone(ctx, scopedClient, apiSub.Spec.Zone.K8s())
-		if err != nil {
-			return errors.Wrapf(err, "failed to get subscription zone %s", apiSub.Spec.Zone.Name)
+		logger.V(1).Info("Referencing provider failover route from ApiExposure", "route", routeRef.String())
+	default:
+		subscriptionZone, getZoneErr := util.GetZone(ctx, scopedClient, apiSub.Spec.Zone.K8s())
+		if getZoneErr != nil {
+			return errors.Wrapf(getZoneErr, "failed to get subscription zone %s", apiSub.Spec.Zone.Name)
 		}
 
-		// Find the proxy route that matches our zone's namespace
 		var found bool
-		for _, proxyRoute := range apiExposure.Status.ProxyRoutes {
-			if proxyRoute.Namespace == zone.Status.Namespace {
-				routeRef = &proxyRoute
+		for i := range apiExposure.Status.ProxyRoutes {
+			proxyRoute := &apiExposure.Status.ProxyRoutes[i]
+			if proxyRoute.Namespace == subscriptionZone.Status.Namespace {
+				routeRef = proxyRoute
 				found = true
 				break
 			}
@@ -257,7 +255,7 @@ func (h *ApiSubscriptionHandler) CreateOrUpdate(ctx context.Context, apiSub *api
 			apiSub.SetCondition(condition.NewBlockedCondition("Waiting for ApiExposure to create the proxy route for this zone"))
 			return nil
 		}
-		log.V(1).Info("Referencing proxy route from ApiExposure", "zone", apiSub.Spec.Zone.Name, "route", routeRef.String())
+		logger.V(1).Info("Referencing proxy route from ApiExposure", "zone", apiSub.Spec.Zone.Name, "route", routeRef.String())
 	}
 
 	apiSub.Status.Route = routeRef
@@ -290,50 +288,48 @@ func (h *ApiSubscriptionHandler) CreateOrUpdate(ctx context.Context, apiSub *api
 			inProviderFailoverZone := apiExposure.HasFailover() && apiExposure.Spec.Traffic.Failover.ContainsZone(subFailoverZone)
 
 			var failoverRouteRef types.ObjectRef
-			if sameZoneAsExposure {
-				// Reference the real route in exposure zone
-				zone, err := util.GetZone(ctx, scopedClient, apiExposure.Spec.Zone.K8s())
-				if err != nil {
-					return errors.Wrapf(err, "failed to get exposure zone %s for failover", apiExposure.Spec.Zone.Name)
+			switch {
+			case sameZoneAsExposure:
+				exposureZone, getZoneErr := util.GetZone(ctx, scopedClient, apiExposure.Spec.Zone.K8s())
+				if getZoneErr != nil {
+					return errors.Wrapf(getZoneErr, "failed to get exposure zone %s for failover", apiExposure.Spec.Zone.Name)
 				}
 				failoverRouteRef = types.ObjectRef{
 					Name:      util.MakeRouteName(apiSub.Spec.ApiBasePath, contextutil.EnvFromContextOrDie(ctx)),
-					Namespace: zone.Status.Namespace,
+					Namespace: exposureZone.Status.Namespace,
 				}
-				log.V(1).Info("Referencing real route in failover zone (same as exposure)", "zone", subFailoverZone.Name)
-			} else if inProviderFailoverZone {
-				// Reference the provider failover route
-				failoverZone, err := util.GetZone(ctx, scopedClient, apiExposure.Spec.Traffic.Failover.Zones[0].K8s())
-				if err != nil {
-					return errors.Wrapf(err, "failed to get provider failover zone %s", apiExposure.Spec.Traffic.Failover.Zones[0].Name)
-				}
-				failoverRouteRef = types.ObjectRef{
-					Name:      util.MakeRouteName(apiSub.Spec.ApiBasePath, contextutil.EnvFromContextOrDie(ctx)),
-					Namespace: failoverZone.Status.Namespace,
-				}
-				log.V(1).Info("Referencing provider failover route", "zone", subFailoverZone.Name)
-			} else {
-				// Reference the proxy route created by ApiExposure in subscriber failover zone
-				zone, err := util.GetZone(ctx, scopedClient, subFailoverZone.K8s())
-				if err != nil {
-					return errors.Wrapf(err, "failed to get subscriber failover zone %s", subFailoverZone.Name)
+				logger.V(1).Info("Referencing real route in failover zone (same as exposure)", "zone", subFailoverZone.Name)
+			case inProviderFailoverZone:
+				providerFailoverZone, getZoneErr := util.GetZone(ctx, scopedClient, apiExposure.Spec.Traffic.Failover.Zones[0].K8s())
+				if getZoneErr != nil {
+					return errors.Wrapf(getZoneErr, "failed to get provider failover zone %s", apiExposure.Spec.Traffic.Failover.Zones[0].Name)
 				}
 				failoverRouteRef = types.ObjectRef{
 					Name:      util.MakeRouteName(apiSub.Spec.ApiBasePath, contextutil.EnvFromContextOrDie(ctx)),
-					Namespace: zone.Status.Namespace,
+					Namespace: providerFailoverZone.Status.Namespace,
 				}
-				log.V(1).Info("Referencing proxy route created by ApiExposure for subscriber failover", "zone", subFailoverZone.Name)
+				logger.V(1).Info("Referencing provider failover route", "zone", subFailoverZone.Name)
+			default:
+				subscriberFailoverZone, getZoneErr := util.GetZone(ctx, scopedClient, subFailoverZone.K8s())
+				if getZoneErr != nil {
+					return errors.Wrapf(getZoneErr, "failed to get subscriber failover zone %s", subFailoverZone.Name)
+				}
+				failoverRouteRef = types.ObjectRef{
+					Name:      util.MakeRouteName(apiSub.Spec.ApiBasePath, contextutil.EnvFromContextOrDie(ctx)),
+					Namespace: subscriberFailoverZone.Status.Namespace,
+				}
+				logger.V(1).Info("Referencing proxy route created by ApiExposure for subscriber failover", "zone", subFailoverZone.Name)
 			}
 
 			apiSub.Status.FailoverRoutes = append(apiSub.Status.FailoverRoutes, failoverRouteRef)
 
 			// Create ConsumeRoute for the failover route
-			log.V(1).Info("Creating failover ConsumeRoute for zone", "zone", subFailoverZone.Name)
-			consumeRoute, err = util.CreateConsumeRoute(ctx, apiSub, subFailoverZone, failoverRouteRef, apiSubApplication.Status.ClientId)
-			if err != nil {
-				return errors.Wrapf(err, "failed to create failover ConsumeRoute for zone %s", subFailoverZone.Name)
+			logger.V(1).Info("Creating failover ConsumeRoute for zone", "zone", subFailoverZone.Name)
+			failoverConsumeRoute, createErr := util.CreateConsumeRoute(ctx, apiSub, subFailoverZone, failoverRouteRef, apiSubApplication.Status.ClientId)
+			if createErr != nil {
+				return errors.Wrapf(createErr, "failed to create failover ConsumeRoute for zone %s", subFailoverZone.Name)
 			}
-			apiSub.Status.FailoverConsumeRoutes = append(apiSub.Status.FailoverConsumeRoutes, *types.ObjectRefFromObject(consumeRoute))
+			apiSub.Status.FailoverConsumeRoutes = append(apiSub.Status.FailoverConsumeRoutes, *types.ObjectRefFromObject(failoverConsumeRoute))
 		}
 	}
 
@@ -341,7 +337,7 @@ func (h *ApiSubscriptionHandler) CreateOrUpdate(ctx context.Context, apiSub *api
 	apiSub.SetCondition(condition.NewDoneProcessingCondition("Successfully provisioned subresources"))
 	apiSub.SetCondition(condition.NewReadyCondition("Provisioned", "Successfully provisioned subresources"))
 
-	log.Info("✅ Successfully processed ApiSubscription")
+	logger.Info("✅ Successfully processed ApiSubscription")
 	return nil
 }
 

--- a/api/internal/handler/apisubscription/handler.go
+++ b/api/internal/handler/apisubscription/handler.go
@@ -30,7 +30,7 @@ var _ handler.Handler[*apiapi.ApiSubscription] = (*ApiSubscriptionHandler)(nil)
 
 type ApiSubscriptionHandler struct{}
 
-//nolint:gocyclo,nestif // Reconciliation coordinates validation, approvals, and route provisioning.
+//nolint:gocyclo // Approval switch (5 paths) and per-zone failover loop drive unavoidable complexity; logic is extracted where possible.
 func (h *ApiSubscriptionHandler) CreateOrUpdate(ctx context.Context, apiSub *apiapi.ApiSubscription) error {
 	logger := log.FromContext(ctx)
 
@@ -112,34 +112,11 @@ func (h *ApiSubscriptionHandler) CreateOrUpdate(ctx context.Context, apiSub *api
 		"basePath": apiSub.Spec.ApiBasePath,
 	}
 
-	// Scopes
-	// check if scopes exist and scopes are subset from api
-	if apiSub.HasM2M() {
-		if apiSub.Spec.Security.M2M.Scopes != nil {
-			if len(api.Spec.Oauth2Scopes) == 0 {
-				apiSub.SetCondition(NewScopesAllowedCondition(apiSub, nil, false))
-				apiSub.SetCondition(condition.NewNotReadyCondition("ScopesNotDefined", "Api does not define any Oauth2 scopes"))
-				apiSub.SetCondition(condition.NewBlockedCondition("Api does not define any Oauth2 scopes. ApiSubscription will be automatically processed, if the API will be updated with scopes"))
-				return nil
-			} else {
-				scopesExist, invalidScopes := util.IsSubsetOfScopes(api.Spec.Oauth2Scopes, apiSub.Spec.Security.M2M.Scopes)
-				if !scopesExist {
-					message := fmt.Sprintf("Some defined scopes are not available. Available scopes: %q. Unsupported scopes: %q",
-						strings.Join(api.Spec.Oauth2Scopes, ", "),
-						strings.Join(invalidScopes, ", "),
-					)
-					apiSub.SetCondition(NewScopesAllowedCondition(apiSub, invalidScopes, false))
-					apiSub.SetCondition(condition.NewNotReadyCondition("InvalidScopes", "One or more scopes which are defined in ApiSubscription are not defined in the ApiSpecification"))
-					apiSub.SetCondition(condition.NewBlockedCondition(message))
-					return nil
-				}
-			}
-		}
-
-		logger.V(1).Info("✅ Scopes are valid and exist")
-		apiSub.SetCondition(NewScopesAllowedCondition(apiSub, apiSub.Spec.Security.M2M.Scopes, true))
-		properties["scopes"] = apiSub.Spec.Security.M2M.Scopes
+	// Scopes: check if scopes exist and are a valid subset of the Api's scopes.
+	if !validateSubscriptionScopes(ctx, api, apiSub, properties) {
+		return nil
 	}
+
 	err = requester.SetProperties(properties)
 	if err != nil {
 		return errors.Wrapf(err, "unable to set approvalRequest properties for apiSubscription: %q in namespace: %q",
@@ -218,44 +195,12 @@ func (h *ApiSubscriptionHandler) CreateOrUpdate(ctx context.Context, apiSub *api
 	sameZoneAsExposure := apiSub.Spec.Zone.Equals(&apiExposure.Spec.Zone)
 	inProviderFailoverZone := apiExposure.HasFailover() && apiExposure.Spec.Traffic.Failover.ContainsZone(apiSub.Spec.Zone)
 
-	var routeRef *types.ObjectRef
-
-	switch {
-	case sameZoneAsExposure:
-		if apiExposure.Status.Route == nil {
-			apiSub.SetCondition(condition.NewBlockedCondition("Waiting for ApiExposure to create the route"))
-			return nil
-		}
-		routeRef = apiExposure.Status.Route
-		logger.V(1).Info("Referencing real route from ApiExposure", "route", routeRef.String())
-	case inProviderFailoverZone:
-		if apiExposure.Status.FailoverRoute == nil {
-			apiSub.SetCondition(condition.NewBlockedCondition("Waiting for ApiExposure to create the failover route"))
-			return nil
-		}
-		routeRef = apiExposure.Status.FailoverRoute
-		logger.V(1).Info("Referencing provider failover route from ApiExposure", "route", routeRef.String())
-	default:
-		subscriptionZone, getZoneErr := util.GetZone(ctx, scopedClient, apiSub.Spec.Zone.K8s())
-		if getZoneErr != nil {
-			return errors.Wrapf(getZoneErr, "failed to get subscription zone %s", apiSub.Spec.Zone.Name)
-		}
-
-		var found bool
-		for i := range apiExposure.Status.ProxyRoutes {
-			proxyRoute := &apiExposure.Status.ProxyRoutes[i]
-			if proxyRoute.Namespace == subscriptionZone.Status.Namespace {
-				routeRef = proxyRoute
-				found = true
-				break
-			}
-		}
-
-		if !found {
-			apiSub.SetCondition(condition.NewBlockedCondition("Waiting for ApiExposure to create the proxy route for this zone"))
-			return nil
-		}
-		logger.V(1).Info("Referencing proxy route from ApiExposure", "zone", apiSub.Spec.Zone.Name, "route", routeRef.String())
+	routeRef, err := resolveRouteRef(ctx, scopedClient, apiSub, apiExposure, sameZoneAsExposure, inProviderFailoverZone)
+	if err != nil {
+		return err
+	}
+	if routeRef == nil {
+		return nil
 	}
 
 	apiSub.Status.Route = routeRef
@@ -352,4 +297,73 @@ func (h *ApiSubscriptionHandler) Delete(ctx context.Context, apiSub *apiapi.ApiS
 		}
 	}
 	return nil
+}
+
+// validateSubscriptionScopes checks that the M2M scopes in apiSub are a valid subset of the Api's scopes.
+// It updates properties["scopes"] on success, sets blocking conditions on failure, and returns false if
+// processing should stop.
+func validateSubscriptionScopes(ctx context.Context, api *apiapi.Api, apiSub *apiapi.ApiSubscription, properties map[string]any) bool {
+	if !apiSub.HasM2M() || apiSub.Spec.Security.M2M.Scopes == nil {
+		return true
+	}
+	if len(api.Spec.Oauth2Scopes) == 0 {
+		apiSub.SetCondition(NewScopesAllowedCondition(apiSub, nil, false))
+		apiSub.SetCondition(condition.NewNotReadyCondition("ScopesNotDefined", "Api does not define any Oauth2 scopes"))
+		apiSub.SetCondition(condition.NewBlockedCondition("Api does not define any Oauth2 scopes. ApiSubscription will be automatically processed, if the API will be updated with scopes"))
+		return false
+	}
+	scopesExist, invalidScopes := util.IsSubsetOfScopes(api.Spec.Oauth2Scopes, apiSub.Spec.Security.M2M.Scopes)
+	if !scopesExist {
+		message := fmt.Sprintf("Some defined scopes are not available. Available scopes: %q. Unsupported scopes: %q",
+			strings.Join(api.Spec.Oauth2Scopes, ", "),
+			strings.Join(invalidScopes, ", "),
+		)
+		apiSub.SetCondition(NewScopesAllowedCondition(apiSub, invalidScopes, false))
+		apiSub.SetCondition(condition.NewNotReadyCondition("InvalidScopes", "One or more scopes which are defined in ApiSubscription are not defined in the ApiSpecification"))
+		apiSub.SetCondition(condition.NewBlockedCondition(message))
+		return false
+	}
+	log.FromContext(ctx).V(1).Info("✅ Scopes are valid and exist")
+	apiSub.SetCondition(NewScopesAllowedCondition(apiSub, apiSub.Spec.Security.M2M.Scopes, true))
+	properties["scopes"] = apiSub.Spec.Security.M2M.Scopes
+	return true
+}
+
+// resolveRouteRef determines which route the ApiSubscription should reference based on zone relationships.
+// Returns (nil, nil) if a blocking condition was set and processing should stop.
+func resolveRouteRef(ctx context.Context, scopedClient cclient.JanitorClient, apiSub *apiapi.ApiSubscription, apiExposure *apiapi.ApiExposure, sameZoneAsExposure, inProviderFailoverZone bool) (*types.ObjectRef, error) {
+	logger := log.FromContext(ctx)
+
+	switch {
+	case sameZoneAsExposure:
+		if apiExposure.Status.Route == nil {
+			apiSub.SetCondition(condition.NewBlockedCondition("Waiting for ApiExposure to create the route"))
+			return nil, nil
+		}
+		logger.V(1).Info("Referencing real route from ApiExposure", "route", apiExposure.Status.Route.String())
+		return apiExposure.Status.Route, nil
+
+	case inProviderFailoverZone:
+		if apiExposure.Status.FailoverRoute == nil {
+			apiSub.SetCondition(condition.NewBlockedCondition("Waiting for ApiExposure to create the failover route"))
+			return nil, nil
+		}
+		logger.V(1).Info("Referencing provider failover route from ApiExposure", "route", apiExposure.Status.FailoverRoute.String())
+		return apiExposure.Status.FailoverRoute, nil
+
+	default:
+		subscriptionZone, err := util.GetZone(ctx, scopedClient, apiSub.Spec.Zone.K8s())
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to get subscription zone %s", apiSub.Spec.Zone.Name)
+		}
+		for i := range apiExposure.Status.ProxyRoutes {
+			proxyRoute := &apiExposure.Status.ProxyRoutes[i]
+			if proxyRoute.Namespace == subscriptionZone.Status.Namespace {
+				logger.V(1).Info("Referencing proxy route from ApiExposure", "zone", apiSub.Spec.Zone.Name, "route", proxyRoute.String())
+				return proxyRoute, nil
+			}
+		}
+		apiSub.SetCondition(condition.NewBlockedCondition("Waiting for ApiExposure to create the proxy route for this zone"))
+		return nil, nil
+	}
 }

--- a/api/internal/handler/apisubscription/remote/handler.go
+++ b/api/internal/handler/apisubscription/remote/handler.go
@@ -8,6 +8,11 @@ import (
 	"context"
 
 	"github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
 	apiapi "github.com/telekom/controlplane/api/api/v1"
 	"github.com/telekom/controlplane/api/internal/handler/util"
 	cclient "github.com/telekom/controlplane/common/pkg/client"
@@ -17,10 +22,6 @@ import (
 	"github.com/telekom/controlplane/common/pkg/types"
 	"github.com/telekom/controlplane/common/pkg/util/contextutil"
 	gatewayapi "github.com/telekom/controlplane/gateway/api/v1"
-	"k8s.io/apimachinery/pkg/api/meta"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 // IsRemoteApiSubscription checks if the given object is a remote api subscription.
@@ -30,15 +31,15 @@ func IsRemoteApiSubscription(obj *apiapi.ApiSubscription) bool {
 }
 
 func HandleRemoteApiSubscription(ctx context.Context, owner *apiapi.ApiSubscription) (err error) {
-	log := log.FromContext(ctx)
+	logger := log.FromContext(ctx)
 	c := cclient.ClientFromContextOrDie(ctx)
 
 	cleanup := func() error {
-		n, err := c.CleanupAll(ctx, cclient.OwnedBy(owner))
-		if err != nil {
-			return errors.Wrapf(err, "failed to cleanup all resources")
+		n, cleanupErr := c.CleanupAll(ctx, cclient.OwnedBy(owner))
+		if cleanupErr != nil {
+			return errors.Wrapf(cleanupErr, "failed to cleanup all resources")
 		}
-		log.Info("🧹 Cleaned up resources", "count", n)
+		logger.Info("🧹 Cleaned up resources", "count", n)
 		return nil
 	}
 
@@ -63,14 +64,14 @@ func HandleRemoteApiSubscription(ctx context.Context, owner *apiapi.ApiSubscript
 	}
 
 	if !meta.IsStatusConditionTrue(application.GetConditions(), condition.ConditionTypeReady) {
-		log.Info("🫷 Application not ready")
+		logger.Info("🫷 Application not ready")
 		return nil
 	}
 
 	mutate := func() error {
-		err := controllerutil.SetControllerReference(owner, req, c.Scheme())
-		if err != nil {
-			return errors.Wrapf(err, "failed to set controller reference")
+		setRefErr := controllerutil.SetControllerReference(owner, req, c.Scheme())
+		if setRefErr != nil {
+			return errors.Wrapf(setRefErr, "failed to set controller reference")
 		}
 		req.Labels = owner.Labels
 		req.Labels[config.BuildLabelKey("org.id")] = owner.Spec.Organization
@@ -101,14 +102,14 @@ func HandleRemoteApiSubscription(ctx context.Context, owner *apiapi.ApiSubscript
 	owner.SetCondition(condition.NewNotReadyCondition("NotReady", "RemoteApiSubscription is provisoned but not ready yet"))
 
 	if res != controllerutil.OperationResultNone {
-		log.Info("🔗 RemoteApiSubscription created or updated", "result", res)
+		logger.Info("🔗 RemoteApiSubscription created or updated", "result", res)
 		return nil
 	}
 
 	approvalResult := IsApproved(ctx, req)
 
 	if approvalResult == ApprovalResultCleanup {
-		log.Info("🧹 RemoteApiSubscription not granted. We need to cleanup")
+		logger.Info("🧹 RemoteApiSubscription not granted. We need to cleanup")
 		owner.SetCondition(condition.NewBlockedCondition("RemoteApiSubscription not granted"))
 		owner.SetCondition(condition.NewNotReadyCondition("RemoteApiSubscriptionNotGranted", "RemoteApiSubscription not granted"))
 
@@ -120,18 +121,18 @@ func HandleRemoteApiSubscription(ctx context.Context, owner *apiapi.ApiSubscript
 	}
 
 	if approvalResult == ApprovalResultBlock {
-		log.Info("🫷 RemoteApiSubscription not approved yet")
+		logger.Info("🫷 RemoteApiSubscription not approved yet")
 		owner.SetCondition(condition.NewBlockedCondition("RemoteApiSubscription not granted yet"))
 		return nil
 	}
 
 	if !meta.IsStatusConditionTrue(req.GetConditions(), condition.ConditionTypeReady) {
-		log.Info("🫷 RemoteApiSubscription not ready")
+		logger.Info("🫷 RemoteApiSubscription not ready")
 		owner.SetCondition(condition.NewBlockedCondition("RemoteApiSubscription is granted but not rerady yet"))
 		return nil
 	}
 
-	log.Info("👌 RemoteApiSubscription ready, we will continue")
+	logger.Info("👌 RemoteApiSubscription ready, we will continue")
 	owner.SetCondition(condition.NewProcessingCondition("RemoteApiSubscriptionReady", "Continue processing"))
 
 	remoteOrg, err := util.GetRemoteOrganization(ctx, types.ObjectRef{
@@ -154,16 +155,16 @@ func HandleRemoteApiSubscription(ctx context.Context, owner *apiapi.ApiSubscript
 
 	var routeRef *types.ObjectRef
 	if !remoteOrg.Spec.Zone.Equals(subscriptionZone) {
-		log.Info("RemoteApiSubscription is in a different zone")
+		logger.Info("RemoteApiSubscription is in a different zone")
 
-		route, err := util.CreateProxyRoute(ctx, owner.Spec.Zone, remoteOrg.Spec.Zone, owner.Spec.ApiBasePath, remoteOrg.Spec.Id)
-		if err != nil {
-			return errors.Wrapf(err, "failed to create proxy route")
+		route, createErr := util.CreateProxyRoute(ctx, owner.Spec.Zone, remoteOrg.Spec.Zone, owner.Spec.ApiBasePath, remoteOrg.Spec.Id)
+		if createErr != nil {
+			return errors.Wrapf(createErr, "failed to create proxy route")
 		}
 
 		routeRef = types.ObjectRefFromObject(route)
 	} else {
-		log.Info("RemoteApiSubscription is in the same zone")
+		logger.Info("RemoteApiSubscription is in the same zone")
 		// Set route as RealRoute
 		routeRef = req.Status.Route
 	}
@@ -184,8 +185,9 @@ func HandleRemoteApiSubscription(ctx context.Context, owner *apiapi.ApiSubscript
 	}
 
 	mutate = func() error {
-		if err := controllerutil.SetControllerReference(owner, routeConsumer, c.Scheme()); err != nil {
-			return errors.Wrapf(err, "failed to set owner-reference on %v", routeConsumer)
+		setRouteConsumerRefErr := controllerutil.SetControllerReference(owner, routeConsumer, c.Scheme())
+		if setRouteConsumerRefErr != nil {
+			return errors.Wrapf(setRouteConsumerRefErr, "failed to set owner-reference on %v", routeConsumer)
 		}
 		routeConsumer.Labels = owner.Labels
 
@@ -194,7 +196,6 @@ func HandleRemoteApiSubscription(ctx context.Context, owner *apiapi.ApiSubscript
 			ConsumerName: application.Status.ClientId,
 		}
 		return nil
-
 	}
 
 	_, err = c.CreateOrUpdate(ctx, routeConsumer, mutate)

--- a/api/internal/handler/apisubscription/util.go
+++ b/api/internal/handler/apisubscription/util.go
@@ -9,19 +9,20 @@ import (
 	"fmt"
 
 	"github.com/pkg/errors"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
 	adminv1 "github.com/telekom/controlplane/admin/api/v1"
 	apiapi "github.com/telekom/controlplane/api/api/v1"
 	"github.com/telekom/controlplane/api/internal/handler/util"
 	cclient "github.com/telekom/controlplane/common/pkg/client"
 	"github.com/telekom/controlplane/common/pkg/condition"
 	gatewayapi "github.com/telekom/controlplane/gateway/api/v1"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 // ApiMustExist checks if the ApiSubscription has a corresponding active Api.
 // If not, it sets appropriate conditions on the ApiSubscription and cleans up child resources.
 func ApiMustExist(ctx context.Context, apiSub *apiapi.ApiSubscription) (*apiapi.Api, error) {
-	log := log.FromContext(ctx)
+	logger := log.FromContext(ctx)
 	scopedClient := cclient.ClientFromContextOrDie(ctx)
 
 	found, api, err := util.FindActiveAPI(ctx, apiSub.Spec.ApiBasePath)
@@ -40,14 +41,14 @@ func ApiMustExist(ctx context.Context, apiSub *apiapi.ApiSubscription) (*apiapi.
 			return nil, errors.Wrapf(err,
 				"Unable to cleanup consumeroutes for Apisubscription:  %s in namespace: %s", apiSub.GetName(), apiSub.GetNamespace())
 		}
-		log.Info("🧹 No active API found. Cleaning up Consumer of ApiSubscription", "basePath", apiSub.Spec.ApiBasePath, "deleted", deleted)
+		logger.Info("🧹 No active API found. Cleaning up Consumer of ApiSubscription", "basePath", apiSub.Spec.ApiBasePath, "deleted", deleted)
 	}
 
 	return api, nil
 }
 
 func ApiExposureMustExist(ctx context.Context, apiSub *apiapi.ApiSubscription) (*apiapi.ApiExposure, error) {
-	log := log.FromContext(ctx)
+	logger := log.FromContext(ctx)
 	scopedClient := cclient.ClientFromContextOrDie(ctx)
 
 	found, apiExp, err := util.FindActiveAPIExposure(ctx, apiSub.Spec.ApiBasePath)
@@ -55,7 +56,7 @@ func ApiExposureMustExist(ctx context.Context, apiSub *apiapi.ApiSubscription) (
 		return nil, err
 	}
 	if !found {
-		log.Info("no active ApiExposure found", "basePath", apiSub.Spec.ApiBasePath)
+		logger.Info("no active ApiExposure found", "basePath", apiSub.Spec.ApiBasePath)
 		apiSub.SetCondition(condition.NewNotReadyCondition("NoApiExposure",
 			fmt.Sprintf("API %q is not exposed. Cannot provision ApiSubscription", apiSub.Spec.ApiBasePath)),
 		)
@@ -68,7 +69,7 @@ func ApiExposureMustExist(ctx context.Context, apiSub *apiapi.ApiSubscription) (
 			return nil, errors.Wrapf(err,
 				"Unable to cleanup consumeroutes for Apisubscription:  %s in namespace: %s", apiSub.GetName(), apiSub.GetNamespace())
 		}
-		log.Info("🧹 No active API-Exposure found. Cleaning up Consumer of ApiSubscription", "basePath", apiSub.Spec.ApiBasePath, "deleted", deleted)
+		logger.Info("🧹 No active API-Exposure found. Cleaning up Consumer of ApiSubscription", "basePath", apiSub.Spec.ApiBasePath, "deleted", deleted)
 	}
 
 	return apiExp, nil
@@ -77,7 +78,7 @@ func ApiExposureMustExist(ctx context.Context, apiSub *apiapi.ApiSubscription) (
 // ApiVisibilityMustBeValid checks if the ApiSubscription is valid for the given ApiExposure visibility
 func ApiVisibilityMustBeValid(ctx context.Context, apiExposure *apiapi.ApiExposure, apiSubscription *apiapi.ApiSubscription) (bool, error) {
 	scopedClient := cclient.ClientFromContextOrDie(ctx)
-	log := log.FromContext(ctx)
+	logger := log.FromContext(ctx)
 
 	exposureVisibility := apiExposure.Spec.Visibility
 
@@ -90,14 +91,14 @@ func ApiVisibilityMustBeValid(ctx context.Context, apiExposure *apiapi.ApiExposu
 	subZone := &adminv1.Zone{}
 	err := scopedClient.Get(ctx, apiSubscription.Spec.Zone.K8s(), subZone)
 	if err != nil {
-		log.Error(err, "unable to get zone", "name", apiSubscription.Spec.Zone.K8s())
+		logger.Error(err, "unable to get zone", "name", apiSubscription.Spec.Zone.K8s())
 		return false, errors.Wrapf(err, "Zone '%s' not found", apiSubscription.Spec.Zone.GetName())
 	}
 
 	// only same zone
 	if exposureVisibility == apiapi.VisibilityZone {
 		if apiExposure.Spec.Zone.GetName() != subZone.GetName() {
-			log.Info(fmt.Sprintf("Exposure visibility is ZONE and it doesnt match the subscription zone '%s'", subZone.GetName()))
+			logger.Info(fmt.Sprintf("Exposure visibility is ZONE and it doesnt match the subscription zone '%s'", subZone.GetName()))
 			return false, nil
 		}
 	}
@@ -105,7 +106,7 @@ func ApiVisibilityMustBeValid(ctx context.Context, apiExposure *apiapi.ApiExposu
 	// only enterprise zones
 	if exposureVisibility == apiapi.VisibilityEnterprise {
 		if subZone.Spec.Visibility != adminv1.ZoneVisibilityEnterprise {
-			log.Info(fmt.Sprintf("Api is exposed with visibility '%s', but subscriptions is from zone with visibility '%s'", apiapi.VisibilityEnterprise, subZone.Spec.Visibility))
+			logger.Info(fmt.Sprintf("Api is exposed with visibility '%s', but subscriptions is from zone with visibility '%s'", apiapi.VisibilityEnterprise, subZone.Spec.Visibility))
 			return false, nil
 		}
 	}

--- a/api/internal/handler/remoteapisubscription/consumer_scenario.go
+++ b/api/internal/handler/remoteapisubscription/consumer_scenario.go
@@ -9,6 +9,10 @@ import (
 	"net/url"
 
 	"github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
 	apiapi "github.com/telekom/controlplane/api/api/v1"
 	"github.com/telekom/controlplane/api/internal/handler/util"
 	"github.com/telekom/controlplane/common/pkg/client"
@@ -18,20 +22,17 @@ import (
 	"github.com/telekom/controlplane/common/pkg/util/contextutil"
 	"github.com/telekom/controlplane/common/pkg/util/labelutil"
 	gatewayapi "github.com/telekom/controlplane/gateway/api/v1"
-	"k8s.io/apimachinery/pkg/api/meta"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 // handleConsumerScenario handles the case where the RemoteApiSubscription is handled by another CP.
 // That means that the current CP just needs to create the route to the other CP.
 // This route is considered a real-route and is shared for all subscriptions to the same API and target CP.
 func (h *RemoteApiSubscriptionHandler) handleConsumerScenario(ctx context.Context, obj *apiapi.RemoteApiSubscription) (err error) {
-	log := log.FromContext(ctx)
+	logger := log.FromContext(ctx)
 	c := client.ClientFromContextOrDie(ctx)
 
 	// Send it to other CP
-	log.V(1).Info("I need to send this to the other CP")
+	logger.V(1).Info("I need to send this to the other CP")
 	remoteOrgRef := types.ObjectRef{
 		Name:      obj.Spec.TargetOrganization,
 		Namespace: contextutil.EnvFromContextOrDie(ctx),
@@ -51,10 +52,10 @@ func (h *RemoteApiSubscriptionHandler) handleConsumerScenario(ctx context.Contex
 		obj.SetCondition(condition.NewNotReadyCondition("Syncing", "Syncing with remote CP"))
 		return nil
 	}
-	log.V(1).Info("RemoteApiSubscription synced with remote CP but not updated")
+	logger.V(1).Info("RemoteApiSubscription synced with remote CP but not updated")
 
 	if !meta.IsStatusConditionTrue(obj.GetConditions(), condition.ConditionTypeReady) {
-		log.V(1).Info("🫷 RemoteApiSubscription not ready")
+		logger.V(1).Info("🫷 RemoteApiSubscription not ready")
 		return nil
 	}
 
@@ -89,24 +90,24 @@ func (h *RemoteApiSubscriptionHandler) handleConsumerScenario(ctx context.Contex
 			config.BuildLabelKey("type"):  "real",
 		}
 
-		url, err := url.Parse(obj.Status.GatewayUrl)
-		if err != nil {
-			return errors.Wrapf(err, "failed to parse gateway url")
+		parsedURL, parseErr := url.Parse(obj.Status.GatewayUrl)
+		if parseErr != nil {
+			return errors.Wrapf(parseErr, "failed to parse gateway url")
 		}
 
-		downstream, err := downstreamRealm.AsDownstream(obj.Spec.ApiBasePath)
-		if err != nil {
-			return errors.Wrap(err, "failed to create downstream")
+		downstream, downstreamErr := downstreamRealm.AsDownstream(obj.Spec.ApiBasePath)
+		if downstreamErr != nil {
+			return errors.Wrap(downstreamErr, "failed to create downstream")
 		}
 
 		route.Spec = gatewayapi.RouteSpec{
 			Realm: downstreamRealmRef,
 			Upstreams: []gatewayapi.Upstream{
 				{
-					Scheme: url.Scheme,
-					Host:   url.Hostname(),
-					Port:   gatewayapi.GetPortOrDefaultFromScheme(url),
-					Path:   url.Path,
+					Scheme: parsedURL.Scheme,
+					Host:   parsedURL.Hostname(),
+					Port:   gatewayapi.GetPortOrDefaultFromScheme(parsedURL),
+					Path:   parsedURL.Path,
 				},
 			},
 			Downstreams: []gatewayapi.Downstream{

--- a/api/internal/handler/remoteapisubscription/handler.go
+++ b/api/internal/handler/remoteapisubscription/handler.go
@@ -8,6 +8,10 @@ import (
 	"context"
 
 	"github.com/pkg/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
 	adminapi "github.com/telekom/controlplane/admin/api/v1"
 	apiapi "github.com/telekom/controlplane/api/api/v1"
 	"github.com/telekom/controlplane/api/internal/handler/remoteapisubscription/syncer"
@@ -16,10 +20,6 @@ import (
 	"github.com/telekom/controlplane/common/pkg/types"
 	"github.com/telekom/controlplane/common/pkg/util/contextutil"
 	gatewayapi "github.com/telekom/controlplane/gateway/api/v1"
-	"sigs.k8s.io/controller-runtime/pkg/log"
-
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 var _ handler.Handler[*apiapi.RemoteApiSubscription] = (*RemoteApiSubscriptionHandler)(nil)
@@ -39,6 +39,7 @@ func (h *RemoteApiSubscriptionHandler) CreateOrUpdate(ctx context.Context, obj *
 	return h.handleProviderScenario(ctx, obj)
 }
 
+//nolint:nestif // Delete handles local cleanup and optional remote sync teardown.
 func (h *RemoteApiSubscriptionHandler) Delete(ctx context.Context, obj *apiapi.RemoteApiSubscription) error {
 	c := client.ClientFromContextOrDie(ctx)
 
@@ -63,9 +64,9 @@ func (h *RemoteApiSubscriptionHandler) Delete(ctx context.Context, obj *apiapi.R
 			}
 		}
 
-		err := h.SyncerFactory.NewClient(remoteOrg).Delete(ctx, obj)
-		if err != nil {
-			return errors.Wrapf(err, "failed to delete RemoteApiSubscription on remote CP")
+		syncErr := h.SyncerFactory.NewClient(remoteOrg).Delete(ctx, obj)
+		if syncErr != nil {
+			return errors.Wrapf(syncErr, "failed to delete RemoteApiSubscription on remote CP")
 		}
 	}
 
@@ -77,18 +78,18 @@ func (h *RemoteApiSubscriptionHandler) Delete(ctx context.Context, obj *apiapi.R
 // IshandledRemotely checks if this RemoteApiSubscription is not handled by this CP
 // but rather by another CP. It does so by checking if a RemoteOrganization exists
 func IshandledRemotely(ctx context.Context, obj *apiapi.RemoteApiSubscription) (bool, *adminapi.RemoteOrganization, error) {
-	log := log.FromContext(ctx)
+	logger := log.FromContext(ctx)
 	c := client.ClientFromContextOrDie(ctx)
 	remoteOrg := &adminapi.RemoteOrganization{}
 	remoteOrgRef := types.ObjectRef{Name: obj.Spec.TargetOrganization, Namespace: contextutil.EnvFromContextOrDie(ctx)}
 	err := c.Get(ctx, remoteOrgRef.K8s(), remoteOrg)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
-			log.Info("RemoteOrganization not found, assuming RemoteApiSubscription is handled locally")
+			logger.Info("RemoteOrganization not found, assuming RemoteApiSubscription is handled locally")
 			return false, nil, nil
 		}
 		return false, nil, errors.Wrapf(err, "failed to get remote organization %s", remoteOrgRef.Name)
 	}
-	log.Info("RemoteOrganization found, assuming RemoteApiSubscription is handled remotely")
+	logger.Info("RemoteOrganization found, assuming RemoteApiSubscription is handled remotely")
 	return true, remoteOrg, nil
 }

--- a/api/internal/handler/remoteapisubscription/provider_scenario.go
+++ b/api/internal/handler/remoteapisubscription/provider_scenario.go
@@ -27,8 +27,6 @@ import (
 
 // handleProviderScenario handles the case where the RemoteApiSubscription is handled by this CP.
 // That means that the current CP needs to create an Application and an ApiSubscription.
-//
-//nolint:nestif // Provider flow updates child resources and mirrors readiness back to the remote CP.
 func (h *RemoteApiSubscriptionHandler) handleProviderScenario(ctx context.Context, obj *apiapi.RemoteApiSubscription) (err error) {
 	logger := log.FromContext(ctx)
 	c := client.ClientFromContextOrDie(ctx)
@@ -153,27 +151,8 @@ func (h *RemoteApiSubscriptionHandler) handleProviderScenario(ctx context.Contex
 		obj.SetCondition(condition.NewProcessingCondition("Processing", "Processing RemoteApiSubscription"))
 		obj.SetCondition(condition.NewNotReadyCondition("Processing", "Processing RemoteApiSubscription"))
 	} else {
-		// No update occurred
-
-		if err = fillApprovalRequestInfo(ctx, obj, apiSubscription); err != nil {
-			return errors.Wrapf(err, "failed to fill approvalrequest info")
-		}
-
-		if err = fillApprovalInfo(ctx, obj, apiSubscription); err != nil {
-			return errors.Wrapf(err, "failed to fill approval info")
-		}
-
-		// check if ready
-		if meta.IsStatusConditionTrue(apiSubscription.GetConditions(), condition.ConditionTypeReady) {
-			obj.SetCondition(condition.NewReadyCondition("Ready", "RemoteApiSubscription is ready"))
-			obj.SetCondition(condition.NewDoneProcessingCondition("RemoteApiSubscription is done processing"))
-
-			if err = fillRouteInfo(ctx, obj, apiSubscription); err != nil {
-				return errors.Wrapf(err, "failed to fill route info")
-			}
-
-		} else {
-			obj.Status.Conditions = apiSubscription.Status.Conditions // TODO: good idea?
+		if err = mirrorChildSubscriptionStatus(ctx, obj, apiSubscription); err != nil {
+			return errors.Wrapf(err, "failed to mirror child subscription status")
 		}
 	}
 
@@ -188,4 +167,21 @@ func (h *RemoteApiSubscriptionHandler) handleProviderScenario(ctx context.Contex
 	}
 
 	return nil
+}
+
+// mirrorChildSubscriptionStatus fills obj's status from the child ApiSubscription's current state.
+func mirrorChildSubscriptionStatus(ctx context.Context, obj *apiapi.RemoteApiSubscription, apiSubscription *apiapi.ApiSubscription) error {
+	if err := fillApprovalRequestInfo(ctx, obj, apiSubscription); err != nil {
+		return errors.Wrapf(err, "failed to fill approvalrequest info")
+	}
+	if err := fillApprovalInfo(ctx, obj, apiSubscription); err != nil {
+		return errors.Wrapf(err, "failed to fill approval info")
+	}
+	if !meta.IsStatusConditionTrue(apiSubscription.GetConditions(), condition.ConditionTypeReady) {
+		obj.Status.Conditions = apiSubscription.Status.Conditions // TODO: good idea?
+		return nil
+	}
+	obj.SetCondition(condition.NewReadyCondition("Ready", "RemoteApiSubscription is ready"))
+	obj.SetCondition(condition.NewDoneProcessingCondition("RemoteApiSubscription is done processing"))
+	return fillRouteInfo(ctx, obj, apiSubscription)
 }

--- a/api/internal/handler/remoteapisubscription/provider_scenario.go
+++ b/api/internal/handler/remoteapisubscription/provider_scenario.go
@@ -9,37 +9,39 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/pkg/errors"
-	"github.com/telekom/controlplane/api/internal/handler/util"
-	"github.com/telekom/controlplane/common/pkg/client"
-	"github.com/telekom/controlplane/common/pkg/condition"
-	"github.com/telekom/controlplane/common/pkg/config"
-	"github.com/telekom/controlplane/common/pkg/types"
-	"github.com/telekom/controlplane/common/pkg/util/contextutil"
-	"github.com/telekom/controlplane/common/pkg/util/labelutil"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	apiapi "github.com/telekom/controlplane/api/api/v1"
+	"github.com/telekom/controlplane/api/internal/handler/util"
 	applicationv1 "github.com/telekom/controlplane/application/api/v1"
+	"github.com/telekom/controlplane/common/pkg/client"
+	"github.com/telekom/controlplane/common/pkg/condition"
+	"github.com/telekom/controlplane/common/pkg/config"
+	"github.com/telekom/controlplane/common/pkg/types"
+	"github.com/telekom/controlplane/common/pkg/util/contextutil"
+	"github.com/telekom/controlplane/common/pkg/util/labelutil"
 )
 
 // handleProviderScenario handles the case where the RemoteApiSubscription is handled by this CP.
 // That means that the current CP needs to create an Application and an ApiSubscription.
+//
+//nolint:nestif // Provider flow updates child resources and mirrors readiness back to the remote CP.
 func (h *RemoteApiSubscriptionHandler) handleProviderScenario(ctx context.Context, obj *apiapi.RemoteApiSubscription) (err error) {
-	log := log.FromContext(ctx)
+	logger := log.FromContext(ctx)
 	c := client.ClientFromContextOrDie(ctx)
 
 	// Handle it locally
-	log.V(1).Info("I need to handle this locally")
+	logger.V(1).Info("I need to handle this locally")
 
 	cleanup := func() error {
-		n, err := c.CleanupAll(ctx, client.OwnedBy(obj))
-		if err != nil {
-			return errors.Wrapf(err, "failed to cleanup all resources")
+		n, cleanupErr := c.CleanupAll(ctx, client.OwnedBy(obj))
+		if cleanupErr != nil {
+			return errors.Wrapf(cleanupErr, "failed to cleanup all resources")
 		}
-		log.V(1).Info("🧹 Cleaned up resources", "count", n)
+		logger.V(1).Info("🧹 Cleaned up resources", "count", n)
 
 		return nil
 	}
@@ -67,9 +69,9 @@ func (h *RemoteApiSubscriptionHandler) handleProviderScenario(ctx context.Contex
 	}
 
 	mutator := func() error {
-		err := controllerutil.SetControllerReference(obj, application, c.Scheme())
-		if err != nil {
-			return errors.Wrapf(err, "failed to set owner reference")
+		setAppRefErr := controllerutil.SetControllerReference(obj, application, c.Scheme())
+		if setAppRefErr != nil {
+			return errors.Wrapf(setAppRefErr, "failed to set owner reference")
 		}
 
 		application.Labels = map[string]string{
@@ -114,9 +116,9 @@ func (h *RemoteApiSubscriptionHandler) handleProviderScenario(ctx context.Contex
 	}
 
 	mutator = func() error {
-		err := controllerutil.SetControllerReference(obj, apiSubscription, c.Scheme())
-		if err != nil {
-			return errors.Wrapf(err, "failed to set owner reference")
+		setSubRefErr := controllerutil.SetControllerReference(obj, apiSubscription, c.Scheme())
+		if setSubRefErr != nil {
+			return errors.Wrapf(setSubRefErr, "failed to set owner reference")
 		}
 		apiSubscription.Labels = map[string]string{
 			apiapi.BasePathLabelKey:             labelutil.NormalizeLabelValue(obj.Spec.ApiBasePath),
@@ -182,7 +184,7 @@ func (h *RemoteApiSubscriptionHandler) handleProviderScenario(ctx context.Contex
 		return errors.Wrapf(err, "failed to send status to remote CP")
 	}
 	if updated {
-		log.Info("🔄 RemoteApiSubscription status updated")
+		logger.Info("🔄 RemoteApiSubscription status updated")
 	}
 
 	return nil

--- a/api/internal/handler/remoteapisubscription/syncer/mock_syncer.go
+++ b/api/internal/handler/remoteapisubscription/syncer/mock_syncer.go
@@ -12,8 +12,7 @@ import (
 
 const NOT_UPDATED = false
 
-type SyncerClientMock struct {
-}
+type SyncerClientMock struct{}
 
 func NewSyncerFactoryMock() SyncerClientFactory[*apiv1.RemoteApiSubscription] {
 	return &syncerFactory[*apiv1.RemoteApiSubscription]{

--- a/api/internal/handler/remoteapisubscription/syncer/syncer.go
+++ b/api/internal/handler/remoteapisubscription/syncer/syncer.go
@@ -11,12 +11,11 @@ import (
 	"fmt"
 
 	"github.com/pkg/errors"
-	"github.com/telekom/controlplane/common/pkg/util/labelutil"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	apiv1 "github.com/telekom/controlplane/api/api/v1"
-
+	"github.com/telekom/controlplane/common/pkg/util/labelutil"
 	cpv1 "github.com/telekom/controlplane/cpapi/api/v1"
 )
 
@@ -67,8 +66,8 @@ type syncerClient struct {
 }
 
 func (c *syncerClient) Send(ctx context.Context, resource *apiv1.RemoteApiSubscription) (bool, *apiv1.RemoteApiSubscription, error) {
-	log := log.FromContext(ctx)
-	log.Info("Sending RemoteApiSubscription to remote CP")
+	logger := log.FromContext(ctx)
+	logger.Info("Sending RemoteApiSubscription to remote CP")
 
 	body := cpv1.RemoteSubscriptionSpec{
 		ApiBasePath: resource.Spec.ApiBasePath,
@@ -102,8 +101,8 @@ func (c *syncerClient) Send(ctx context.Context, resource *apiv1.RemoteApiSubscr
 }
 
 func (c *syncerClient) SendStatus(ctx context.Context, resource *apiv1.RemoteApiSubscription) (bool, *apiv1.RemoteApiSubscription, error) {
-	log := log.FromContext(ctx)
-	log.Info("Sending RemoteApiSubscriptionStatus to remote CP")
+	logger := log.FromContext(ctx)
+	logger.Info("Sending RemoteApiSubscriptionStatus to remote CP")
 
 	body := cpv1.RemoteSubscriptionStatus{
 		Conditions: MapConditions(resource.Status.Conditions),
@@ -138,8 +137,8 @@ func (c *syncerClient) SendStatus(ctx context.Context, resource *apiv1.RemoteApi
 }
 
 func (c *syncerClient) Delete(ctx context.Context, resource *apiv1.RemoteApiSubscription) error {
-	log := log.FromContext(ctx)
-	log.Info("Deleting RemoteApiSubscription from remote CP")
+	logger := log.FromContext(ctx)
+	logger.Info("Deleting RemoteApiSubscription from remote CP")
 
 	resourceId := MakeResourceId(resource)
 

--- a/api/internal/handler/remoteapisubscription/util.go
+++ b/api/internal/handler/remoteapisubscription/util.go
@@ -59,7 +59,7 @@ func fillApprovalRequestInfo(ctx context.Context, obj *apiapi.RemoteApiSubscript
 	err = c.Get(ctx, apiSubscription.Status.ApprovalRequest.K8s(), approvalRequest)
 	if err != nil {
 		if !apierrors.IsNotFound(err) {
-			return errors.Wrapf(err, "failed to get approval %s", apiSubscription.Status.Approval.Name)
+			return errors.Wrapf(err, "failed to get approval request %s", apiSubscription.Status.ApprovalRequest.Name)
 		}
 		return nil
 	}

--- a/api/internal/handler/remoteapisubscription/util.go
+++ b/api/internal/handler/remoteapisubscription/util.go
@@ -9,13 +9,14 @@ import (
 	"fmt"
 
 	"github.com/pkg/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+
 	adminapi "github.com/telekom/controlplane/admin/api/v1"
 	apiapi "github.com/telekom/controlplane/api/api/v1"
 	approvalapi "github.com/telekom/controlplane/approval/api/v1"
 	"github.com/telekom/controlplane/common/pkg/client"
 	"github.com/telekom/controlplane/common/pkg/types"
 	gatewayapi "github.com/telekom/controlplane/gateway/api/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 )
 
 func CalculateRemoteOrgZone(remoteOrg *adminapi.RemoteOrganization) types.ObjectRef {
@@ -44,7 +45,7 @@ func fillApprovalInfo(ctx context.Context, obj *apiapi.RemoteApiSubscription, ap
 		ApprovalState: approval.Spec.State.String(),
 		Message:       "", // todo - resolve later, should be taken from decisions
 	}
-	return
+	return err
 }
 
 func fillApprovalRequestInfo(ctx context.Context, obj *apiapi.RemoteApiSubscription, apiSubscription *apiapi.ApiSubscription) (err error) {
@@ -66,7 +67,7 @@ func fillApprovalRequestInfo(ctx context.Context, obj *apiapi.RemoteApiSubscript
 		ApprovalState: approvalRequest.Spec.State.String(),
 		Message:       "", // todo - resolve later, should be taken from decisions
 	}
-	return
+	return err
 }
 
 func fillRouteInfo(ctx context.Context, obj *apiapi.RemoteApiSubscription, apiSubscription *apiapi.ApiSubscription) (err error) {
@@ -85,5 +86,5 @@ func fillRouteInfo(ctx context.Context, obj *apiapi.RemoteApiSubscription, apiSu
 	}
 	// TODO: This is shit. What if we have multiple downstreams? Why is it like this?
 	obj.Status.GatewayUrl = "https://" + downstreamRoute.Spec.Downstreams[0].Host + downstreamRoute.Spec.Downstreams[0].Path
-	return
+	return err
 }

--- a/api/internal/handler/suite_test.go
+++ b/api/internal/handler/suite_test.go
@@ -13,9 +13,6 @@ import (
 	"testing"
 	"time"
 
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
-
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -26,7 +23,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	"github.com/telekom/controlplane/api/internal/controller"
-	// +kubebuilder:scaffold:imports
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 )
 
 // These tests use Ginkgo (BDD-style Go testing framework). Refer to
@@ -39,11 +38,13 @@ const (
 	testEnvironment = "test"
 )
 
-var cfg *rest.Config
-var k8sClient client.Client
-var testEnv *envtest.Environment
-var ctx context.Context
-var cancel context.CancelFunc
+var (
+	cfg       *rest.Config
+	k8sClient client.Client
+	testEnv   *envtest.Environment
+	ctx       context.Context
+	cancel    context.CancelFunc
+)
 
 func TestHandlers(t *testing.T) {
 	RegisterFailHandler(Fail)
@@ -57,14 +58,14 @@ var _ = BeforeSuite(func() {
 	ctx, cancel = context.WithCancel(context.TODO())
 
 	By("bootstrapping test environment")
-	//testEnv = &envtest.Environment{
+	// testEnv = &envtest.Environment{
 	//	CRDDirectoryPaths: append(
 	//		testutil.GetCrdPathsOrDie("^github.com/telekom/controlplane/(application|approval|admin|gateway|identity)/api$"),
 	//		filepath.Join("..", "..", "config", "crd", "bases")),
 	//	ErrorIfCRDPathMissing: true,
 	//	BinaryAssetsDirectory: filepath.Join("..", "..", "bin", "k8s",
 	//		fmt.Sprintf("%s-%s-%s", os.Getenv("ENVTEST_K8S_VERSION"), runtime.GOOS, runtime.GOARCH)),
-	//}
+	// }
 	testEnv = &envtest.Environment{
 		CRDDirectoryPaths: append(
 			make([]string, 0),
@@ -95,7 +96,6 @@ var _ = BeforeSuite(func() {
 
 	By("Creating the environment namespace")
 	CreateNamespace(testEnvironment)
-
 })
 
 var _ = AfterSuite(func() {

--- a/api/internal/handler/util/gateway.go
+++ b/api/internal/handler/util/gateway.go
@@ -9,11 +9,12 @@ import (
 	"net/url"
 
 	"github.com/pkg/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
 	cclient "github.com/telekom/controlplane/common/pkg/client"
 	gatewayapi "github.com/telekom/controlplane/gateway/api/v1"
 	identityapi "github.com/telekom/controlplane/identity/api/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 func AsUpstreamForProxyRoute(ctx context.Context, realm *gatewayapi.Realm, apiBasePath string) (ups gatewayapi.Upstream, err error) {
@@ -25,7 +26,8 @@ func AsUpstreamForProxyRoute(ctx context.Context, realm *gatewayapi.Realm, apiBa
 			Namespace: realm.Namespace,
 		},
 	}
-	if err := c.Get(ctx, client.ObjectKeyFromObject(identityClient), identityClient); err != nil {
+	err = c.Get(ctx, client.ObjectKeyFromObject(identityClient), identityClient)
+	if err != nil {
 		return ups, errors.Wrapf(err, "failed to get gateway client for %s/%s", realm.Name, realm.Namespace)
 	}
 
@@ -37,21 +39,22 @@ func AsUpstreamForProxyRoute(ctx context.Context, realm *gatewayapi.Realm, apiBa
 	ups.ClientSecret = identityClient.Spec.ClientSecret
 	ups.IssuerUrl = identityClient.Status.IssuerUrl
 
-	return
+	return ups, err
 }
 
 func AsUpstreamForRealRoute(
-	ctx context.Context, rawUrl string, weight int) (ups gatewayapi.Upstream, err error) {
-	url, err := url.Parse(rawUrl)
+	ctx context.Context, rawUrl string, weight int,
+) (ups gatewayapi.Upstream, err error) {
+	parsedURL, err := url.Parse(rawUrl)
 	if err != nil {
 		return ups, errors.Wrapf(err, "failed to parse URL %s", rawUrl)
 	}
 
 	return gatewayapi.Upstream{
-		Scheme: url.Scheme,
-		Host:   url.Hostname(),
-		Port:   gatewayapi.GetPortOrDefaultFromScheme(url),
-		Path:   url.Path,
+		Scheme: parsedURL.Scheme,
+		Host:   parsedURL.Hostname(),
+		Port:   gatewayapi.GetPortOrDefaultFromScheme(parsedURL),
+		Path:   parsedURL.Path,
 		Weight: weight,
 	}, nil
 }

--- a/api/internal/handler/util/getters.go
+++ b/api/internal/handler/util/getters.go
@@ -9,35 +9,35 @@ import (
 	"fmt"
 	"sort"
 
-	"github.com/telekom/controlplane/common/pkg/config"
-
 	"github.com/pkg/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
 	adminapi "github.com/telekom/controlplane/admin/api/v1"
 	apiv1 "github.com/telekom/controlplane/api/api/v1"
 	applicationapi "github.com/telekom/controlplane/application/api/v1"
 	approvalbuilder "github.com/telekom/controlplane/approval/api/v1/builder"
 	cclient "github.com/telekom/controlplane/common/pkg/client"
 	"github.com/telekom/controlplane/common/pkg/condition"
+	"github.com/telekom/controlplane/common/pkg/config"
 	"github.com/telekom/controlplane/common/pkg/controller"
 	"github.com/telekom/controlplane/common/pkg/errors/ctrlerrors"
 	"github.com/telekom/controlplane/common/pkg/types"
 	"github.com/telekom/controlplane/common/pkg/util/labelutil"
 	gatewayapi "github.com/telekom/controlplane/gateway/api/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/api/meta"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
-var (
-	ApplicationLabelKey = config.BuildLabelKey("application")
-)
+const stringTrue = "true"
+
+var ApplicationLabelKey = config.BuildLabelKey("application")
 
 // GetZone retrieves a Zone object based on the provided ObjectRef for a zone.
-func GetZone(ctx context.Context, client cclient.ScopedClient, ref client.ObjectKey) (*adminapi.Zone, error) {
+func GetZone(ctx context.Context, scopedClient cclient.ScopedClient, ref client.ObjectKey) (*adminapi.Zone, error) {
 	zone := &adminapi.Zone{}
-	err := client.Get(ctx, ref, zone)
+	err := scopedClient.Get(ctx, ref, zone)
 	if err != nil {
 		if !apierrors.IsNotFound(err) {
 			return nil, errors.Wrap(err, fmt.Sprintf("failed to find zone %q", ref.String()))
@@ -66,10 +66,10 @@ func GetApplicationFromLabel(ctx context.Context, apiExposure *apiv1.ApiExposure
 }
 
 func GetApplication(ctx context.Context, ref types.ObjectRef) (*applicationapi.Application, error) {
-	client := cclient.ClientFromContextOrDie(ctx)
+	scopedClient := cclient.ClientFromContextOrDie(ctx)
 
 	application := &applicationapi.Application{}
-	err := client.Get(ctx, ref.K8s(), application)
+	err := scopedClient.Get(ctx, ref.K8s(), application)
 	if err != nil {
 		if !apierrors.IsNotFound(err) {
 			return nil, errors.Wrap(err, fmt.Sprintf("failed to find application %q", ref.String()))
@@ -84,10 +84,10 @@ func GetApplication(ctx context.Context, ref types.ObjectRef) (*applicationapi.A
 }
 
 func GetRealm(ctx context.Context, ref client.ObjectKey) (*gatewayapi.Realm, error) {
-	client := cclient.ClientFromContextOrDie(ctx)
+	scopedClient := cclient.ClientFromContextOrDie(ctx)
 
 	realm := &gatewayapi.Realm{}
-	err := client.Get(ctx, ref, realm)
+	err := scopedClient.Get(ctx, ref, realm)
 	if err != nil {
 		if !apierrors.IsNotFound(err) {
 			return nil, errors.Wrap(err, fmt.Sprintf("failed to find realm %q", ref.String()))
@@ -123,7 +123,7 @@ func GetRealmForZone(ctx context.Context, zoneRef types.ObjectRef, realmName str
 
 // FindAPI checks if there is an active Api corresponding to the given apiBasePath.
 func FindActiveAPI(ctx context.Context, apiBasePath string) (bool, *apiv1.Api, error) {
-	log := log.FromContext(ctx)
+	logger := log.FromContext(ctx)
 	scopedClient := cclient.ClientFromContextOrDie(ctx)
 
 	apiBasePathLabelValue := labelutil.NormalizeLabelValue(apiBasePath)
@@ -151,7 +151,7 @@ func FindActiveAPI(ctx context.Context, apiBasePath string) (bool, *apiv1.Api, e
 			return apiList.Items[i].CreationTimestamp.Before(&apiList.Items[j].CreationTimestamp)
 		})
 		relevantApi = &apiList.Items[0]
-		log.Info("⚠️  Multiple active Apis found for the same BasePath. Using the oldest one.", "basePath", apiBasePathLabelValue, "apiName", relevantApi.Name)
+		logger.Info("⚠️  Multiple active Apis found for the same BasePath. Using the oldest one.", "basePath", apiBasePathLabelValue, "apiName", relevantApi.Name)
 	}
 
 	if err := condition.EnsureReady(relevantApi); err != nil {
@@ -163,7 +163,7 @@ func FindActiveAPI(ctx context.Context, apiBasePath string) (bool, *apiv1.Api, e
 
 // FindAPIExposure checks if there is an active ApiExposure corresponding to the given apiBasePath.
 func FindActiveAPIExposure(ctx context.Context, apiBasePath string) (bool, *apiv1.ApiExposure, error) {
-	log := log.FromContext(ctx)
+	logger := log.FromContext(ctx)
 	scopedClient := cclient.ClientFromContextOrDie(ctx)
 
 	apiBasePathLabelValue := labelutil.NormalizeLabelValue(apiBasePath)
@@ -171,13 +171,13 @@ func FindActiveAPIExposure(ctx context.Context, apiBasePath string) (bool, *apiv
 	apiExposureList := &apiv1.ApiExposureList{}
 	err := scopedClient.List(ctx, apiExposureList,
 		client.MatchingLabels{apiv1.BasePathLabelKey: apiBasePathLabelValue},
-		client.MatchingFields{"status.active": "true"})
+		client.MatchingFields{"status.active": stringTrue})
 	if err != nil {
 		return false, nil, errors.Wrapf(err,
 			"failed to list corresponding ApiExposures for ApiBasePath: %q", apiBasePathLabelValue)
 	}
 
-	log.V(1).Info("found active ApiExposures", "size", len(apiExposureList.Items), "basePath", apiBasePathLabelValue)
+	logger.V(1).Info("found active ApiExposures", "size", len(apiExposureList.Items), "basePath", apiBasePathLabelValue)
 
 	var relevantApiExposure *apiv1.ApiExposure
 
@@ -193,7 +193,7 @@ func FindActiveAPIExposure(ctx context.Context, apiBasePath string) (bool, *apiv
 			return apiExposureList.Items[i].CreationTimestamp.Before(&apiExposureList.Items[j].CreationTimestamp)
 		})
 		relevantApiExposure = &apiExposureList.Items[0]
-		log.Info("⚠️  Multiple active ApiExposures found for the same BasePath. Using the oldest one.", "basePath", apiBasePathLabelValue, "apiExposureName", relevantApiExposure.Name)
+		logger.Info("⚠️  Multiple active ApiExposures found for the same BasePath. Using the oldest one.", "basePath", apiBasePathLabelValue, "apiExposureName", relevantApiExposure.Name)
 	}
 
 	if err := condition.EnsureReady(relevantApiExposure); err != nil {

--- a/api/internal/handler/util/remote.go
+++ b/api/internal/handler/util/remote.go
@@ -9,12 +9,13 @@ import (
 	"fmt"
 
 	"github.com/pkg/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+
 	adminapi "github.com/telekom/controlplane/admin/api/v1"
 	"github.com/telekom/controlplane/common/pkg/client"
 	"github.com/telekom/controlplane/common/pkg/condition"
 	"github.com/telekom/controlplane/common/pkg/errors/ctrlerrors"
 	"github.com/telekom/controlplane/common/pkg/types"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 )
 
 func GetRemoteOrganization(ctx context.Context, ref types.ObjectRef) (*adminapi.RemoteOrganization, error) {

--- a/api/internal/handler/util/route_util.go
+++ b/api/internal/handler/util/route_util.go
@@ -9,17 +9,18 @@ import (
 	"fmt"
 
 	"github.com/pkg/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
 	apiapi "github.com/telekom/controlplane/api/api/v1"
 	cclient "github.com/telekom/controlplane/common/pkg/client"
 	"github.com/telekom/controlplane/common/pkg/config"
 	"github.com/telekom/controlplane/common/pkg/types"
 	"github.com/telekom/controlplane/common/pkg/util/labelutil"
 	gatewayapi "github.com/telekom/controlplane/gateway/api/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 const (
@@ -28,9 +29,9 @@ const (
 	GatewayConsumerName = "gateway"
 )
 
-var (
-	LabelFailoverSecondary = config.BuildLabelKey("failover.secondary")
-)
+const labelTrue = "true"
+
+var LabelFailoverSecondary = config.BuildLabelKey("failover.secondary")
 
 type CreateRouteOptions struct {
 	FailoverUpstreams   []apiapi.Upstream
@@ -147,9 +148,9 @@ func MakeRouteName(apiBasePath, realmName string) string {
 	return routeName
 }
 
-func CreateProxyRoute(ctx context.Context, downstreamZoneRef types.ObjectRef, upstreamZoneRef types.ObjectRef, apiBasePath, realmName string, opts ...CreateRouteOption) (*gatewayapi.Route, error) {
+func CreateProxyRoute(ctx context.Context, downstreamZoneRef, upstreamZoneRef types.ObjectRef, apiBasePath, realmName string, opts ...CreateRouteOption) (*gatewayapi.Route, error) {
 	c := cclient.ClientFromContextOrDie(ctx)
-	log := log.FromContext(ctx)
+	logger := log.FromContext(ctx)
 
 	options := &CreateRouteOptions{}
 	for _, opt := range opts {
@@ -191,14 +192,14 @@ func CreateProxyRoute(ctx context.Context, downstreamZoneRef types.ObjectRef, up
 			config.BuildLabelKey("type"):  "proxy",
 		}
 
-		downstream, err := downstreamRealm.AsDownstream(apiBasePath)
-		if err != nil {
-			return errors.Wrap(err, "failed to create downstream")
+		downstream, downstreamErr := downstreamRealm.AsDownstream(apiBasePath)
+		if downstreamErr != nil {
+			return errors.Wrap(downstreamErr, "failed to create downstream")
 		}
 
-		upstream, err := AsUpstreamForProxyRoute(ctx, upstreamRealm, apiBasePath)
-		if err != nil {
-			return errors.Wrap(err, "failed to create upstream")
+		upstream, upstreamErr := AsUpstreamForProxyRoute(ctx, upstreamRealm, apiBasePath)
+		if upstreamErr != nil {
+			return errors.Wrap(upstreamErr, "failed to create upstream")
 		}
 
 		proxyRoute.Spec = gatewayapi.RouteSpec{
@@ -211,7 +212,7 @@ func CreateProxyRoute(ctx context.Context, downstreamZoneRef types.ObjectRef, up
 			},
 		}
 
-		log.Info("Creating proxy route", "route", proxyRoute.Name, "namespace", proxyRoute.Namespace, "failover", options.HasFailover())
+		logger.Info("Creating proxy route", "route", proxyRoute.Name, "namespace", proxyRoute.Namespace, "failover", options.HasFailover())
 
 		if options.HasServiceRateLimit() {
 			proxyRoute.Spec.Traffic = gatewayapi.Traffic{
@@ -220,7 +221,7 @@ func CreateProxyRoute(ctx context.Context, downstreamZoneRef types.ObjectRef, up
 		}
 
 		if options.IsFailoverSecondary() {
-			proxyRoute.Labels[LabelFailoverSecondary] = "true"
+			proxyRoute.Labels[LabelFailoverSecondary] = labelTrue
 
 			// A failover secondary route is the target of cross-zone proxy requests,
 			// so the gateway mesh-client must be allowed to access it.
@@ -231,9 +232,9 @@ func CreateProxyRoute(ctx context.Context, downstreamZoneRef types.ObjectRef, up
 
 			failoverUpstreams := make([]gatewayapi.Upstream, 0, len(options.FailoverUpstreams))
 			for _, rawUpstream := range options.FailoverUpstreams {
-				failoverUpstream, err := AsUpstreamForRealRoute(ctx, rawUpstream.Url, rawUpstream.Weight)
-				if err != nil {
-					return errors.Wrapf(err, "failed to create failover upstream %s", rawUpstream.Url)
+				failoverUpstream, upstreamErr := AsUpstreamForRealRoute(ctx, rawUpstream.Url, rawUpstream.Weight)
+				if upstreamErr != nil {
+					return errors.Wrapf(upstreamErr, "failed to create failover upstream %s", rawUpstream.Url)
 				}
 				failoverUpstreams = append(failoverUpstreams, failoverUpstream)
 			}
@@ -254,11 +255,14 @@ func CreateProxyRoute(ctx context.Context, downstreamZoneRef types.ObjectRef, up
 
 		if options.HasFailover() {
 			proxyRoute.Labels[config.BuildLabelKey("failover.zone")] = labelutil.NormalizeValue(options.FailoverZone.Name)
-			failoverUpstreamRealm, _, err := GetRealmForZone(ctx, options.FailoverZone, realmName)
-			if err != nil {
-				return errors.Wrapf(err, "failed to get failover zone %s", options.FailoverZone.String())
+			failoverUpstreamRealm, _, getRealmErr := GetRealmForZone(ctx, options.FailoverZone, realmName)
+			if getRealmErr != nil {
+				return errors.Wrapf(getRealmErr, "failed to get failover zone %s", options.FailoverZone.String())
 			}
-			failoverUpstream, err := AsUpstreamForProxyRoute(ctx, failoverUpstreamRealm, apiBasePath)
+			failoverUpstream, upstreamErr := AsUpstreamForProxyRoute(ctx, failoverUpstreamRealm, apiBasePath)
+			if upstreamErr != nil {
+				return errors.Wrapf(upstreamErr, "failed to create failover upstream for zone %s", options.FailoverZone.String())
+			}
 
 			proxyRoute.Spec.Traffic = gatewayapi.Traffic{
 				Failover: &gatewayapi.Failover{
@@ -288,7 +292,7 @@ func CleanupProxyRoute(ctx context.Context, routeRef *types.ObjectRef, opts ...C
 	if routeRef == nil {
 		return nil
 	}
-	log := log.FromContext(ctx).WithValues("route.name", routeRef.Name, "route.namespace", routeRef.Namespace)
+	logger := log.FromContext(ctx).WithValues("route.name", routeRef.Name, "route.namespace", routeRef.Namespace)
 
 	options := &CreateRouteOptions{}
 	for _, opt := range opts {
@@ -305,12 +309,12 @@ func CleanupProxyRoute(ctx context.Context, routeRef *types.ObjectRef, opts ...C
 	}
 
 	if route.GetLabels()[config.BuildLabelKey("type")] == "real" { // DO NOT DELETE REAL ROUTES
-		log.V(1).Info("🫷 Not deleting route as it is a real route")
+		logger.V(1).Info("🫷 Not deleting route as it is a real route")
 		return nil
 	}
 
-	if route.GetLabels()[LabelFailoverSecondary] == "true" { // DO NOT DELETE FAILOVER ROUTES
-		log.V(1).Info("🫷 Not deleting route as it is a failover secondary")
+	if route.GetLabels()[LabelFailoverSecondary] == labelTrue { // DO NOT DELETE FAILOVER ROUTES
+		logger.V(1).Info("🫷 Not deleting route as it is a failover secondary")
 		return nil
 	}
 
@@ -327,17 +331,17 @@ func CleanupProxyRoute(ctx context.Context, routeRef *types.ObjectRef, opts ...C
 	}
 
 	if len(apiSubscriptions.Items) > 1 {
-		log.Info("🫷 Not deleting route as more than 1 subscriptions exists")
+		logger.Info("🫷 Not deleting route as more than 1 subscriptions exists")
 		return nil
 	}
 
-	log.Info("🧹 Deleting route as no more subscriptions exist")
+	logger.Info("🧹 Deleting route as no more subscriptions exist")
 
 	err = scopedClient.Delete(ctx, route)
 	if err != nil {
 		return errors.Wrapf(err, "failed to delete route")
 	}
-	log.Info("✅ Successfully deleted obsolete route")
+	logger.Info("✅ Successfully deleted obsolete route")
 
 	return nil
 }
@@ -403,16 +407,16 @@ func CreateRealRoute(ctx context.Context, downstreamZoneRef types.ObjectRef, api
 			config.BuildLabelKey("type"):  "real",
 		}
 
-		downstream, err := downstreamRealm.AsDownstream(apiExposure.Spec.ApiBasePath)
-		if err != nil {
-			return errors.Wrap(err, "failed to create downstream")
+		downstream, downstreamErr := downstreamRealm.AsDownstream(apiExposure.Spec.ApiBasePath)
+		if downstreamErr != nil {
+			return errors.Wrap(downstreamErr, "failed to create downstream")
 		}
 
 		gatewayUpstreams := make([]gatewayapi.Upstream, 0, len(apiExposure.Spec.Upstreams))
 		for _, upstream := range apiExposure.Spec.Upstreams {
-			gatewayUpstream, err := AsUpstreamForRealRoute(ctx, upstream.Url, upstream.Weight)
-			if err != nil {
-				return errors.Wrapf(err, "failed to create upstream for URL %s", upstream.Url)
+			gatewayUpstream, upstreamErr := AsUpstreamForRealRoute(ctx, upstream.Url, upstream.Weight)
+			if upstreamErr != nil {
+				return errors.Wrapf(upstreamErr, "failed to create upstream for URL %s", upstream.Url)
 			}
 			gatewayUpstreams = append(gatewayUpstreams, gatewayUpstream)
 		}
@@ -457,7 +461,7 @@ func CreateRealRoute(ctx context.Context, downstreamZoneRef types.ObjectRef, api
 	return route, nil
 }
 
-func CreateConsumeRoute(ctx context.Context, apiSub *apiapi.ApiSubscription, downstreamZoneRef types.ObjectRef, routeRef types.ObjectRef, clientId string, opts ...CreateConsumeRouteOption) (*gatewayapi.ConsumeRoute, error) {
+func CreateConsumeRoute(ctx context.Context, apiSub *apiapi.ApiSubscription, downstreamZoneRef, routeRef types.ObjectRef, clientId string, opts ...CreateConsumeRouteOption) (*gatewayapi.ConsumeRoute, error) {
 	scopedClient := cclient.ClientFromContextOrDie(ctx)
 
 	options := &CreateConsumeRouteOptions{}
@@ -506,6 +510,7 @@ func CreateConsumeRoute(ctx context.Context, apiSub *apiapi.ApiSubscription, dow
 	return routeConsumer, nil
 }
 
+//nolint:nestif // Security mapping mirrors the nested API security shape.
 func mapSecurity(apiSecurity *apiapi.Security) *gatewayapi.Security {
 	if apiSecurity == nil {
 		return nil

--- a/api/internal/handler/util/route_util_test.go
+++ b/api/internal/handler/util/route_util_test.go
@@ -13,7 +13,6 @@ import (
 )
 
 var _ = Describe("Route Util", func() {
-
 	Describe("GatewayConsumerName", func() {
 		It("should equal 'gateway'", func() {
 			Expect(GatewayConsumerName).To(Equal("gateway"))
@@ -31,7 +30,6 @@ var _ = Describe("Route Util", func() {
 	})
 
 	Describe("CreateRouteOptions", func() {
-
 		Describe("WithProxyTarget", func() {
 			It("should set IsProxyTarget to true", func() {
 				opts := &CreateRouteOptions{}
@@ -183,7 +181,6 @@ var _ = Describe("Route Util", func() {
 	})
 
 	Describe("CreateConsumeRouteOptions", func() {
-
 		Describe("WithConsumerRouteRateLimit", func() {
 			It("should set consumer rate limit on options", func() {
 				limits := apiapi.Limits{Second: 5, Minute: 50, Hour: 500}

--- a/api/internal/handler/util_proxy_route_test.go
+++ b/api/internal/handler/util_proxy_route_test.go
@@ -8,8 +8,6 @@ import (
 	"context"
 	"fmt"
 
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	adminapi "github.com/telekom/controlplane/admin/api/v1"
@@ -21,6 +19,9 @@ import (
 	"github.com/telekom/controlplane/common/pkg/util/contextutil"
 	gatewayapi "github.com/telekom/controlplane/gateway/api/v1"
 	identityapi "github.com/telekom/controlplane/identity/api/v1"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 )
 
 func CreateZone(name string) *adminapi.Zone {
@@ -114,9 +115,7 @@ func CreateGatewayClient(zone *adminapi.Zone) *identityapi.Client {
 }
 
 var _ = Describe("Util Tests", func() {
-
 	Context("Creation of Proxy-Routes", Ordered, func() {
-
 		ctx = context.Background()
 		var consumerZone *adminapi.Zone
 		var providerZone *adminapi.Zone
@@ -137,7 +136,6 @@ var _ = Describe("Util Tests", func() {
 			providerZone = CreateZone("provider")
 			CreateRealm(testEnvironment, "provider")
 			CreateGatewayClient(providerZone)
-
 		})
 
 		It("should create a normal Proxy-Route", func() {
@@ -189,6 +187,5 @@ var _ = Describe("Util Tests", func() {
 			Expect(upstream.ClientId).To(Equal("gateway"))
 			Expect(upstream.ClientSecret).To(Equal("topsecret"))
 		})
-
 	})
 })


### PR DESCRIPTION
- Rename shadowing locals (log→logger, api→apiObj, client→cl, url→u, err vars)
- Fix range value copies in controller map functions (use index/pointer)
- Remove duplicate imports and normalize package aliases
- Fix sprintfQuotedString: use %q instead of quoted %s
- Extract repeated string literals into constants (Allowed, true)
- Convert if-else chains to switch statements
- Fix comment spacing (add space after //)
- Remove ineffectual err assignment in route_util.go
- Add //nolint directives for intentional duplication and high-complexity handlers
- Enable lint_fail_on_issues in CI