### PR TITLE
feat: enforce team api category

### DIFF
--- a/api/config/rbac/role.yaml
+++ b/api/config/rbac/role.yaml
@@ -128,3 +128,11 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - organization.cp.ei.telekom.de
+  resources:
+  - teams
+  verbs:
+  - get
+  - list
+  - watch

--- a/api/go.mod
+++ b/api/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/telekom/controlplane/cpapi/api v0.0.0
 	github.com/telekom/controlplane/gateway/api v0.0.0
 	github.com/telekom/controlplane/identity/api v0.0.0
+	github.com/telekom/controlplane/organization/api v0.0.0
 )
 
 replace (
@@ -26,6 +27,7 @@ replace (
 	github.com/telekom/controlplane/cpapi/api => ../cpapi/api
 	github.com/telekom/controlplane/gateway/api => ../gateway/api
 	github.com/telekom/controlplane/identity/api => ../identity/api
+	github.com/telekom/controlplane/organization/api => ../organization/api
 )
 
 require (

--- a/api/internal/controller/apiexposure_controller.go
+++ b/api/internal/controller/apiexposure_controller.go
@@ -45,6 +45,7 @@ type ApiExposureReconciler struct {
 // +kubebuilder:rbac:groups=admin.cp.ei.telekom.de,resources=zones/status,verbs=get
 // +kubebuilder:rbac:groups=gateway.cp.ei.telekom.de,resources=realms,verbs=get;list;watch
 // +kubebuilder:rbac:groups=gateway.cp.ei.telekom.de,resources=routes,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=organization.cp.ei.telekom.de,resources=teams,verbs=get;list;watch
 
 func (r *ApiExposureReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	return r.Controller.Reconcile(ctx, req, &apiv1.ApiExposure{})

--- a/api/internal/controller/apisubscription_controller.go
+++ b/api/internal/controller/apisubscription_controller.go
@@ -54,6 +54,7 @@ type ApiSubscriptionReconciler struct {
 // +kubebuilder:rbac:groups=gateway.cp.ei.telekom.de,resources=consumeroutes,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=identity.cp.ei.telekom.de,resources=clients,verbs=get;list;watch
 // +kubebuilder:rbac:groups=application.cp.ei.telekom.de,resources=applications,verbs=get;list;watch
+// +kubebuilder:rbac:groups=organization.cp.ei.telekom.de,resources=teams,verbs=get;list;watch
 
 func (r *ApiSubscriptionReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	return r.Controller.Reconcile(ctx, req, new(apiapi.ApiSubscription))

--- a/api/internal/controller/index.go
+++ b/api/internal/controller/index.go
@@ -52,6 +52,23 @@ func RegisterIndecesOrDie(ctx context.Context, mgr ctrl.Manager) {
 		os.Exit(1)
 	}
 
+	filterApiCategoryLabelValue := func(obj client.Object) []string {
+		apiCategory, ok := obj.(*apiapi.ApiCategory)
+		if !ok {
+			return nil
+		}
+		if apiCategory.Spec.LabelValue == "" {
+			return nil
+		}
+		return []string{apiCategory.Spec.LabelValue}
+	}
+	err = mgr.GetFieldIndexer().
+		IndexField(ctx, &apiapi.ApiCategory{}, "spec.labelValue", filterApiCategoryLabelValue)
+	if err != nil {
+		ctrl.Log.Error(err, "unable to create fieldIndex for ApiCategory", "FieldIndex", "spec.labelValue")
+		os.Exit(1)
+	}
+
 	err = index.SetOwnerIndex(ctx, mgr.GetFieldIndexer(), &apiapi.RemoteApiSubscription{})
 	if err != nil {
 		ctrl.Log.Error(err, "unable to create field-indexer")

--- a/api/internal/controller/schema.go
+++ b/api/internal/controller/schema.go
@@ -15,6 +15,7 @@ import (
 	approvalapi "github.com/telekom/controlplane/approval/api/v1"
 	gatewayapi "github.com/telekom/controlplane/gateway/api/v1"
 	identityapi "github.com/telekom/controlplane/identity/api/v1"
+	organizationapi "github.com/telekom/controlplane/organization/api/v1"
 )
 
 func RegisterSchemesOrDie(scheme *runtime.Scheme) {
@@ -25,4 +26,5 @@ func RegisterSchemesOrDie(scheme *runtime.Scheme) {
 	utilruntime.Must(apiapi.AddToScheme(scheme))
 	utilruntime.Must(identityapi.AddToScheme(scheme))
 	utilruntime.Must(applicationapi.AddToScheme(scheme))
+	utilruntime.Must(organizationapi.AddToScheme(scheme))
 }

--- a/api/internal/controller/suite_test.go
+++ b/api/internal/controller/suite_test.go
@@ -26,6 +26,7 @@ import (
 
 	apiv1 "github.com/telekom/controlplane/api/api/v1"
 	"github.com/telekom/controlplane/api/internal/handler/remoteapisubscription/syncer"
+	"github.com/telekom/controlplane/common/pkg/config"
 	"github.com/telekom/controlplane/common/pkg/test/mock"
 	organizationapi "github.com/telekom/controlplane/organization/api/v1"
 
@@ -199,7 +200,7 @@ func CreateTestGroup() *organizationapi.Group {
 			Name:      testGroup,
 			Namespace: testEnvironment,
 			Labels: map[string]string{
-				"cp.ei.telekom.de/environment": testEnvironment,
+				config.EnvironmentLabelKey: testEnvironment,
 			},
 		},
 		Spec: organizationapi.GroupSpec{
@@ -217,7 +218,7 @@ func CreateTestTeam() *organizationapi.Team {
 			Name:      organizationapi.TeamResourceName(testGroup, testTeamName),
 			Namespace: testEnvironment,
 			Labels: map[string]string{
-				"cp.ei.telekom.de/environment": testEnvironment,
+				config.EnvironmentLabelKey: testEnvironment,
 			},
 		},
 		Spec: organizationapi.TeamSpec{
@@ -243,7 +244,7 @@ func CreateTestApiCategory() *apiv1.ApiCategory {
 			Name:      "other",
 			Namespace: testNamespace,
 			Labels: map[string]string{
-				"cp.ei.telekom.de/environment": testEnvironment,
+				config.EnvironmentLabelKey: testEnvironment,
 			},
 		},
 		Spec: apiv1.ApiCategorySpec{

--- a/api/internal/controller/suite_test.go
+++ b/api/internal/controller/suite_test.go
@@ -27,6 +27,7 @@ import (
 	apiv1 "github.com/telekom/controlplane/api/api/v1"
 	"github.com/telekom/controlplane/api/internal/handler/remoteapisubscription/syncer"
 	"github.com/telekom/controlplane/common/pkg/test/mock"
+	organizationapi "github.com/telekom/controlplane/organization/api/v1"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -39,9 +40,18 @@ import (
 const (
 	timeout         = 2 * time.Second
 	interval        = 100 * time.Millisecond
-	testNamespace   = "default"
 	testEnvironment = "test"
+	testGroup       = "dev"
+	testTeamName    = "api"
+	testCategory    = "Customer"
 )
+
+var testNamespace string
+
+func init() {
+	// testNamespace is constructed using the convention: <environment>--<group>--<team>
+	testNamespace = testEnvironment + "--" + testGroup + "--" + testTeamName
+}
 
 var (
 	cfg       *rest.Config
@@ -74,6 +84,7 @@ var _ = BeforeSuite(func() {
 			filepath.Join("..", "..", "..", "admin", "config", "crd", "bases"),
 			filepath.Join("..", "..", "..", "gateway", "config", "crd", "bases"),
 			filepath.Join("..", "..", "..", "identity", "config", "crd", "bases"),
+			filepath.Join("..", "..", "..", "organization", "config", "crd", "bases"),
 		),
 		ErrorIfCRDPathMissing: true,
 		BinaryAssetsDirectory: filepath.Join("..", "..", "bin", "k8s",
@@ -149,6 +160,16 @@ var _ = BeforeSuite(func() {
 	By("Creating the environment namespace")
 	CreateNamespace(testEnvironment)
 
+	By("Creating the test group and team")
+	CreateTestGroup()
+	CreateTestTeam()
+
+	By("Creating the test namespace")
+	CreateNamespace(testNamespace)
+
+	By("Creating the test API category")
+	CreateTestApiCategory()
+
 	go func() {
 		defer GinkgoRecover()
 		err = k8sManager.Start(ctx)
@@ -170,4 +191,72 @@ func CreateNamespace(name string) {
 		},
 	}
 	Expect(k8sClient.Create(ctx, ns)).To(Succeed())
+}
+
+func CreateTestGroup() *organizationapi.Group {
+	group := &organizationapi.Group{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testGroup,
+			Namespace: testEnvironment,
+			Labels: map[string]string{
+				"cp.ei.telekom.de/environment": testEnvironment,
+			},
+		},
+		Spec: organizationapi.GroupSpec{
+			DisplayName: "Test Group",
+			Description: "Test group for API tests",
+		},
+	}
+	Expect(k8sClient.Create(ctx, group)).To(Succeed())
+	return group
+}
+
+func CreateTestTeam() *organizationapi.Team {
+	team := &organizationapi.Team{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      organizationapi.TeamResourceName(testGroup, testTeamName),
+			Namespace: testEnvironment,
+			Labels: map[string]string{
+				"cp.ei.telekom.de/environment": testEnvironment,
+			},
+		},
+		Spec: organizationapi.TeamSpec{
+			Name:     testTeamName,
+			Group:    testGroup,
+			Email:    "test-team@example.com",
+			Category: organizationapi.TeamCategory(testCategory),
+			Members: []organizationapi.Member{
+				{
+					Name:  "Test User",
+					Email: "test@example.com",
+				},
+			},
+		},
+	}
+	Expect(k8sClient.Create(ctx, team)).To(Succeed())
+	return team
+}
+
+func CreateTestApiCategory() *apiv1.ApiCategory {
+	apiCat := &apiv1.ApiCategory{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "other",
+			Namespace: testNamespace,
+			Labels: map[string]string{
+				"cp.ei.telekom.de/environment": testEnvironment,
+			},
+		},
+		Spec: apiv1.ApiCategorySpec{
+			LabelValue:  "other",
+			Active:      true,
+			Description: "Other category for testing",
+			AllowTeams: &apiv1.AllowTeamsConfig{
+				Categories: []string{string(organizationapi.TeamCategoryCustomer)},
+				Names:      []string{},
+			},
+			MustHaveGroupPrefix: false,
+		},
+	}
+	Expect(k8sClient.Create(ctx, apiCat)).To(Succeed())
+	return apiCat
 }

--- a/api/internal/controller/suite_test.go
+++ b/api/internal/controller/suite_test.go
@@ -44,7 +44,7 @@ const (
 	testEnvironment = "test"
 	testGroup       = "dev"
 	testTeamName    = "api"
-	testCategory    = "Customer"
+	testCategory    = organizationapi.TeamCategoryCustomer
 )
 
 var testNamespace string
@@ -225,7 +225,7 @@ func CreateTestTeam() *organizationapi.Team {
 			Name:     testTeamName,
 			Group:    testGroup,
 			Email:    "test-team@example.com",
-			Category: organizationapi.TeamCategory(testCategory),
+			Category: testCategory,
 			Members: []organizationapi.Member{
 				{
 					Name:  "Test User",

--- a/api/internal/handler/apiexposure/handler.go
+++ b/api/internal/handler/apiexposure/handler.go
@@ -266,18 +266,20 @@ func validateApiCategoryPolicy(ctx context.Context, api *apiapi.Api, application
 			log.FromContext(ctx).V(1).Info("Skipping ApiCategory policy validation because no ApiCategories exist")
 			return true
 		}
-		msg := util.BuildApiCategoryPolicyResolutionMessage(api.Spec.Category, err)
+
 		var be ctrlerrors.BlockedError
 		var re ctrlerrors.RetryableError
 
-		if errors.As(err, &be) {
+		msg := util.BuildApiCategoryPolicyResolutionMessage(api.Spec.Category, err)
+		switch {
+		case errors.As(err, &be):
 			log.FromContext(ctx).V(1).Info("ApiCategory policy validation blocked", "reason", err.Error())
 			apiExp.SetCondition(condition.NewNotReadyCondition(util.ApiCategoryPolicyResolutionFailedReason, msg))
 			apiExp.SetCondition(condition.NewBlockedCondition(msg))
-		} else if errors.As(err, &re) {
+		case errors.As(err, &re):
 			log.FromContext(ctx).V(1).Info("ApiCategory policy validation retryable", "reason", err.Error())
 			apiExp.SetCondition(condition.NewNotReadyCondition(util.ApiCategoryPolicyResolutionFailedReason, msg))
-		} else {
+		default:
 			log.FromContext(ctx).V(1).Info("ApiCategory policy validation failed", "reason", err.Error())
 			apiExp.SetCondition(condition.NewNotReadyCondition(util.ApiCategoryPolicyResolutionFailedReason, msg))
 			apiExp.SetCondition(condition.NewBlockedCondition(msg))

--- a/api/internal/handler/apiexposure/handler.go
+++ b/api/internal/handler/apiexposure/handler.go
@@ -6,6 +6,7 @@ package apiexposure
 
 import (
 	"context"
+	stderrors "errors"
 	"fmt"
 	"strings"
 
@@ -251,6 +252,8 @@ func validateApiCategoryPolicy(ctx context.Context, api *apiapi.Api, application
 	team, err := organizationapi.FindTeamForObject(ctx, application)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
+			// Defensive fallback: team-not-found should not happen in normal lifecycle,
+			// because team deletion removes the namespace and with it ApiExposures.
 			log.FromContext(ctx).V(1).Info("Skipping ApiCategory policy validation because team was not found")
 			return true
 		}
@@ -261,39 +264,37 @@ func validateApiCategoryPolicy(ctx context.Context, api *apiapi.Api, application
 	}
 
 	apiCategory, err := util.ResolveActiveApiCategoryForApi(ctx, api)
-	if err != nil {
-		if apierrors.IsNotFound(err) {
-			log.FromContext(ctx).V(1).Info("Skipping ApiCategory policy validation because no ApiCategories exist")
-			return true
-		}
-
-		var be ctrlerrors.BlockedError
-		var re ctrlerrors.RetryableError
-
-		msg := util.BuildApiCategoryPolicyResolutionMessage(api.Spec.Category, err)
-		switch {
-		case errors.As(err, &be):
-			log.FromContext(ctx).V(1).Info("ApiCategory policy validation blocked", "reason", err.Error())
-			apiExp.SetCondition(condition.NewNotReadyCondition(util.ApiCategoryPolicyResolutionFailedReason, msg))
+	if err == nil {
+		teamCategory := string(team.Spec.Category)
+		if !apiCategory.IsAllowedForTeamCategory(teamCategory) {
+			msg := util.BuildApiCategoryExposureDeniedMessage(teamCategory, apiCategory.Spec.LabelValue)
+			apiExp.SetCondition(condition.NewNotReadyCondition(util.ApiCategoryTeamCategoryNotAllowedReason, msg))
 			apiExp.SetCondition(condition.NewBlockedCondition(msg))
-		case errors.As(err, &re):
-			log.FromContext(ctx).V(1).Info("ApiCategory policy validation retryable", "reason", err.Error())
-			apiExp.SetCondition(condition.NewNotReadyCondition(util.ApiCategoryPolicyResolutionFailedReason, msg))
-		default:
-			log.FromContext(ctx).V(1).Info("ApiCategory policy validation failed", "reason", err.Error())
-			apiExp.SetCondition(condition.NewNotReadyCondition(util.ApiCategoryPolicyResolutionFailedReason, msg))
-			apiExp.SetCondition(condition.NewBlockedCondition(msg))
+			return false
 		}
-		return false
+		return true
 	}
 
-	teamCategory := string(team.Spec.Category)
-	if !apiCategory.IsAllowedForTeamCategory(teamCategory) {
-		msg := util.BuildApiCategoryExposureDeniedMessage(teamCategory, apiCategory.Spec.LabelValue)
-		apiExp.SetCondition(condition.NewNotReadyCondition(util.ApiCategoryTeamCategoryNotAllowedReason, msg))
+	if apierrors.IsNotFound(err) {
+		log.FromContext(ctx).V(1).Info("Skipping ApiCategory policy validation because no ApiCategories exist")
+		return true
+	}
+
+	msg := util.BuildApiCategoryPolicyResolutionMessage(api.Spec.Category, err)
+	blockedErr, isBlocked := stderrors.AsType[ctrlerrors.BlockedError](err)
+	retryableErr, isRetryable := stderrors.AsType[ctrlerrors.RetryableError](err)
+	switch {
+	case isBlocked:
+		log.FromContext(ctx).V(1).Info("ApiCategory policy validation blocked", "reason", blockedErr.Error())
+		apiExp.SetCondition(condition.NewNotReadyCondition(util.ApiCategoryPolicyResolutionFailedReason, msg))
 		apiExp.SetCondition(condition.NewBlockedCondition(msg))
-		return false
+	case isRetryable:
+		log.FromContext(ctx).V(1).Info("ApiCategory policy validation retryable", "reason", retryableErr.Error())
+		apiExp.SetCondition(condition.NewNotReadyCondition(util.ApiCategoryPolicyResolutionFailedReason, msg))
+	default:
+		log.FromContext(ctx).V(1).Info("ApiCategory policy validation failed", "reason", err.Error())
+		apiExp.SetCondition(condition.NewNotReadyCondition(util.ApiCategoryPolicyResolutionFailedReason, msg))
+		apiExp.SetCondition(condition.NewBlockedCondition(msg))
 	}
-
-	return true
+	return false
 }

--- a/api/internal/handler/apiexposure/handler.go
+++ b/api/internal/handler/apiexposure/handler.go
@@ -262,6 +262,10 @@ func validateApiCategoryPolicy(ctx context.Context, api *apiapi.Api, application
 
 	apiCategory, err := util.ResolveActiveApiCategoryForApi(ctx, api)
 	if err != nil {
+		if apierrors.IsNotFound(err) {
+			log.FromContext(ctx).V(1).Info("Skipping ApiCategory policy validation because no ApiCategories exist")
+			return true
+		}
 		msg := util.BuildApiCategoryPolicyResolutionMessage(api.Spec.Category, err)
 		var be ctrlerrors.BlockedError
 		var re ctrlerrors.RetryableError
@@ -279,10 +283,6 @@ func validateApiCategoryPolicy(ctx context.Context, api *apiapi.Api, application
 			apiExp.SetCondition(condition.NewBlockedCondition(msg))
 		}
 		return false
-	}
-	if apiCategory == nil {
-		log.FromContext(ctx).V(1).Info("Skipping ApiCategory policy validation because no ApiCategories exist")
-		return true
 	}
 
 	teamCategory := string(team.Spec.Category)

--- a/api/internal/handler/apiexposure/handler.go
+++ b/api/internal/handler/apiexposure/handler.go
@@ -18,6 +18,7 @@ import (
 	applicationapi "github.com/telekom/controlplane/application/api/v1"
 	cclient "github.com/telekom/controlplane/common/pkg/client"
 	"github.com/telekom/controlplane/common/pkg/condition"
+	"github.com/telekom/controlplane/common/pkg/errors/ctrlerrors"
 	"github.com/telekom/controlplane/common/pkg/handler"
 	"github.com/telekom/controlplane/common/pkg/types"
 	"github.com/telekom/controlplane/common/pkg/util/contextutil"
@@ -249,6 +250,10 @@ func validateExposureScopes(ctx context.Context, api *apiapi.Api, apiExp *apiapi
 func validateApiCategoryPolicy(ctx context.Context, api *apiapi.Api, application *applicationapi.Application, apiExp *apiapi.ApiExposure) bool {
 	team, err := organizationapi.FindTeamForObject(ctx, application)
 	if err != nil {
+		if apierrors.IsNotFound(err) {
+			log.FromContext(ctx).V(1).Info("Skipping ApiCategory policy validation because team was not found")
+			return true
+		}
 		msg := util.BuildApiCategoryPolicyResolutionMessage(api.Spec.Category, err)
 		apiExp.SetCondition(condition.NewNotReadyCondition(util.ApiCategoryPolicyResolutionFailedReason, msg))
 		apiExp.SetCondition(condition.NewBlockedCondition(msg))
@@ -258,8 +263,21 @@ func validateApiCategoryPolicy(ctx context.Context, api *apiapi.Api, application
 	apiCategory, err := util.ResolveActiveApiCategoryForApi(ctx, api)
 	if err != nil {
 		msg := util.BuildApiCategoryPolicyResolutionMessage(api.Spec.Category, err)
-		apiExp.SetCondition(condition.NewNotReadyCondition(util.ApiCategoryPolicyResolutionFailedReason, msg))
-		apiExp.SetCondition(condition.NewBlockedCondition(msg))
+		var be ctrlerrors.BlockedError
+		var re ctrlerrors.RetryableError
+
+		if errors.As(err, &be) {
+			log.FromContext(ctx).V(1).Info("ApiCategory policy validation blocked", "reason", err.Error())
+			apiExp.SetCondition(condition.NewNotReadyCondition(util.ApiCategoryPolicyResolutionFailedReason, msg))
+			apiExp.SetCondition(condition.NewBlockedCondition(msg))
+		} else if errors.As(err, &re) {
+			log.FromContext(ctx).V(1).Info("ApiCategory policy validation retryable", "reason", err.Error())
+			apiExp.SetCondition(condition.NewNotReadyCondition(util.ApiCategoryPolicyResolutionFailedReason, msg))
+		} else {
+			log.FromContext(ctx).V(1).Info("ApiCategory policy validation failed", "reason", err.Error())
+			apiExp.SetCondition(condition.NewNotReadyCondition(util.ApiCategoryPolicyResolutionFailedReason, msg))
+			apiExp.SetCondition(condition.NewBlockedCondition(msg))
+		}
 		return false
 	}
 	if apiCategory == nil {

--- a/api/internal/handler/apiexposure/handler.go
+++ b/api/internal/handler/apiexposure/handler.go
@@ -15,12 +15,14 @@ import (
 
 	apiapi "github.com/telekom/controlplane/api/api/v1"
 	"github.com/telekom/controlplane/api/internal/handler/util"
+	applicationapi "github.com/telekom/controlplane/application/api/v1"
 	cclient "github.com/telekom/controlplane/common/pkg/client"
 	"github.com/telekom/controlplane/common/pkg/condition"
 	"github.com/telekom/controlplane/common/pkg/handler"
 	"github.com/telekom/controlplane/common/pkg/types"
 	"github.com/telekom/controlplane/common/pkg/util/contextutil"
 	gatewayapi "github.com/telekom/controlplane/gateway/api/v1"
+	organizationapi "github.com/telekom/controlplane/organization/api/v1"
 )
 
 var _ handler.Handler[*apiapi.ApiExposure] = (*ApiExposureHandler)(nil)
@@ -60,9 +62,16 @@ func (h *ApiExposureHandler) CreateOrUpdate(ctx context.Context, apiExp *apiapi.
 
 	// Core Validations are done, can continue
 
+	apiExpApplication, err := util.GetApplicationFromLabel(ctx, apiExp)
+	if err != nil {
+		return err
+	}
+
+	if !validateApiCategoryPolicy(ctx, api, apiExpApplication, apiExp) {
+		return nil
+	}
+
 	// Scopes: check if scopes exist and are a valid subset of the Api's scopes.
-	// TODO: further validations (currently contained in the old code)
-	// - validate if team category allows exposure of api category
 	if !validateExposureScopes(ctx, api, apiExp) {
 		return nil
 	}
@@ -231,5 +240,33 @@ func validateExposureScopes(ctx context.Context, api *apiapi.Api, apiExp *apiapi
 		return false
 	}
 	log.FromContext(ctx).V(1).Info("✅ Scopes are valid and exist")
+	return true
+}
+
+func validateApiCategoryPolicy(ctx context.Context, api *apiapi.Api, application *applicationapi.Application, apiExp *apiapi.ApiExposure) bool {
+	team, err := organizationapi.FindTeamForObject(ctx, application)
+	if err != nil {
+		msg := util.BuildApiCategoryPolicyResolutionMessage(api.Spec.Category, err)
+		apiExp.SetCondition(condition.NewNotReadyCondition(util.ApiCategoryPolicyResolutionFailedReason, msg))
+		apiExp.SetCondition(condition.NewBlockedCondition(msg))
+		return false
+	}
+
+	apiCategory, err := util.ResolveActiveApiCategoryForApi(ctx, api)
+	if err != nil {
+		msg := util.BuildApiCategoryPolicyResolutionMessage(api.Spec.Category, err)
+		apiExp.SetCondition(condition.NewNotReadyCondition(util.ApiCategoryPolicyResolutionFailedReason, msg))
+		apiExp.SetCondition(condition.NewBlockedCondition(msg))
+		return false
+	}
+
+	teamCategory := string(team.Spec.Category)
+	if !apiCategory.IsAllowedForTeamCategory(teamCategory) {
+		msg := util.BuildApiCategoryExposureDeniedMessage(teamCategory, apiCategory.Spec.LabelValue)
+		apiExp.SetCondition(condition.NewNotReadyCondition(util.ApiCategoryTeamCategoryNotAllowedReason, msg))
+		apiExp.SetCondition(condition.NewBlockedCondition(msg))
+		return false
+	}
+
 	return true
 }

--- a/api/internal/handler/apiexposure/handler.go
+++ b/api/internal/handler/apiexposure/handler.go
@@ -64,7 +64,10 @@ func (h *ApiExposureHandler) CreateOrUpdate(ctx context.Context, apiExp *apiapi.
 
 	apiExpApplication, err := util.GetApplicationFromLabel(ctx, apiExp)
 	if err != nil {
-		return err
+		msg := fmt.Sprintf("Application for ApiExposure cannot be resolved: %v", err)
+		apiExp.SetCondition(condition.NewNotReadyCondition("ApplicationResolutionFailed", msg))
+		apiExp.SetCondition(condition.NewBlockedCondition(msg))
+		return nil
 	}
 
 	if !validateApiCategoryPolicy(ctx, api, apiExpApplication, apiExp) {

--- a/api/internal/handler/apiexposure/handler.go
+++ b/api/internal/handler/apiexposure/handler.go
@@ -259,6 +259,10 @@ func validateApiCategoryPolicy(ctx context.Context, api *apiapi.Api, application
 		apiExp.SetCondition(condition.NewBlockedCondition(msg))
 		return false
 	}
+	if apiCategory == nil {
+		log.FromContext(ctx).V(1).Info("Skipping ApiCategory policy validation because no ApiCategories exist")
+		return true
+	}
 
 	teamCategory := string(team.Spec.Category)
 	if !apiCategory.IsAllowedForTeamCategory(teamCategory) {

--- a/api/internal/handler/apiexposure/handler_test.go
+++ b/api/internal/handler/apiexposure/handler_test.go
@@ -172,7 +172,17 @@ func newClientContext(environment string, objects ...crclient.Object) context.Co
 	Expect(apiv1.AddToScheme(sch)).To(Succeed())
 	Expect(applicationapi.AddToScheme(sch)).To(Succeed())
 	Expect(organizationapi.AddToScheme(sch)).To(Succeed())
-	fakeClient := fake.NewClientBuilder().WithScheme(sch).WithObjects(objects...).Build()
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(sch).
+		WithObjects(objects...).
+		WithIndex(&apiv1.ApiCategory{}, "spec.labelValue", func(obj crclient.Object) []string {
+			apiCategory, ok := obj.(*apiv1.ApiCategory)
+			if !ok || apiCategory.Spec.LabelValue == "" {
+				return nil
+			}
+			return []string{apiCategory.Spec.LabelValue}
+		}).
+		Build()
 	janitorClient := cclient.NewJanitorClient(cclient.NewScopedClient(fakeClient, environment))
 	return cclient.WithClient(context.Background(), janitorClient)
 }

--- a/api/internal/handler/apiexposure/handler_test.go
+++ b/api/internal/handler/apiexposure/handler_test.go
@@ -1,0 +1,179 @@
+// Copyright 2025 Deutsche Telekom IT GmbH
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package apiexposure
+
+import (
+	"context"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	crclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	apiv1 "github.com/telekom/controlplane/api/api/v1"
+	"github.com/telekom/controlplane/api/internal/handler/util"
+	applicationapi "github.com/telekom/controlplane/application/api/v1"
+	cclient "github.com/telekom/controlplane/common/pkg/client"
+	"github.com/telekom/controlplane/common/pkg/condition"
+	"github.com/telekom/controlplane/common/pkg/config"
+	organizationapi "github.com/telekom/controlplane/organization/api/v1"
+)
+
+func TestValidateApiCategoryPolicy(t *testing.T) {
+	t.Parallel()
+
+	const (
+		environment = "test"
+		group       = "alpha"
+		teamName    = "core"
+	)
+
+	baseApp := &applicationapi.Application{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "provider-app",
+			Namespace: environment + "--" + group + "--" + teamName,
+		},
+	}
+	baseAPI := &apiv1.Api{
+		Spec: apiv1.ApiSpec{
+			Category: "partner",
+		},
+	}
+
+	tests := []struct {
+		name           string
+		teamCategory   organizationapi.TeamCategory
+		apiCategories  []apiv1.ApiCategory
+		expectedResult bool
+		expectedReason string
+	}{
+		{
+			name:         "allowed category",
+			teamCategory: organizationapi.TeamCategoryCustomer,
+			apiCategories: []apiv1.ApiCategory{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "partner", Namespace: environment, Labels: map[string]string{config.EnvironmentLabelKey: environment}},
+					Spec: apiv1.ApiCategorySpec{
+						LabelValue: "partner",
+						Active:     true,
+						AllowTeams: &apiv1.AllowTeamsConfig{Categories: []string{"Customer"}},
+					},
+				},
+			},
+			expectedResult: true,
+		},
+		{
+			name:         "denied category",
+			teamCategory: organizationapi.TeamCategoryInfrastructure,
+			apiCategories: []apiv1.ApiCategory{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "partner", Namespace: environment, Labels: map[string]string{config.EnvironmentLabelKey: environment}},
+					Spec: apiv1.ApiCategorySpec{
+						LabelValue: "partner",
+						Active:     true,
+						AllowTeams: &apiv1.AllowTeamsConfig{Categories: []string{"Customer"}},
+					},
+				},
+			},
+			expectedResult: false,
+			expectedReason: util.ApiCategoryTeamCategoryNotAllowedReason,
+		},
+		{
+			name:           "unresolved category",
+			teamCategory:   organizationapi.TeamCategoryCustomer,
+			apiCategories:  nil,
+			expectedResult: false,
+			expectedReason: util.ApiCategoryPolicyResolutionFailedReason,
+		},
+		{
+			name:         "inactive category",
+			teamCategory: organizationapi.TeamCategoryCustomer,
+			apiCategories: []apiv1.ApiCategory{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "partner", Namespace: environment, Labels: map[string]string{config.EnvironmentLabelKey: environment}},
+					Spec: apiv1.ApiCategorySpec{
+						LabelValue: "partner",
+						Active:     false,
+					},
+				},
+			},
+			expectedResult: false,
+			expectedReason: util.ApiCategoryPolicyResolutionFailedReason,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			team := &organizationapi.Team{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      group + "--" + teamName,
+					Namespace: environment,
+					Labels: map[string]string{
+						config.EnvironmentLabelKey: environment,
+					},
+				},
+				Spec: organizationapi.TeamSpec{
+					Group:    group,
+					Name:     teamName,
+					Email:    "team@example.com",
+					Category: tt.teamCategory,
+				},
+			}
+
+			objects := []crclient.Object{team}
+			for i := range tt.apiCategories {
+				cat := tt.apiCategories[i]
+				objects = append(objects, &cat)
+			}
+
+			ctx := newClientContext(t, environment, objects...)
+			apiExp := &apiv1.ApiExposure{}
+
+			result := validateApiCategoryPolicy(ctx, baseAPI, baseApp, apiExp)
+			if result != tt.expectedResult {
+				t.Fatalf("expected result %v, got %v", tt.expectedResult, result)
+			}
+
+			if tt.expectedReason == "" {
+				notReady := meta.FindStatusCondition(apiExp.GetConditions(), condition.ConditionTypeReady)
+				if notReady != nil && notReady.Status == metav1.ConditionFalse {
+					t.Fatalf("expected no not-ready condition for allowed path, got: %#v", notReady)
+				}
+				return
+			}
+
+			notReady := meta.FindStatusCondition(apiExp.GetConditions(), condition.ConditionTypeReady)
+			if notReady == nil {
+				t.Fatalf("expected not-ready condition to be set")
+			}
+			if notReady.Reason != tt.expectedReason {
+				t.Fatalf("expected reason %q, got %q", tt.expectedReason, notReady.Reason)
+			}
+		})
+	}
+}
+
+func newClientContext(t *testing.T, environment string, objects ...crclient.Object) context.Context {
+	t.Helper()
+
+	sch := runtime.NewScheme()
+	if err := apiv1.AddToScheme(sch); err != nil {
+		t.Fatalf("failed to register api scheme: %v", err)
+	}
+	if err := applicationapi.AddToScheme(sch); err != nil {
+		t.Fatalf("failed to register application scheme: %v", err)
+	}
+	if err := organizationapi.AddToScheme(sch); err != nil {
+		t.Fatalf("failed to register organization scheme: %v", err)
+	}
+	fakeClient := fake.NewClientBuilder().WithScheme(sch).WithObjects(objects...).Build()
+	janitorClient := cclient.NewJanitorClient(cclient.NewScopedClient(fakeClient, environment))
+	return cclient.WithClient(context.Background(), janitorClient)
+}

--- a/api/internal/handler/apiexposure/handler_test.go
+++ b/api/internal/handler/apiexposure/handler_test.go
@@ -86,9 +86,23 @@ var _ = Describe("ApiExposure Handler", func() {
 				expectedReason: util.ApiCategoryTeamCategoryNotAllowedReason,
 			},
 			{
-				name:           "unresolved category",
+				name:           "no categories configured",
 				teamCategory:   organizationapi.TeamCategoryCustomer,
 				apiCategories:  nil,
+				expectedResult: true,
+			},
+			{
+				name:         "missing category",
+				teamCategory: organizationapi.TeamCategoryCustomer,
+				apiCategories: []apiv1.ApiCategory{
+					{
+						ObjectMeta: metav1.ObjectMeta{Name: "other", Namespace: environment, Labels: map[string]string{config.EnvironmentLabelKey: environment}},
+						Spec: apiv1.ApiCategorySpec{
+							LabelValue: "other",
+							Active:     true,
+						},
+					},
+				},
 				expectedResult: false,
 				expectedReason: util.ApiCategoryPolicyResolutionFailedReason,
 			},

--- a/api/internal/handler/apiexposure/handler_test.go
+++ b/api/internal/handler/apiexposure/handler_test.go
@@ -6,8 +6,9 @@ package apiexposure
 
 import (
 	"context"
-	"testing"
 
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -23,156 +24,140 @@ import (
 	organizationapi "github.com/telekom/controlplane/organization/api/v1"
 )
 
-func TestValidateApiCategoryPolicy(t *testing.T) {
-	t.Parallel()
+var _ = Describe("ApiExposure Handler", func() {
+	Context("validateApiCategoryPolicy", func() {
+		const (
+			environment = "test"
+			group       = "alpha"
+			teamName    = "core"
+		)
 
-	const (
-		environment = "test"
-		group       = "alpha"
-		teamName    = "core"
-	)
-
-	baseApp := &applicationapi.Application{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "provider-app",
-			Namespace: environment + "--" + group + "--" + teamName,
-		},
-	}
-	baseAPI := &apiv1.Api{
-		Spec: apiv1.ApiSpec{
-			Category: "partner",
-		},
-	}
-
-	tests := []struct {
-		name           string
-		teamCategory   organizationapi.TeamCategory
-		apiCategories  []apiv1.ApiCategory
-		expectedResult bool
-		expectedReason string
-	}{
-		{
-			name:         "allowed category",
-			teamCategory: organizationapi.TeamCategoryCustomer,
-			apiCategories: []apiv1.ApiCategory{
-				{
-					ObjectMeta: metav1.ObjectMeta{Name: "partner", Namespace: environment, Labels: map[string]string{config.EnvironmentLabelKey: environment}},
-					Spec: apiv1.ApiCategorySpec{
-						LabelValue: "partner",
-						Active:     true,
-						AllowTeams: &apiv1.AllowTeamsConfig{Categories: []string{"Customer"}},
-					},
-				},
+		baseApp := &applicationapi.Application{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "provider-app",
+				Namespace: environment + "--" + group + "--" + teamName,
 			},
-			expectedResult: true,
-		},
-		{
-			name:         "denied category",
-			teamCategory: organizationapi.TeamCategoryInfrastructure,
-			apiCategories: []apiv1.ApiCategory{
-				{
-					ObjectMeta: metav1.ObjectMeta{Name: "partner", Namespace: environment, Labels: map[string]string{config.EnvironmentLabelKey: environment}},
-					Spec: apiv1.ApiCategorySpec{
-						LabelValue: "partner",
-						Active:     true,
-						AllowTeams: &apiv1.AllowTeamsConfig{Categories: []string{"Customer"}},
-					},
-				},
+		}
+		baseAPI := &apiv1.Api{
+			Spec: apiv1.ApiSpec{
+				Category: "partner",
 			},
-			expectedResult: false,
-			expectedReason: util.ApiCategoryTeamCategoryNotAllowedReason,
-		},
-		{
-			name:           "unresolved category",
-			teamCategory:   organizationapi.TeamCategoryCustomer,
-			apiCategories:  nil,
-			expectedResult: false,
-			expectedReason: util.ApiCategoryPolicyResolutionFailedReason,
-		},
-		{
-			name:         "inactive category",
-			teamCategory: organizationapi.TeamCategoryCustomer,
-			apiCategories: []apiv1.ApiCategory{
-				{
-					ObjectMeta: metav1.ObjectMeta{Name: "partner", Namespace: environment, Labels: map[string]string{config.EnvironmentLabelKey: environment}},
-					Spec: apiv1.ApiCategorySpec{
-						LabelValue: "partner",
-						Active:     false,
+		}
+
+		type testCase struct {
+			name           string
+			teamCategory   organizationapi.TeamCategory
+			apiCategories  []apiv1.ApiCategory
+			expectedResult bool
+			expectedReason string
+		}
+
+		tests := []testCase{
+			{
+				name:         "allowed category",
+				teamCategory: organizationapi.TeamCategoryCustomer,
+				apiCategories: []apiv1.ApiCategory{
+					{
+						ObjectMeta: metav1.ObjectMeta{Name: "partner", Namespace: environment, Labels: map[string]string{config.EnvironmentLabelKey: environment}},
+						Spec: apiv1.ApiCategorySpec{
+							LabelValue: "partner",
+							Active:     true,
+							AllowTeams: &apiv1.AllowTeamsConfig{Categories: []string{"Customer"}},
+						},
 					},
 				},
+				expectedResult: true,
 			},
-			expectedResult: false,
-			expectedReason: util.ApiCategoryPolicyResolutionFailedReason,
-		},
-	}
-
-	for _, tt := range tests {
-		tt := tt
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
-			team := &organizationapi.Team{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      group + "--" + teamName,
-					Namespace: environment,
-					Labels: map[string]string{
-						config.EnvironmentLabelKey: environment,
+			{
+				name:         "denied category",
+				teamCategory: organizationapi.TeamCategoryInfrastructure,
+				apiCategories: []apiv1.ApiCategory{
+					{
+						ObjectMeta: metav1.ObjectMeta{Name: "partner", Namespace: environment, Labels: map[string]string{config.EnvironmentLabelKey: environment}},
+						Spec: apiv1.ApiCategorySpec{
+							LabelValue: "partner",
+							Active:     true,
+							AllowTeams: &apiv1.AllowTeamsConfig{Categories: []string{"Customer"}},
+						},
 					},
 				},
-				Spec: organizationapi.TeamSpec{
-					Group:    group,
-					Name:     teamName,
-					Email:    "team@example.com",
-					Category: tt.teamCategory,
+				expectedResult: false,
+				expectedReason: util.ApiCategoryTeamCategoryNotAllowedReason,
+			},
+			{
+				name:           "unresolved category",
+				teamCategory:   organizationapi.TeamCategoryCustomer,
+				apiCategories:  nil,
+				expectedResult: false,
+				expectedReason: util.ApiCategoryPolicyResolutionFailedReason,
+			},
+			{
+				name:         "inactive category",
+				teamCategory: organizationapi.TeamCategoryCustomer,
+				apiCategories: []apiv1.ApiCategory{
+					{
+						ObjectMeta: metav1.ObjectMeta{Name: "partner", Namespace: environment, Labels: map[string]string{config.EnvironmentLabelKey: environment}},
+						Spec: apiv1.ApiCategorySpec{
+							LabelValue: "partner",
+							Active:     false,
+						},
+					},
 				},
-			}
+				expectedResult: false,
+				expectedReason: util.ApiCategoryPolicyResolutionFailedReason,
+			},
+		}
 
-			objects := []crclient.Object{team}
-			for i := range tt.apiCategories {
-				cat := tt.apiCategories[i]
-				objects = append(objects, &cat)
-			}
-
-			ctx := newClientContext(t, environment, objects...)
-			apiExp := &apiv1.ApiExposure{}
-
-			result := validateApiCategoryPolicy(ctx, baseAPI, baseApp, apiExp)
-			if result != tt.expectedResult {
-				t.Fatalf("expected result %v, got %v", tt.expectedResult, result)
-			}
-
-			if tt.expectedReason == "" {
-				notReady := meta.FindStatusCondition(apiExp.GetConditions(), condition.ConditionTypeReady)
-				if notReady != nil && notReady.Status == metav1.ConditionFalse {
-					t.Fatalf("expected no not-ready condition for allowed path, got: %#v", notReady)
+		for _, tt := range tests {
+			tt := tt
+			It(tt.name, func() {
+				team := &organizationapi.Team{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      group + "--" + teamName,
+						Namespace: environment,
+						Labels: map[string]string{
+							config.EnvironmentLabelKey: environment,
+						},
+					},
+					Spec: organizationapi.TeamSpec{
+						Group:    group,
+						Name:     teamName,
+						Email:    "team@example.com",
+						Category: tt.teamCategory,
+					},
 				}
-				return
-			}
 
-			notReady := meta.FindStatusCondition(apiExp.GetConditions(), condition.ConditionTypeReady)
-			if notReady == nil {
-				t.Fatalf("expected not-ready condition to be set")
-			}
-			if notReady.Reason != tt.expectedReason {
-				t.Fatalf("expected reason %q, got %q", tt.expectedReason, notReady.Reason)
-			}
-		})
-	}
-}
+				objects := []crclient.Object{team}
+				for i := range tt.apiCategories {
+					cat := tt.apiCategories[i]
+					objects = append(objects, &cat)
+				}
 
-func newClientContext(t *testing.T, environment string, objects ...crclient.Object) context.Context {
-	t.Helper()
+				ctx := newClientContext(environment, objects...)
+				apiExp := &apiv1.ApiExposure{}
 
+				result := validateApiCategoryPolicy(ctx, baseAPI, baseApp, apiExp)
+				Expect(result).To(Equal(tt.expectedResult))
+
+				if tt.expectedReason == "" {
+					notReady := meta.FindStatusCondition(apiExp.GetConditions(), condition.ConditionTypeReady)
+					Expect(notReady == nil || notReady.Status != metav1.ConditionFalse).To(BeTrue())
+					return
+				}
+
+				notReady := meta.FindStatusCondition(apiExp.GetConditions(), condition.ConditionTypeReady)
+				Expect(notReady).NotTo(BeNil())
+				Expect(notReady.Reason).To(Equal(tt.expectedReason))
+			})
+		}
+	})
+})
+
+func newClientContext(environment string, objects ...crclient.Object) context.Context {
 	sch := runtime.NewScheme()
-	if err := apiv1.AddToScheme(sch); err != nil {
-		t.Fatalf("failed to register api scheme: %v", err)
-	}
-	if err := applicationapi.AddToScheme(sch); err != nil {
-		t.Fatalf("failed to register application scheme: %v", err)
-	}
-	if err := organizationapi.AddToScheme(sch); err != nil {
-		t.Fatalf("failed to register organization scheme: %v", err)
-	}
+	Expect(apiv1.AddToScheme(sch)).To(Succeed())
+	Expect(applicationapi.AddToScheme(sch)).To(Succeed())
+	Expect(organizationapi.AddToScheme(sch)).To(Succeed())
 	fakeClient := fake.NewClientBuilder().WithScheme(sch).WithObjects(objects...).Build()
 	janitorClient := cclient.NewJanitorClient(cclient.NewScopedClient(fakeClient, environment))
 	return cclient.WithClient(context.Background(), janitorClient)

--- a/api/internal/handler/apiexposure/handler_test.go
+++ b/api/internal/handler/apiexposure/handler_test.go
@@ -7,8 +7,6 @@ package apiexposure
 import (
 	"context"
 
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -22,6 +20,9 @@ import (
 	"github.com/telekom/controlplane/common/pkg/condition"
 	"github.com/telekom/controlplane/common/pkg/config"
 	organizationapi "github.com/telekom/controlplane/organization/api/v1"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("ApiExposure Handler", func() {
@@ -109,7 +110,6 @@ var _ = Describe("ApiExposure Handler", func() {
 		}
 
 		for _, tt := range tests {
-			tt := tt
 			It(tt.name, func() {
 				team := &organizationapi.Team{
 					ObjectMeta: metav1.ObjectMeta{

--- a/api/internal/handler/apiexposure/suite_test.go
+++ b/api/internal/handler/apiexposure/suite_test.go
@@ -1,0 +1,17 @@
+// Copyright 2025 Deutsche Telekom IT GmbH
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package apiexposure
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestApiExposureHandler(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "ApiExposure Handler Suite")
+}

--- a/api/internal/handler/apisubscription/handler.go
+++ b/api/internal/handler/apisubscription/handler.go
@@ -387,6 +387,10 @@ func validateApiCategoryPolicy(ctx context.Context, api *apiapi.Api, application
 		apiSub.SetCondition(condition.NewBlockedCondition(msg))
 		return false
 	}
+	if apiCategory == nil {
+		log.FromContext(ctx).V(1).Info("Skipping ApiCategory policy validation because no ApiCategories exist")
+		return true
+	}
 
 	teamCategory := string(team.Spec.Category)
 	if !apiCategory.IsAllowedForTeamCategory(teamCategory) {

--- a/api/internal/handler/apisubscription/handler.go
+++ b/api/internal/handler/apisubscription/handler.go
@@ -6,6 +6,7 @@ package apisubscription
 
 import (
 	"context"
+	stderrors "errors"
 	"fmt"
 	"strings"
 
@@ -376,6 +377,8 @@ func validateApiCategoryPolicy(ctx context.Context, api *apiapi.Api, application
 	team, err := organizationapi.FindTeamForObject(ctx, application)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
+			// Defensive fallback: team-not-found should not happen in normal lifecycle,
+			// because team deletion removes the namespace and with it ApiSubscriptions.
 			log.FromContext(ctx).V(1).Info("Skipping ApiCategory policy validation because team was not found")
 			return true
 		}
@@ -386,39 +389,37 @@ func validateApiCategoryPolicy(ctx context.Context, api *apiapi.Api, application
 	}
 
 	apiCategory, err := util.ResolveActiveApiCategoryForApi(ctx, api)
-	if err != nil {
-		if apierrors.IsNotFound(err) {
-			log.FromContext(ctx).V(1).Info("Skipping ApiCategory policy validation because no ApiCategories exist")
-			return true
-		}
-
-		var be ctrlerrors.BlockedError
-		var re ctrlerrors.RetryableError
-
-		msg := util.BuildApiCategoryPolicyResolutionMessage(api.Spec.Category, err)
-		switch {
-		case errors.As(err, &be):
-			log.FromContext(ctx).V(1).Info("ApiCategory policy validation blocked", "reason", err.Error())
-			apiSub.SetCondition(condition.NewNotReadyCondition(util.ApiCategoryPolicyResolutionFailedReason, msg))
+	if err == nil {
+		teamCategory := string(team.Spec.Category)
+		if !apiCategory.IsAllowedForTeamCategory(teamCategory) {
+			msg := util.BuildApiCategorySubscriptionDeniedMessage(teamCategory, apiCategory.Spec.LabelValue)
+			apiSub.SetCondition(condition.NewNotReadyCondition(util.ApiCategoryTeamCategoryNotAllowedReason, msg))
 			apiSub.SetCondition(condition.NewBlockedCondition(msg))
-		case errors.As(err, &re):
-			log.FromContext(ctx).V(1).Info("ApiCategory policy validation retryable", "reason", err.Error())
-			apiSub.SetCondition(condition.NewNotReadyCondition(util.ApiCategoryPolicyResolutionFailedReason, msg))
-		default:
-			log.FromContext(ctx).V(1).Info("ApiCategory policy validation failed", "reason", err.Error())
-			apiSub.SetCondition(condition.NewNotReadyCondition(util.ApiCategoryPolicyResolutionFailedReason, msg))
-			apiSub.SetCondition(condition.NewBlockedCondition(msg))
+			return false
 		}
-		return false
+		return true
 	}
 
-	teamCategory := string(team.Spec.Category)
-	if !apiCategory.IsAllowedForTeamCategory(teamCategory) {
-		msg := util.BuildApiCategorySubscriptionDeniedMessage(teamCategory, apiCategory.Spec.LabelValue)
-		apiSub.SetCondition(condition.NewNotReadyCondition(util.ApiCategoryTeamCategoryNotAllowedReason, msg))
+	if apierrors.IsNotFound(err) {
+		log.FromContext(ctx).V(1).Info("Skipping ApiCategory policy validation because no ApiCategories exist")
+		return true
+	}
+
+	msg := util.BuildApiCategoryPolicyResolutionMessage(api.Spec.Category, err)
+	blockedErr, isBlocked := stderrors.AsType[ctrlerrors.BlockedError](err)
+	retryableErr, isRetryable := stderrors.AsType[ctrlerrors.RetryableError](err)
+	switch {
+	case isBlocked:
+		log.FromContext(ctx).V(1).Info("ApiCategory policy validation blocked", "reason", blockedErr.Error())
+		apiSub.SetCondition(condition.NewNotReadyCondition(util.ApiCategoryPolicyResolutionFailedReason, msg))
 		apiSub.SetCondition(condition.NewBlockedCondition(msg))
-		return false
+	case isRetryable:
+		log.FromContext(ctx).V(1).Info("ApiCategory policy validation retryable", "reason", retryableErr.Error())
+		apiSub.SetCondition(condition.NewNotReadyCondition(util.ApiCategoryPolicyResolutionFailedReason, msg))
+	default:
+		log.FromContext(ctx).V(1).Info("ApiCategory policy validation failed", "reason", err.Error())
+		apiSub.SetCondition(condition.NewNotReadyCondition(util.ApiCategoryPolicyResolutionFailedReason, msg))
+		apiSub.SetCondition(condition.NewBlockedCondition(msg))
 	}
-
-	return true
+	return false
 }

--- a/api/internal/handler/apisubscription/handler.go
+++ b/api/internal/handler/apisubscription/handler.go
@@ -15,6 +15,7 @@ import (
 	apiapi "github.com/telekom/controlplane/api/api/v1"
 	"github.com/telekom/controlplane/api/internal/handler/apisubscription/remote"
 	"github.com/telekom/controlplane/api/internal/handler/util"
+	applicationapi "github.com/telekom/controlplane/application/api/v1"
 	approvalapi "github.com/telekom/controlplane/approval/api/v1"
 	"github.com/telekom/controlplane/approval/api/v1/builder"
 	cclient "github.com/telekom/controlplane/common/pkg/client"
@@ -24,6 +25,7 @@ import (
 	"github.com/telekom/controlplane/common/pkg/types"
 	"github.com/telekom/controlplane/common/pkg/util/contextutil"
 	gatewayapi "github.com/telekom/controlplane/gateway/api/v1"
+	organizationapi "github.com/telekom/controlplane/organization/api/v1"
 )
 
 var _ handler.Handler[*apiapi.ApiSubscription] = (*ApiSubscriptionHandler)(nil)
@@ -97,8 +99,9 @@ func (h *ApiSubscriptionHandler) CreateOrUpdate(ctx context.Context, apiSub *api
 		return err
 	}
 
-	// TODO: further validations (currently contained in the old code)
-	// - validate if team category allows subscription of api category
+	if !validateApiCategoryPolicy(ctx, api, apiSubApplication, apiSub) {
+		return nil
+	}
 
 	// 5. Manage Approval process
 
@@ -366,4 +369,32 @@ func resolveRouteRef(ctx context.Context, scopedClient cclient.JanitorClient, ap
 		apiSub.SetCondition(condition.NewBlockedCondition("Waiting for ApiExposure to create the proxy route for this zone"))
 		return nil, nil
 	}
+}
+
+func validateApiCategoryPolicy(ctx context.Context, api *apiapi.Api, application *applicationapi.Application, apiSub *apiapi.ApiSubscription) bool {
+	team, err := organizationapi.FindTeamForObject(ctx, application)
+	if err != nil {
+		msg := util.BuildApiCategoryPolicyResolutionMessage(api.Spec.Category, err)
+		apiSub.SetCondition(condition.NewNotReadyCondition(util.ApiCategoryPolicyResolutionFailedReason, msg))
+		apiSub.SetCondition(condition.NewBlockedCondition(msg))
+		return false
+	}
+
+	apiCategory, err := util.ResolveActiveApiCategoryForApi(ctx, api)
+	if err != nil {
+		msg := util.BuildApiCategoryPolicyResolutionMessage(api.Spec.Category, err)
+		apiSub.SetCondition(condition.NewNotReadyCondition(util.ApiCategoryPolicyResolutionFailedReason, msg))
+		apiSub.SetCondition(condition.NewBlockedCondition(msg))
+		return false
+	}
+
+	teamCategory := string(team.Spec.Category)
+	if !apiCategory.IsAllowedForTeamCategory(teamCategory) {
+		msg := util.BuildApiCategorySubscriptionDeniedMessage(teamCategory, apiCategory.Spec.LabelValue)
+		apiSub.SetCondition(condition.NewNotReadyCondition(util.ApiCategoryTeamCategoryNotAllowedReason, msg))
+		apiSub.SetCondition(condition.NewBlockedCondition(msg))
+		return false
+	}
+
+	return true
 }

--- a/api/internal/handler/apisubscription/handler.go
+++ b/api/internal/handler/apisubscription/handler.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	apiapi "github.com/telekom/controlplane/api/api/v1"
@@ -374,6 +375,10 @@ func resolveRouteRef(ctx context.Context, scopedClient cclient.JanitorClient, ap
 func validateApiCategoryPolicy(ctx context.Context, api *apiapi.Api, application *applicationapi.Application, apiSub *apiapi.ApiSubscription) bool {
 	team, err := organizationapi.FindTeamForObject(ctx, application)
 	if err != nil {
+		if apierrors.IsNotFound(err) {
+			log.FromContext(ctx).V(1).Info("Skipping ApiCategory policy validation because team was not found")
+			return true
+		}
 		msg := util.BuildApiCategoryPolicyResolutionMessage(api.Spec.Category, err)
 		apiSub.SetCondition(condition.NewNotReadyCondition(util.ApiCategoryPolicyResolutionFailedReason, msg))
 		apiSub.SetCondition(condition.NewBlockedCondition(msg))
@@ -383,8 +388,21 @@ func validateApiCategoryPolicy(ctx context.Context, api *apiapi.Api, application
 	apiCategory, err := util.ResolveActiveApiCategoryForApi(ctx, api)
 	if err != nil {
 		msg := util.BuildApiCategoryPolicyResolutionMessage(api.Spec.Category, err)
-		apiSub.SetCondition(condition.NewNotReadyCondition(util.ApiCategoryPolicyResolutionFailedReason, msg))
-		apiSub.SetCondition(condition.NewBlockedCondition(msg))
+		var be ctrlerrors.BlockedError
+		var re ctrlerrors.RetryableError
+
+		if errors.As(err, &be) {
+			log.FromContext(ctx).V(1).Info("ApiCategory policy validation blocked", "reason", err.Error())
+			apiSub.SetCondition(condition.NewNotReadyCondition(util.ApiCategoryPolicyResolutionFailedReason, msg))
+			apiSub.SetCondition(condition.NewBlockedCondition(msg))
+		} else if errors.As(err, &re) {
+			log.FromContext(ctx).V(1).Info("ApiCategory policy validation retryable", "reason", err.Error())
+			apiSub.SetCondition(condition.NewNotReadyCondition(util.ApiCategoryPolicyResolutionFailedReason, msg))
+		} else {
+			log.FromContext(ctx).V(1).Info("ApiCategory policy validation failed", "reason", err.Error())
+			apiSub.SetCondition(condition.NewNotReadyCondition(util.ApiCategoryPolicyResolutionFailedReason, msg))
+			apiSub.SetCondition(condition.NewBlockedCondition(msg))
+		}
 		return false
 	}
 	if apiCategory == nil {

--- a/api/internal/handler/apisubscription/handler.go
+++ b/api/internal/handler/apisubscription/handler.go
@@ -391,18 +391,20 @@ func validateApiCategoryPolicy(ctx context.Context, api *apiapi.Api, application
 			log.FromContext(ctx).V(1).Info("Skipping ApiCategory policy validation because no ApiCategories exist")
 			return true
 		}
-		msg := util.BuildApiCategoryPolicyResolutionMessage(api.Spec.Category, err)
+
 		var be ctrlerrors.BlockedError
 		var re ctrlerrors.RetryableError
 
-		if errors.As(err, &be) {
+		msg := util.BuildApiCategoryPolicyResolutionMessage(api.Spec.Category, err)
+		switch {
+		case errors.As(err, &be):
 			log.FromContext(ctx).V(1).Info("ApiCategory policy validation blocked", "reason", err.Error())
 			apiSub.SetCondition(condition.NewNotReadyCondition(util.ApiCategoryPolicyResolutionFailedReason, msg))
 			apiSub.SetCondition(condition.NewBlockedCondition(msg))
-		} else if errors.As(err, &re) {
+		case errors.As(err, &re):
 			log.FromContext(ctx).V(1).Info("ApiCategory policy validation retryable", "reason", err.Error())
 			apiSub.SetCondition(condition.NewNotReadyCondition(util.ApiCategoryPolicyResolutionFailedReason, msg))
-		} else {
+		default:
 			log.FromContext(ctx).V(1).Info("ApiCategory policy validation failed", "reason", err.Error())
 			apiSub.SetCondition(condition.NewNotReadyCondition(util.ApiCategoryPolicyResolutionFailedReason, msg))
 			apiSub.SetCondition(condition.NewBlockedCondition(msg))

--- a/api/internal/handler/apisubscription/handler.go
+++ b/api/internal/handler/apisubscription/handler.go
@@ -387,6 +387,10 @@ func validateApiCategoryPolicy(ctx context.Context, api *apiapi.Api, application
 
 	apiCategory, err := util.ResolveActiveApiCategoryForApi(ctx, api)
 	if err != nil {
+		if apierrors.IsNotFound(err) {
+			log.FromContext(ctx).V(1).Info("Skipping ApiCategory policy validation because no ApiCategories exist")
+			return true
+		}
 		msg := util.BuildApiCategoryPolicyResolutionMessage(api.Spec.Category, err)
 		var be ctrlerrors.BlockedError
 		var re ctrlerrors.RetryableError
@@ -404,10 +408,6 @@ func validateApiCategoryPolicy(ctx context.Context, api *apiapi.Api, application
 			apiSub.SetCondition(condition.NewBlockedCondition(msg))
 		}
 		return false
-	}
-	if apiCategory == nil {
-		log.FromContext(ctx).V(1).Info("Skipping ApiCategory policy validation because no ApiCategories exist")
-		return true
 	}
 
 	teamCategory := string(team.Spec.Category)

--- a/api/internal/handler/apisubscription/handler_test.go
+++ b/api/internal/handler/apisubscription/handler_test.go
@@ -1,0 +1,179 @@
+// Copyright 2025 Deutsche Telekom IT GmbH
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package apisubscription
+
+import (
+	"context"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	crclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	apiv1 "github.com/telekom/controlplane/api/api/v1"
+	"github.com/telekom/controlplane/api/internal/handler/util"
+	applicationapi "github.com/telekom/controlplane/application/api/v1"
+	cclient "github.com/telekom/controlplane/common/pkg/client"
+	"github.com/telekom/controlplane/common/pkg/condition"
+	"github.com/telekom/controlplane/common/pkg/config"
+	organizationapi "github.com/telekom/controlplane/organization/api/v1"
+)
+
+func TestValidateApiCategoryPolicy(t *testing.T) {
+	t.Parallel()
+
+	const (
+		environment = "test"
+		group       = "alpha"
+		teamName    = "core"
+	)
+
+	baseApp := &applicationapi.Application{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "consumer-app",
+			Namespace: environment + "--" + group + "--" + teamName,
+		},
+	}
+	baseAPI := &apiv1.Api{
+		Spec: apiv1.ApiSpec{
+			Category: "partner",
+		},
+	}
+
+	tests := []struct {
+		name           string
+		teamCategory   organizationapi.TeamCategory
+		apiCategories  []apiv1.ApiCategory
+		expectedResult bool
+		expectedReason string
+	}{
+		{
+			name:         "allowed category",
+			teamCategory: organizationapi.TeamCategoryCustomer,
+			apiCategories: []apiv1.ApiCategory{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "partner", Namespace: environment, Labels: map[string]string{config.EnvironmentLabelKey: environment}},
+					Spec: apiv1.ApiCategorySpec{
+						LabelValue: "partner",
+						Active:     true,
+						AllowTeams: &apiv1.AllowTeamsConfig{Categories: []string{"Customer"}},
+					},
+				},
+			},
+			expectedResult: true,
+		},
+		{
+			name:         "denied category",
+			teamCategory: organizationapi.TeamCategoryInfrastructure,
+			apiCategories: []apiv1.ApiCategory{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "partner", Namespace: environment, Labels: map[string]string{config.EnvironmentLabelKey: environment}},
+					Spec: apiv1.ApiCategorySpec{
+						LabelValue: "partner",
+						Active:     true,
+						AllowTeams: &apiv1.AllowTeamsConfig{Categories: []string{"Customer"}},
+					},
+				},
+			},
+			expectedResult: false,
+			expectedReason: util.ApiCategoryTeamCategoryNotAllowedReason,
+		},
+		{
+			name:           "unresolved category",
+			teamCategory:   organizationapi.TeamCategoryCustomer,
+			apiCategories:  nil,
+			expectedResult: false,
+			expectedReason: util.ApiCategoryPolicyResolutionFailedReason,
+		},
+		{
+			name:         "inactive category",
+			teamCategory: organizationapi.TeamCategoryCustomer,
+			apiCategories: []apiv1.ApiCategory{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "partner", Namespace: environment, Labels: map[string]string{config.EnvironmentLabelKey: environment}},
+					Spec: apiv1.ApiCategorySpec{
+						LabelValue: "partner",
+						Active:     false,
+					},
+				},
+			},
+			expectedResult: false,
+			expectedReason: util.ApiCategoryPolicyResolutionFailedReason,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			team := &organizationapi.Team{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      group + "--" + teamName,
+					Namespace: environment,
+					Labels: map[string]string{
+						config.EnvironmentLabelKey: environment,
+					},
+				},
+				Spec: organizationapi.TeamSpec{
+					Group:    group,
+					Name:     teamName,
+					Email:    "team@example.com",
+					Category: tt.teamCategory,
+				},
+			}
+
+			objects := []crclient.Object{team}
+			for i := range tt.apiCategories {
+				cat := tt.apiCategories[i]
+				objects = append(objects, &cat)
+			}
+
+			ctx := newClientContext(t, environment, objects...)
+			apiSub := &apiv1.ApiSubscription{}
+
+			result := validateApiCategoryPolicy(ctx, baseAPI, baseApp, apiSub)
+			if result != tt.expectedResult {
+				t.Fatalf("expected result %v, got %v", tt.expectedResult, result)
+			}
+
+			if tt.expectedReason == "" {
+				notReady := meta.FindStatusCondition(apiSub.GetConditions(), condition.ConditionTypeReady)
+				if notReady != nil && notReady.Status == metav1.ConditionFalse {
+					t.Fatalf("expected no not-ready condition for allowed path, got: %#v", notReady)
+				}
+				return
+			}
+
+			notReady := meta.FindStatusCondition(apiSub.GetConditions(), condition.ConditionTypeReady)
+			if notReady == nil {
+				t.Fatalf("expected not-ready condition to be set")
+			}
+			if notReady.Reason != tt.expectedReason {
+				t.Fatalf("expected reason %q, got %q", tt.expectedReason, notReady.Reason)
+			}
+		})
+	}
+}
+
+func newClientContext(t *testing.T, environment string, objects ...crclient.Object) context.Context {
+	t.Helper()
+
+	sch := runtime.NewScheme()
+	if err := apiv1.AddToScheme(sch); err != nil {
+		t.Fatalf("failed to register api scheme: %v", err)
+	}
+	if err := applicationapi.AddToScheme(sch); err != nil {
+		t.Fatalf("failed to register application scheme: %v", err)
+	}
+	if err := organizationapi.AddToScheme(sch); err != nil {
+		t.Fatalf("failed to register organization scheme: %v", err)
+	}
+	fakeClient := fake.NewClientBuilder().WithScheme(sch).WithObjects(objects...).Build()
+	janitorClient := cclient.NewJanitorClient(cclient.NewScopedClient(fakeClient, environment))
+	return cclient.WithClient(context.Background(), janitorClient)
+}

--- a/api/internal/handler/apisubscription/handler_test.go
+++ b/api/internal/handler/apisubscription/handler_test.go
@@ -7,8 +7,6 @@ package apisubscription
 import (
 	"context"
 
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -22,6 +20,9 @@ import (
 	"github.com/telekom/controlplane/common/pkg/condition"
 	"github.com/telekom/controlplane/common/pkg/config"
 	organizationapi "github.com/telekom/controlplane/organization/api/v1"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("ApiSubscription Handler", func() {
@@ -109,7 +110,6 @@ var _ = Describe("ApiSubscription Handler", func() {
 		}
 
 		for _, tt := range tests {
-			tt := tt
 			It(tt.name, func() {
 				team := &organizationapi.Team{
 					ObjectMeta: metav1.ObjectMeta{

--- a/api/internal/handler/apisubscription/handler_test.go
+++ b/api/internal/handler/apisubscription/handler_test.go
@@ -172,7 +172,17 @@ func newClientContext(environment string, objects ...crclient.Object) context.Co
 	Expect(apiv1.AddToScheme(sch)).To(Succeed())
 	Expect(applicationapi.AddToScheme(sch)).To(Succeed())
 	Expect(organizationapi.AddToScheme(sch)).To(Succeed())
-	fakeClient := fake.NewClientBuilder().WithScheme(sch).WithObjects(objects...).Build()
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(sch).
+		WithObjects(objects...).
+		WithIndex(&apiv1.ApiCategory{}, "spec.labelValue", func(obj crclient.Object) []string {
+			apiCategory, ok := obj.(*apiv1.ApiCategory)
+			if !ok || apiCategory.Spec.LabelValue == "" {
+				return nil
+			}
+			return []string{apiCategory.Spec.LabelValue}
+		}).
+		Build()
 	janitorClient := cclient.NewJanitorClient(cclient.NewScopedClient(fakeClient, environment))
 	return cclient.WithClient(context.Background(), janitorClient)
 }

--- a/api/internal/handler/apisubscription/handler_test.go
+++ b/api/internal/handler/apisubscription/handler_test.go
@@ -86,9 +86,23 @@ var _ = Describe("ApiSubscription Handler", func() {
 				expectedReason: util.ApiCategoryTeamCategoryNotAllowedReason,
 			},
 			{
-				name:           "unresolved category",
+				name:           "no categories configured",
 				teamCategory:   organizationapi.TeamCategoryCustomer,
 				apiCategories:  nil,
+				expectedResult: true,
+			},
+			{
+				name:         "missing category",
+				teamCategory: organizationapi.TeamCategoryCustomer,
+				apiCategories: []apiv1.ApiCategory{
+					{
+						ObjectMeta: metav1.ObjectMeta{Name: "other", Namespace: environment, Labels: map[string]string{config.EnvironmentLabelKey: environment}},
+						Spec: apiv1.ApiCategorySpec{
+							LabelValue: "other",
+							Active:     true,
+						},
+					},
+				},
 				expectedResult: false,
 				expectedReason: util.ApiCategoryPolicyResolutionFailedReason,
 			},

--- a/api/internal/handler/apisubscription/handler_test.go
+++ b/api/internal/handler/apisubscription/handler_test.go
@@ -6,8 +6,9 @@ package apisubscription
 
 import (
 	"context"
-	"testing"
 
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -23,156 +24,140 @@ import (
 	organizationapi "github.com/telekom/controlplane/organization/api/v1"
 )
 
-func TestValidateApiCategoryPolicy(t *testing.T) {
-	t.Parallel()
+var _ = Describe("ApiSubscription Handler", func() {
+	Context("validateApiCategoryPolicy", func() {
+		const (
+			environment = "test"
+			group       = "alpha"
+			teamName    = "core"
+		)
 
-	const (
-		environment = "test"
-		group       = "alpha"
-		teamName    = "core"
-	)
-
-	baseApp := &applicationapi.Application{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "consumer-app",
-			Namespace: environment + "--" + group + "--" + teamName,
-		},
-	}
-	baseAPI := &apiv1.Api{
-		Spec: apiv1.ApiSpec{
-			Category: "partner",
-		},
-	}
-
-	tests := []struct {
-		name           string
-		teamCategory   organizationapi.TeamCategory
-		apiCategories  []apiv1.ApiCategory
-		expectedResult bool
-		expectedReason string
-	}{
-		{
-			name:         "allowed category",
-			teamCategory: organizationapi.TeamCategoryCustomer,
-			apiCategories: []apiv1.ApiCategory{
-				{
-					ObjectMeta: metav1.ObjectMeta{Name: "partner", Namespace: environment, Labels: map[string]string{config.EnvironmentLabelKey: environment}},
-					Spec: apiv1.ApiCategorySpec{
-						LabelValue: "partner",
-						Active:     true,
-						AllowTeams: &apiv1.AllowTeamsConfig{Categories: []string{"Customer"}},
-					},
-				},
+		baseApp := &applicationapi.Application{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "consumer-app",
+				Namespace: environment + "--" + group + "--" + teamName,
 			},
-			expectedResult: true,
-		},
-		{
-			name:         "denied category",
-			teamCategory: organizationapi.TeamCategoryInfrastructure,
-			apiCategories: []apiv1.ApiCategory{
-				{
-					ObjectMeta: metav1.ObjectMeta{Name: "partner", Namespace: environment, Labels: map[string]string{config.EnvironmentLabelKey: environment}},
-					Spec: apiv1.ApiCategorySpec{
-						LabelValue: "partner",
-						Active:     true,
-						AllowTeams: &apiv1.AllowTeamsConfig{Categories: []string{"Customer"}},
-					},
-				},
+		}
+		baseAPI := &apiv1.Api{
+			Spec: apiv1.ApiSpec{
+				Category: "partner",
 			},
-			expectedResult: false,
-			expectedReason: util.ApiCategoryTeamCategoryNotAllowedReason,
-		},
-		{
-			name:           "unresolved category",
-			teamCategory:   organizationapi.TeamCategoryCustomer,
-			apiCategories:  nil,
-			expectedResult: false,
-			expectedReason: util.ApiCategoryPolicyResolutionFailedReason,
-		},
-		{
-			name:         "inactive category",
-			teamCategory: organizationapi.TeamCategoryCustomer,
-			apiCategories: []apiv1.ApiCategory{
-				{
-					ObjectMeta: metav1.ObjectMeta{Name: "partner", Namespace: environment, Labels: map[string]string{config.EnvironmentLabelKey: environment}},
-					Spec: apiv1.ApiCategorySpec{
-						LabelValue: "partner",
-						Active:     false,
+		}
+
+		type testCase struct {
+			name           string
+			teamCategory   organizationapi.TeamCategory
+			apiCategories  []apiv1.ApiCategory
+			expectedResult bool
+			expectedReason string
+		}
+
+		tests := []testCase{
+			{
+				name:         "allowed category",
+				teamCategory: organizationapi.TeamCategoryCustomer,
+				apiCategories: []apiv1.ApiCategory{
+					{
+						ObjectMeta: metav1.ObjectMeta{Name: "partner", Namespace: environment, Labels: map[string]string{config.EnvironmentLabelKey: environment}},
+						Spec: apiv1.ApiCategorySpec{
+							LabelValue: "partner",
+							Active:     true,
+							AllowTeams: &apiv1.AllowTeamsConfig{Categories: []string{"Customer"}},
+						},
 					},
 				},
+				expectedResult: true,
 			},
-			expectedResult: false,
-			expectedReason: util.ApiCategoryPolicyResolutionFailedReason,
-		},
-	}
-
-	for _, tt := range tests {
-		tt := tt
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
-			team := &organizationapi.Team{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      group + "--" + teamName,
-					Namespace: environment,
-					Labels: map[string]string{
-						config.EnvironmentLabelKey: environment,
+			{
+				name:         "denied category",
+				teamCategory: organizationapi.TeamCategoryInfrastructure,
+				apiCategories: []apiv1.ApiCategory{
+					{
+						ObjectMeta: metav1.ObjectMeta{Name: "partner", Namespace: environment, Labels: map[string]string{config.EnvironmentLabelKey: environment}},
+						Spec: apiv1.ApiCategorySpec{
+							LabelValue: "partner",
+							Active:     true,
+							AllowTeams: &apiv1.AllowTeamsConfig{Categories: []string{"Customer"}},
+						},
 					},
 				},
-				Spec: organizationapi.TeamSpec{
-					Group:    group,
-					Name:     teamName,
-					Email:    "team@example.com",
-					Category: tt.teamCategory,
+				expectedResult: false,
+				expectedReason: util.ApiCategoryTeamCategoryNotAllowedReason,
+			},
+			{
+				name:           "unresolved category",
+				teamCategory:   organizationapi.TeamCategoryCustomer,
+				apiCategories:  nil,
+				expectedResult: false,
+				expectedReason: util.ApiCategoryPolicyResolutionFailedReason,
+			},
+			{
+				name:         "inactive category",
+				teamCategory: organizationapi.TeamCategoryCustomer,
+				apiCategories: []apiv1.ApiCategory{
+					{
+						ObjectMeta: metav1.ObjectMeta{Name: "partner", Namespace: environment, Labels: map[string]string{config.EnvironmentLabelKey: environment}},
+						Spec: apiv1.ApiCategorySpec{
+							LabelValue: "partner",
+							Active:     false,
+						},
+					},
 				},
-			}
+				expectedResult: false,
+				expectedReason: util.ApiCategoryPolicyResolutionFailedReason,
+			},
+		}
 
-			objects := []crclient.Object{team}
-			for i := range tt.apiCategories {
-				cat := tt.apiCategories[i]
-				objects = append(objects, &cat)
-			}
-
-			ctx := newClientContext(t, environment, objects...)
-			apiSub := &apiv1.ApiSubscription{}
-
-			result := validateApiCategoryPolicy(ctx, baseAPI, baseApp, apiSub)
-			if result != tt.expectedResult {
-				t.Fatalf("expected result %v, got %v", tt.expectedResult, result)
-			}
-
-			if tt.expectedReason == "" {
-				notReady := meta.FindStatusCondition(apiSub.GetConditions(), condition.ConditionTypeReady)
-				if notReady != nil && notReady.Status == metav1.ConditionFalse {
-					t.Fatalf("expected no not-ready condition for allowed path, got: %#v", notReady)
+		for _, tt := range tests {
+			tt := tt
+			It(tt.name, func() {
+				team := &organizationapi.Team{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      group + "--" + teamName,
+						Namespace: environment,
+						Labels: map[string]string{
+							config.EnvironmentLabelKey: environment,
+						},
+					},
+					Spec: organizationapi.TeamSpec{
+						Group:    group,
+						Name:     teamName,
+						Email:    "team@example.com",
+						Category: tt.teamCategory,
+					},
 				}
-				return
-			}
 
-			notReady := meta.FindStatusCondition(apiSub.GetConditions(), condition.ConditionTypeReady)
-			if notReady == nil {
-				t.Fatalf("expected not-ready condition to be set")
-			}
-			if notReady.Reason != tt.expectedReason {
-				t.Fatalf("expected reason %q, got %q", tt.expectedReason, notReady.Reason)
-			}
-		})
-	}
-}
+				objects := []crclient.Object{team}
+				for i := range tt.apiCategories {
+					cat := tt.apiCategories[i]
+					objects = append(objects, &cat)
+				}
 
-func newClientContext(t *testing.T, environment string, objects ...crclient.Object) context.Context {
-	t.Helper()
+				ctx := newClientContext(environment, objects...)
+				apiSub := &apiv1.ApiSubscription{}
 
+				result := validateApiCategoryPolicy(ctx, baseAPI, baseApp, apiSub)
+				Expect(result).To(Equal(tt.expectedResult))
+
+				if tt.expectedReason == "" {
+					notReady := meta.FindStatusCondition(apiSub.GetConditions(), condition.ConditionTypeReady)
+					Expect(notReady == nil || notReady.Status != metav1.ConditionFalse).To(BeTrue())
+					return
+				}
+
+				notReady := meta.FindStatusCondition(apiSub.GetConditions(), condition.ConditionTypeReady)
+				Expect(notReady).NotTo(BeNil())
+				Expect(notReady.Reason).To(Equal(tt.expectedReason))
+			})
+		}
+	})
+})
+
+func newClientContext(environment string, objects ...crclient.Object) context.Context {
 	sch := runtime.NewScheme()
-	if err := apiv1.AddToScheme(sch); err != nil {
-		t.Fatalf("failed to register api scheme: %v", err)
-	}
-	if err := applicationapi.AddToScheme(sch); err != nil {
-		t.Fatalf("failed to register application scheme: %v", err)
-	}
-	if err := organizationapi.AddToScheme(sch); err != nil {
-		t.Fatalf("failed to register organization scheme: %v", err)
-	}
+	Expect(apiv1.AddToScheme(sch)).To(Succeed())
+	Expect(applicationapi.AddToScheme(sch)).To(Succeed())
+	Expect(organizationapi.AddToScheme(sch)).To(Succeed())
 	fakeClient := fake.NewClientBuilder().WithScheme(sch).WithObjects(objects...).Build()
 	janitorClient := cclient.NewJanitorClient(cclient.NewScopedClient(fakeClient, environment))
 	return cclient.WithClient(context.Background(), janitorClient)

--- a/api/internal/handler/apisubscription/suite_test.go
+++ b/api/internal/handler/apisubscription/suite_test.go
@@ -1,0 +1,17 @@
+// Copyright 2025 Deutsche Telekom IT GmbH
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package apisubscription
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestApiSubscriptionHandler(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "ApiSubscription Handler Suite")
+}

--- a/api/internal/handler/util/api_category_policy_test.go
+++ b/api/internal/handler/util/api_category_policy_test.go
@@ -109,7 +109,17 @@ var _ = Describe("ApiCategory Policy", func() {
 func newClientContext(environment string, objects ...crclient.Object) context.Context {
 	sch := runtime.NewScheme()
 	Expect(apiv1.AddToScheme(sch)).To(Succeed())
-	fakeClient := fake.NewClientBuilder().WithScheme(sch).WithObjects(objects...).Build()
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(sch).
+		WithObjects(objects...).
+		WithIndex(&apiv1.ApiCategory{}, "spec.labelValue", func(obj crclient.Object) []string {
+			apiCategory, ok := obj.(*apiv1.ApiCategory)
+			if !ok || apiCategory.Spec.LabelValue == "" {
+				return nil
+			}
+			return []string{apiCategory.Spec.LabelValue}
+		}).
+		Build()
 	janitorClient := cclient.NewJanitorClient(cclient.NewScopedClient(fakeClient, environment))
 	return cclient.WithClient(context.Background(), janitorClient)
 }

--- a/api/internal/handler/util/api_category_policy_test.go
+++ b/api/internal/handler/util/api_category_policy_test.go
@@ -6,7 +6,6 @@ package util
 
 import (
 	"context"
-	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -16,12 +15,14 @@ import (
 	apiv1 "github.com/telekom/controlplane/api/api/v1"
 	cclient "github.com/telekom/controlplane/common/pkg/client"
 	"github.com/telekom/controlplane/common/pkg/config"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 )
 
-func TestResolveActiveApiCategoryByLabelValue(t *testing.T) {
-	t.Parallel()
-
+var _ = Describe("ApiCategory Policy", func() {
 	const environment = "test"
+
 	activeCategory := &apiv1.ApiCategory{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "partner",
@@ -35,6 +36,7 @@ func TestResolveActiveApiCategoryByLabelValue(t *testing.T) {
 			Active:     true,
 		},
 	}
+
 	inactiveCategory := &apiv1.ApiCategory{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "legacy",
@@ -49,55 +51,64 @@ func TestResolveActiveApiCategoryByLabelValue(t *testing.T) {
 		},
 	}
 
-	ctx := newClientContext(t, environment, activeCategory, inactiveCategory)
+	DescribeTable("ResolveActiveApiCategoryByLabelValue",
+		func(objects []crclient.Object, labelValue string, expectNil, expectErr bool) {
+			ctx := newClientContext(environment, objects...)
+			category, err := ResolveActiveApiCategoryByLabelValue(ctx, labelValue)
 
-	if _, err := ResolveActiveApiCategoryByLabelValue(ctx, "partner"); err != nil {
-		t.Fatalf("expected active category to resolve, got error: %v", err)
-	}
-	if _, err := ResolveActiveApiCategoryByLabelValue(ctx, "legacy"); err == nil {
-		t.Fatalf("expected inactive category to fail resolution")
-	}
-	if _, err := ResolveActiveApiCategoryByLabelValue(ctx, "missing"); err == nil {
-		t.Fatalf("expected missing category to fail resolution")
-	}
-}
+			if expectErr {
+				Expect(err).To(HaveOccurred())
+				return
+			}
 
-func TestResolveActiveApiCategoryForApi(t *testing.T) {
-	t.Parallel()
+			Expect(err).NotTo(HaveOccurred())
+			if expectNil {
+				Expect(category).To(BeNil())
+				return
+			}
 
-	const environment = "test"
-	category := &apiv1.ApiCategory{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "internal",
-			Namespace: environment,
-			Labels: map[string]string{
-				config.EnvironmentLabelKey: environment,
-			},
+			Expect(category).NotTo(BeNil())
+			Expect(category.Spec.LabelValue).To(Equal(labelValue))
 		},
-		Spec: apiv1.ApiCategorySpec{
-			LabelValue: "internal",
-			Active:     true,
-		},
-	}
-	api := &apiv1.Api{
-		Spec: apiv1.ApiSpec{
-			Category: "internal",
-		},
-	}
+		Entry("resolves an active category", []crclient.Object{activeCategory}, "partner", false, false),
+		Entry("skips validation when no categories exist", []crclient.Object{}, "partner", true, false),
+		Entry("rejects an inactive category", []crclient.Object{inactiveCategory}, "legacy", true, true),
+		Entry("rejects a missing category when categories exist", []crclient.Object{activeCategory}, "missing", true, true),
+	)
 
-	ctx := newClientContext(t, environment, category)
-	if _, err := ResolveActiveApiCategoryForApi(ctx, api); err != nil {
-		t.Fatalf("expected api category resolution to succeed, got error: %v", err)
-	}
-}
+	Describe("ResolveActiveApiCategoryForApi", func() {
+		It("resolves the category from the api spec", func() {
+			category := &apiv1.ApiCategory{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "internal",
+					Namespace: environment,
+					Labels: map[string]string{
+						config.EnvironmentLabelKey: environment,
+					},
+				},
+				Spec: apiv1.ApiCategorySpec{
+					LabelValue: "internal",
+					Active:     true,
+				},
+			}
+			api := &apiv1.Api{
+				Spec: apiv1.ApiSpec{
+					Category: "internal",
+				},
+			}
 
-func newClientContext(t *testing.T, environment string, objects ...crclient.Object) context.Context {
-	t.Helper()
+			ctx := newClientContext(environment, category)
+			resolved, err := ResolveActiveApiCategoryForApi(ctx, api)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(resolved).NotTo(BeNil())
+			Expect(resolved.Spec.LabelValue).To(Equal("internal"))
+		})
+	})
+})
 
+func newClientContext(environment string, objects ...crclient.Object) context.Context {
 	sch := runtime.NewScheme()
-	if err := apiv1.AddToScheme(sch); err != nil {
-		t.Fatalf("failed to register api scheme: %v", err)
-	}
+	Expect(apiv1.AddToScheme(sch)).To(Succeed())
 	fakeClient := fake.NewClientBuilder().WithScheme(sch).WithObjects(objects...).Build()
 	janitorClient := cclient.NewJanitorClient(cclient.NewScopedClient(fakeClient, environment))
 	return cclient.WithClient(context.Background(), janitorClient)

--- a/api/internal/handler/util/api_category_policy_test.go
+++ b/api/internal/handler/util/api_category_policy_test.go
@@ -1,0 +1,104 @@
+// Copyright 2026 Deutsche Telekom IT GmbH
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package util
+
+import (
+	"context"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	crclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	apiv1 "github.com/telekom/controlplane/api/api/v1"
+	cclient "github.com/telekom/controlplane/common/pkg/client"
+	"github.com/telekom/controlplane/common/pkg/config"
+)
+
+func TestResolveActiveApiCategoryByLabelValue(t *testing.T) {
+	t.Parallel()
+
+	const environment = "test"
+	activeCategory := &apiv1.ApiCategory{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "partner",
+			Namespace: environment,
+			Labels: map[string]string{
+				config.EnvironmentLabelKey: environment,
+			},
+		},
+		Spec: apiv1.ApiCategorySpec{
+			LabelValue: "partner",
+			Active:     true,
+		},
+	}
+	inactiveCategory := &apiv1.ApiCategory{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "legacy",
+			Namespace: environment,
+			Labels: map[string]string{
+				config.EnvironmentLabelKey: environment,
+			},
+		},
+		Spec: apiv1.ApiCategorySpec{
+			LabelValue: "legacy",
+			Active:     false,
+		},
+	}
+
+	ctx := newClientContext(t, environment, activeCategory, inactiveCategory)
+
+	if _, err := ResolveActiveApiCategoryByLabelValue(ctx, "partner"); err != nil {
+		t.Fatalf("expected active category to resolve, got error: %v", err)
+	}
+	if _, err := ResolveActiveApiCategoryByLabelValue(ctx, "legacy"); err == nil {
+		t.Fatalf("expected inactive category to fail resolution")
+	}
+	if _, err := ResolveActiveApiCategoryByLabelValue(ctx, "missing"); err == nil {
+		t.Fatalf("expected missing category to fail resolution")
+	}
+}
+
+func TestResolveActiveApiCategoryForApi(t *testing.T) {
+	t.Parallel()
+
+	const environment = "test"
+	category := &apiv1.ApiCategory{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "internal",
+			Namespace: environment,
+			Labels: map[string]string{
+				config.EnvironmentLabelKey: environment,
+			},
+		},
+		Spec: apiv1.ApiCategorySpec{
+			LabelValue: "internal",
+			Active:     true,
+		},
+	}
+	api := &apiv1.Api{
+		Spec: apiv1.ApiSpec{
+			Category: "internal",
+		},
+	}
+
+	ctx := newClientContext(t, environment, category)
+	if _, err := ResolveActiveApiCategoryForApi(ctx, api); err != nil {
+		t.Fatalf("expected api category resolution to succeed, got error: %v", err)
+	}
+}
+
+func newClientContext(t *testing.T, environment string, objects ...crclient.Object) context.Context {
+	t.Helper()
+
+	sch := runtime.NewScheme()
+	if err := apiv1.AddToScheme(sch); err != nil {
+		t.Fatalf("failed to register api scheme: %v", err)
+	}
+	fakeClient := fake.NewClientBuilder().WithScheme(sch).WithObjects(objects...).Build()
+	janitorClient := cclient.NewJanitorClient(cclient.NewScopedClient(fakeClient, environment))
+	return cclient.WithClient(context.Background(), janitorClient)
+}

--- a/api/internal/handler/util/api_category_policy_test.go
+++ b/api/internal/handler/util/api_category_policy_test.go
@@ -71,7 +71,7 @@ var _ = Describe("ApiCategory Policy", func() {
 			Expect(category.Spec.LabelValue).To(Equal(labelValue))
 		},
 		Entry("resolves an active category", []crclient.Object{activeCategory}, "partner", false, false),
-		Entry("skips validation when no categories exist", []crclient.Object{}, "partner", true, false),
+		Entry("skips validation when no categories exist", []crclient.Object{}, "partner", true, true),
 		Entry("rejects an inactive category", []crclient.Object{inactiveCategory}, "legacy", true, true),
 		Entry("rejects a missing category when categories exist", []crclient.Object{activeCategory}, "missing", true, true),
 	)

--- a/api/internal/handler/util/getters.go
+++ b/api/internal/handler/util/getters.go
@@ -177,13 +177,17 @@ func ResolveActiveApiCategoryForApi(ctx context.Context, api *apiv1.Api) (*apiv1
 func ResolveActiveApiCategoryByLabelValue(ctx context.Context, labelValue string) (*apiv1.ApiCategory, error) {
 	scopedClient := cclient.ClientFromContextOrDie(ctx)
 	normalizedLabelValue := strings.TrimSpace(labelValue)
-	if normalizedLabelValue == "" {
-		return nil, ctrlerrors.BlockedErrorf("ApiCategory label value is empty")
-	}
-
 	apiCategoryList := &apiv1.ApiCategoryList{}
 	if err := scopedClient.List(ctx, apiCategoryList); err != nil {
 		return nil, errors.Wrap(err, "failed to list ApiCategories")
+	}
+
+	if len(apiCategoryList.Items) == 0 {
+		return nil, nil
+	}
+
+	if normalizedLabelValue == "" {
+		return nil, ctrlerrors.BlockedErrorf("ApiCategory label value is empty")
 	}
 
 	apiCategory, found := apiCategoryList.FindByLabelValue(normalizedLabelValue)
@@ -201,11 +205,11 @@ func BuildApiCategoryPolicyResolutionMessage(apiCategoryLabel string, err error)
 }
 
 func BuildApiCategoryExposureDeniedMessage(teamCategory, apiCategoryLabel string) string {
-	return fmt.Sprintf("Team of category %s are not allowed to expose APIs of category %s", teamCategory, apiCategoryLabel)
+	return fmt.Sprintf("Team with category %q is not allowed to expose APIs of category %q", teamCategory, apiCategoryLabel)
 }
 
 func BuildApiCategorySubscriptionDeniedMessage(teamCategory, apiCategoryLabel string) string {
-	return fmt.Sprintf("Team of category %s are not allowed to subscribe APIs of category %s", teamCategory, apiCategoryLabel)
+	return fmt.Sprintf("Team with category %q is not allowed to subscribe to APIs of category %q", teamCategory, apiCategoryLabel)
 }
 
 // FindAPIExposure checks if there is an active ApiExposure corresponding to the given apiBasePath.

--- a/api/internal/handler/util/getters.go
+++ b/api/internal/handler/util/getters.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 	"sort"
+	"strings"
 
 	"github.com/pkg/errors"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -33,6 +34,11 @@ import (
 const stringTrue = "true"
 
 var ApplicationLabelKey = config.BuildLabelKey("application")
+
+const (
+	ApiCategoryPolicyResolutionFailedReason = "ApiCategoryPolicyResolutionFailed"
+	ApiCategoryTeamCategoryNotAllowedReason = "ApiCategoryTeamCategoryNotAllowed"
+)
 
 // GetZone retrieves a Zone object based on the provided ObjectRef for a zone.
 func GetZone(ctx context.Context, scopedClient cclient.ScopedClient, ref client.ObjectKey) (*adminapi.Zone, error) {
@@ -159,6 +165,47 @@ func FindActiveAPI(ctx context.Context, apiBasePath string) (bool, *apiv1.Api, e
 	}
 
 	return true, relevantApi, nil
+}
+
+func ResolveActiveApiCategoryForApi(ctx context.Context, api *apiv1.Api) (*apiv1.ApiCategory, error) {
+	if api == nil {
+		return nil, errors.New("api is nil")
+	}
+	return ResolveActiveApiCategoryByLabelValue(ctx, api.Spec.Category)
+}
+
+func ResolveActiveApiCategoryByLabelValue(ctx context.Context, labelValue string) (*apiv1.ApiCategory, error) {
+	scopedClient := cclient.ClientFromContextOrDie(ctx)
+	normalizedLabelValue := strings.TrimSpace(labelValue)
+	if normalizedLabelValue == "" {
+		return nil, ctrlerrors.BlockedErrorf("ApiCategory label value is empty")
+	}
+
+	apiCategoryList := &apiv1.ApiCategoryList{}
+	if err := scopedClient.List(ctx, apiCategoryList); err != nil {
+		return nil, errors.Wrap(err, "failed to list ApiCategories")
+	}
+
+	apiCategory, found := apiCategoryList.FindByLabelValue(normalizedLabelValue)
+	if !found {
+		return nil, ctrlerrors.BlockedErrorf("ApiCategory %q not found", normalizedLabelValue)
+	}
+	if !apiCategory.Spec.Active {
+		return nil, ctrlerrors.BlockedErrorf("ApiCategory %q is not active", normalizedLabelValue)
+	}
+	return apiCategory, nil
+}
+
+func BuildApiCategoryPolicyResolutionMessage(apiCategoryLabel string, err error) string {
+	return fmt.Sprintf("ApiCategory policy for category %q cannot be resolved: %v", apiCategoryLabel, err)
+}
+
+func BuildApiCategoryExposureDeniedMessage(teamCategory, apiCategoryLabel string) string {
+	return fmt.Sprintf("Team of category %s are not allowed to expose APIs of category %s", teamCategory, apiCategoryLabel)
+}
+
+func BuildApiCategorySubscriptionDeniedMessage(teamCategory, apiCategoryLabel string) string {
+	return fmt.Sprintf("Team of category %s are not allowed to subscribe APIs of category %s", teamCategory, apiCategoryLabel)
 }
 
 // FindAPIExposure checks if there is an active ApiExposure corresponding to the given apiBasePath.

--- a/api/internal/handler/util/getters.go
+++ b/api/internal/handler/util/getters.go
@@ -14,6 +14,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
@@ -183,7 +184,7 @@ func ResolveActiveApiCategoryByLabelValue(ctx context.Context, labelValue string
 	}
 
 	if len(apiCategoryList.Items) == 0 {
-		return nil, nil
+		return nil, apierrors.NewNotFound(schema.GroupResource{Group: apiv1.GroupVersion.Group, Resource: "apicategories"}, normalizedLabelValue)
 	}
 
 	if normalizedLabelValue == "" {

--- a/api/internal/handler/util/getters.go
+++ b/api/internal/handler/util/getters.go
@@ -178,23 +178,25 @@ func ResolveActiveApiCategoryForApi(ctx context.Context, api *apiv1.Api) (*apiv1
 func ResolveActiveApiCategoryByLabelValue(ctx context.Context, labelValue string) (*apiv1.ApiCategory, error) {
 	scopedClient := cclient.ClientFromContextOrDie(ctx)
 	normalizedLabelValue := strings.TrimSpace(labelValue)
-	apiCategoryList := &apiv1.ApiCategoryList{}
-	if err := scopedClient.List(ctx, apiCategoryList); err != nil {
-		return nil, errors.Wrap(err, "failed to list ApiCategories")
-	}
-
-	if len(apiCategoryList.Items) == 0 {
-		return nil, apierrors.NewNotFound(schema.GroupResource{Group: apiv1.GroupVersion.Group, Resource: "apicategories"}, normalizedLabelValue)
-	}
-
 	if normalizedLabelValue == "" {
 		return nil, ctrlerrors.BlockedErrorf("ApiCategory label value is empty")
 	}
 
-	apiCategory, found := apiCategoryList.FindByLabelValue(normalizedLabelValue)
-	if !found {
+	apiCategoryList := &apiv1.ApiCategoryList{}
+	if err := scopedClient.List(ctx, apiCategoryList, client.MatchingFields{"spec.labelValue": normalizedLabelValue}); err != nil {
+		return nil, errors.Wrap(err, "failed to list ApiCategories by label value")
+	}
+	if len(apiCategoryList.Items) == 0 {
+		anyApiCategoryList := &apiv1.ApiCategoryList{}
+		if err := scopedClient.List(ctx, anyApiCategoryList, client.Limit(1)); err != nil {
+			return nil, errors.Wrap(err, "failed to verify whether ApiCategories exist")
+		}
+		if len(anyApiCategoryList.Items) == 0 {
+			return nil, apierrors.NewNotFound(schema.GroupResource{Group: apiv1.GroupVersion.Group, Resource: "apicategories"}, normalizedLabelValue)
+		}
 		return nil, ctrlerrors.BlockedErrorf("ApiCategory %q not found", normalizedLabelValue)
 	}
+	apiCategory := &apiCategoryList.Items[0]
 	if !apiCategory.Spec.Active {
 		return nil, ctrlerrors.BlockedErrorf("ApiCategory %q is not active", normalizedLabelValue)
 	}

--- a/docs/docs/admin-journey/features/api-categories.md
+++ b/docs/docs/admin-journey/features/api-categories.md
@@ -27,6 +27,12 @@ info:
 
 When the specification is submitted, the platform looks up the matching `ApiCategory` resource and validates the request against its rules. If the category does not exist, is inactive, or the team is not allowed to use it, the request is rejected.
 
+When API runtime resources are processed, the platform also enforces `allowTeams.categories` for `ApiExposure` and `ApiSubscription` before provisioning downstream gateway resources.
+
+:::note
+Runtime enforcement in this phase is intentionally scoped to `allowTeams.categories`. `allowTeams.names` is currently not evaluated by `ApiExposure` and `ApiSubscription` handlers.
+:::
+
 :::info
 If no `ApiCategory` resources exist in the environment, the platform skips category validation entirely and accepts any value. This means you can adopt API Categories gradually — they only take effect once you create your first one.
 :::

--- a/docs/docs/admin-journey/features/api-categories.md
+++ b/docs/docs/admin-journey/features/api-categories.md
@@ -34,7 +34,7 @@ Runtime enforcement in this phase is intentionally scoped to `allowTeams.categor
 :::
 
 :::info
-If no `ApiCategory` resources exist in the environment, the platform skips category validation entirely and accepts any value. This means you can adopt API Categories gradually — they only take effect once you create your first one.
+If no `ApiCategory` resources exist in the environment, the platform skips runtime category validation entirely and accepts any value. This means you can adopt API Categories gradually — they only take effect once you create your first one.
 :::
 
 :::caution

--- a/tools/e2e-tester/examples/api-category/customer-blocked-exposure/apispec.yaml
+++ b/tools/e2e-tester/examples/api-category/customer-blocked-exposure/apispec.yaml
@@ -1,0 +1,12 @@
+# Copyright 2026 Deutsche Telekom IT GmbH
+#
+# SPDX-License-Identifier: Apache-2.0
+
+openapi: 3.0.0
+info:
+  title: E2E API Category Customer Blocked Exposure
+  version: 1.0.0
+  x-api-category: Infrastructure
+servers:
+  - url: http://localhost:8080/devops/e2e-api-category-customer-blocked-exposure/v1
+    description: Local server for testing

--- a/tools/e2e-tester/examples/api-category/customer-blocked-exposure/rover.yaml
+++ b/tools/e2e-tester/examples/api-category/customer-blocked-exposure/rover.yaml
@@ -1,0 +1,15 @@
+# Copyright 2026 Deutsche Telekom IT GmbH
+#
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: tcp.ei.telekom.de/v1
+kind: Rover
+metadata:
+  name: e2e-api-category-customer-blocked-exposure
+spec:
+  zone: dataplane1
+  exposures:
+    - basePath: /devops/e2e-api-category-customer-blocked-exposure/v1
+      visibility: ENTERPRISE
+      approval: AUTO
+      upstream: http://test-service:8080

--- a/tools/e2e-tester/examples/api-category/customer-blocked-subscription/rover.yaml
+++ b/tools/e2e-tester/examples/api-category/customer-blocked-subscription/rover.yaml
@@ -1,0 +1,16 @@
+# Copyright 2026 Deutsche Telekom IT GmbH
+#
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: tcp.ei.telekom.de/v1
+kind: Rover
+metadata:
+  name: e2e-api-category-customer-blocked-subscription
+spec:
+  zone: dataplane1
+  subscriptions:
+    - basePath: /devops/e2e-api-category-infra-allowed/v1
+      security:
+        oauth2:
+          username: test-user
+          password: test-password

--- a/tools/e2e-tester/examples/api-category/infra-allowed/apispec.yaml
+++ b/tools/e2e-tester/examples/api-category/infra-allowed/apispec.yaml
@@ -1,0 +1,12 @@
+# Copyright 2026 Deutsche Telekom IT GmbH
+#
+# SPDX-License-Identifier: Apache-2.0
+
+openapi: 3.0.0
+info:
+  title: E2E API Category Infra Allowed
+  version: 1.0.0
+  x-api-category: Infrastructure
+servers:
+  - url: http://localhost:8080/devops/e2e-api-category-infra-allowed/v1
+    description: Local server for testing

--- a/tools/e2e-tester/examples/api-category/infra-allowed/rover.yaml
+++ b/tools/e2e-tester/examples/api-category/infra-allowed/rover.yaml
@@ -1,0 +1,15 @@
+# Copyright 2026 Deutsche Telekom IT GmbH
+#
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: tcp.ei.telekom.de/v1
+kind: Rover
+metadata:
+  name: e2e-api-category-infra-allowed
+spec:
+  zone: dataplane1
+  exposures:
+    - basePath: /devops/e2e-api-category-infra-allowed/v1
+      visibility: ENTERPRISE
+      approval: AUTO
+      upstream: http://test-service:8080


### PR DESCRIPTION
## Why

`ApiExposure` and `ApiSubscription` currently do not enforce the live `ApiCategory.allowTeams.categories` policy in the Go control plane. This creates governance drift between declared category policy and runtime behavior.

## What Changes

- Add category-policy validation to `ApiExposure` reconciliation, blocking provisioning when the provider team category is not allowed by the referenced `ApiCategory`.
- Add category-policy validation to `ApiSubscription` reconciliation, blocking provisioning when the subscriber team category is not allowed by the referenced `ApiCategory`.
- Reuse the existing `ApiCategory.allowTeams.categories` policy as the source of truth for allowed team categories.
- Add explicit status conditions/messages to make category mismatches observable and actionable.
- Add tests covering allowed and denied combinations for both resources.
