### PR TITLE
feat(team-user-ns-migration): team user is now in the same namespace as

### DIFF
--- a/organization/internal/controller/team_controller.go
+++ b/organization/internal/controller/team_controller.go
@@ -6,7 +6,6 @@ package controller
 
 import (
 	"context"
-	"strings"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/record"
@@ -61,8 +60,7 @@ func (r *TeamReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&organizationv1.Team{}).
-		Watches(&identityv1.Client{},
-			handler.EnqueueRequestsFromMapFunc(r.mapClientToTeam),
+		Owns(&identityv1.Client{},
 			builder.WithPredicates(predicate.GenerationChangedPredicate{})).
 		Watches(&notificationv1.NotificationChannel{},
 			handler.EnqueueRequestsFromMapFunc(r.mapNotificationChannelToTeam),
@@ -100,36 +98,6 @@ func (r *TeamReconciler) mapGroupToTeam(ctx context.Context, obj client.Object) 
 	requests := make([]reconcile.Request, 0, len(teamList.Items))
 	for i := range teamList.Items {
 		if teamList.Items[i].Spec.Group == groupObj.Name {
-			requests = append(requests, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(&teamList.Items[i])})
-		}
-	}
-
-	return requests
-}
-
-func (r *TeamReconciler) mapClientToTeam(ctx context.Context, obj client.Object) []reconcile.Request {
-	logger := log.FromContext(ctx)
-
-	identityClient, ok := obj.(*identityv1.Client)
-	if !ok {
-		return nil
-	}
-
-	listOptsForTeams := []client.ListOption{
-		client.MatchingLabels{
-			cconfig.EnvironmentLabelKey: identityClient.Labels[cconfig.EnvironmentLabelKey],
-		},
-	}
-
-	teamList := organizationv1.TeamList{}
-	if err := r.List(ctx, &teamList, listOptsForTeams...); err != nil {
-		logger.Error(err, "failed to list Teams")
-		return nil
-	}
-
-	requests := make([]reconcile.Request, 0, len(teamList.Items))
-	for i := range teamList.Items {
-		if teamList.Items[i].Status.Namespace == identityClient.GetNamespace() && strings.HasSuffix(identityClient.GetName(), "--team-user") {
 			requests = append(requests, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(&teamList.Items[i])})
 		}
 	}

--- a/organization/internal/controller/team_controller_test.go
+++ b/organization/internal/controller/team_controller_test.go
@@ -158,10 +158,6 @@ var _ = Describe("Team Controller", Ordered, func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				Eventually(func(g Gomega) {
-					By("Checking if the identity client has been deleted")
-					err = k8sClient.Get(ctx, team.Status.IdentityClientRef.K8s(), &identityv1.Client{})
-					g.Expect(errors.IsNotFound(err)).To(BeTrue())
-
 					By("Checking if the Team namespace is being terminated")
 					ns := newNamespaceObj(team.Status.Namespace)
 					err = k8sClient.Get(ctx, client.ObjectKeyFromObject(ns), ns)
@@ -173,9 +169,9 @@ var _ = Describe("Team Controller", Ordered, func() {
 					err = k8sClient.Get(ctx, team.Status.GatewayConsumerRef.K8s(), &gatewayv1.Consumer{})
 					g.Expect(errors.IsNotFound(err)).To(BeTrue())
 
-					By("Checking identity client deletion")
-					err = k8sClient.Get(ctx, team.Status.IdentityClientRef.K8s(), &identityv1.Client{})
-					g.Expect(errors.IsNotFound(err)).To(BeTrue())
+					// Identity client deletion is handled by K8s garbage collection via owner reference.
+					// EnvTest does not run the GC controller, so we skip this assertion here.
+					// Owner reference correctness is verified in the main test.
 
 					By("Checking notification channel deletion")
 					err = k8sClient.Get(ctx, team.Status.NotificationChannelRef.K8s(), &notificationv1.NotificationChannel{})
@@ -214,7 +210,7 @@ var _ = Describe("Team Controller", Ordered, func() {
 					}))
 
 					By("Checking the team identity client ref")
-					g.Expect(team.Status.IdentityClientRef.String()).To(Equal(expectedTeamNamespaceName + "/" + groupName + "--" + teamName + "--team-user"))
+					g.Expect(team.Status.IdentityClientRef.String()).To(Equal(testNamespace + "/" + groupName + "--" + teamName + "--team-user"))
 
 					By("Checking the team identity client object")
 					identityClient := &identityv1.Client{}
@@ -237,6 +233,11 @@ var _ = Describe("Team Controller", Ordered, func() {
 					g.Expect(identityClient.GetLabels()).To(BeEquivalentTo(map[string]string{
 						config.EnvironmentLabelKey: testEnvironment,
 					}))
+
+					By("Checking the team identity client owner reference")
+					g.Expect(identityClient.GetOwnerReferences()).To(HaveLen(1))
+					g.Expect(identityClient.GetOwnerReferences()[0].Name).To(Equal(team.GetName()))
+					g.Expect(identityClient.GetOwnerReferences()[0].UID).To(Equal(team.GetUID()))
 
 					By("Checking the team gateway consumer ref")
 					g.Expect(team.Status.GatewayConsumerRef.String()).To(Equal(expectedTeamNamespaceName + "/" + groupName + "--" + teamName + "--team-user"))

--- a/organization/internal/handler/team/handler/identity_client/build.go
+++ b/organization/internal/handler/team/handler/identity_client/build.go
@@ -17,7 +17,7 @@ func buildIdentityClientObj(owner *organisationv1.Team) *identityv1.Client {
 	return &identityv1.Client{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      MakeClientId(owner),
-			Namespace: owner.Status.Namespace,
+			Namespace: owner.GetNamespace(),
 		},
 	}
 }

--- a/organization/internal/handler/team/handler/identity_client/build_test.go
+++ b/organization/internal/handler/team/handler/identity_client/build_test.go
@@ -18,6 +18,9 @@ import (
 func TestBuildIdentityClientObj(t *testing.T) {
 	RegisterTestingT(t)
 	team := &organizationv1.Team{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "env",
+		},
 		Spec: organizationv1.TeamSpec{
 			Name:  "team",
 			Group: "group",
@@ -30,7 +33,7 @@ func TestBuildIdentityClientObj(t *testing.T) {
 	expected := &identityv1.Client{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "group--team--team-user",
-			Namespace: "env--group--team",
+			Namespace: "env",
 		},
 	}
 	got := buildIdentityClientObj(team)

--- a/organization/internal/handler/team/handler/identity_client/identity_client.go
+++ b/organization/internal/handler/team/handler/identity_client/identity_client.go
@@ -7,12 +7,13 @@ package identity_client
 import (
 	"context"
 
+	ctrl "sigs.k8s.io/controller-runtime"
+
 	cclient "github.com/telekom/controlplane/common/pkg/client"
 	"github.com/telekom/controlplane/common/pkg/types"
 	organisationv1 "github.com/telekom/controlplane/organization/api/v1"
 	"github.com/telekom/controlplane/organization/internal/handler/team/handler"
 	"github.com/telekom/controlplane/organization/internal/handler/util"
-	ctrl "sigs.k8s.io/controller-runtime"
 )
 
 func MakeClientId(owner *organisationv1.Team) string {

--- a/organization/internal/handler/team/handler/identity_client/identity_client.go
+++ b/organization/internal/handler/team/handler/identity_client/identity_client.go
@@ -7,14 +7,12 @@ package identity_client
 import (
 	"context"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	cclient "github.com/telekom/controlplane/common/pkg/client"
 	"github.com/telekom/controlplane/common/pkg/types"
-	identityv1 "github.com/telekom/controlplane/identity/api/v1"
 	organisationv1 "github.com/telekom/controlplane/organization/api/v1"
 	"github.com/telekom/controlplane/organization/internal/handler/team/handler"
 	"github.com/telekom/controlplane/organization/internal/handler/util"
+	ctrl "sigs.k8s.io/controller-runtime"
 )
 
 func MakeClientId(owner *organisationv1.Team) string {
@@ -41,7 +39,7 @@ func (i IdentityClientHandler) CreateOrUpdate(ctx context.Context, owner *organi
 		identityClient.Spec.Realm = zoneObj.Status.TeamApiIdentityRealm
 		identityClient.SetLabels(owner.GetLabels())
 
-		return nil
+		return ctrl.SetControllerReference(owner, identityClient, k8sClient.Scheme())
 	}
 
 	if _, err = k8sClient.CreateOrUpdate(ctx, identityClient, mutate); err != nil {
@@ -53,18 +51,10 @@ func (i IdentityClientHandler) CreateOrUpdate(ctx context.Context, owner *organi
 	return nil
 }
 
-func (i IdentityClientHandler) Delete(ctx context.Context, owner *organisationv1.Team) error {
-	var err error
-	k8sClient := cclient.ClientFromContextOrDie(ctx)
-	if owner.Status.IdentityClientRef != nil {
-		err = k8sClient.Delete(ctx, &identityv1.Client{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      owner.Status.IdentityClientRef.GetName(),
-				Namespace: owner.Status.IdentityClientRef.GetNamespace(),
-			},
-		})
-	}
-	return err
+func (i IdentityClientHandler) Delete(_ context.Context, _ *organisationv1.Team) error {
+	// Deletion is handled automatically by Kubernetes garbage collection
+	// via the owner reference set on the identity client.
+	return nil
 }
 
 func (i IdentityClientHandler) Identifier() string {

--- a/organization/internal/team_webhook_reconciler_test.go
+++ b/organization/internal/team_webhook_reconciler_test.go
@@ -165,11 +165,9 @@ var _ = Describe("Team Reconciler, Group Reconciler and Team Webhook", Ordered, 
 				err = k8sClient.Delete(ctx, group)
 				Expect(err).NotTo(HaveOccurred())
 
-				Eventually(func(g Gomega) {
-					By("Checking if the identity client has been deleted")
-					err = k8sClient.Get(ctx, team.Status.IdentityClientRef.K8s(), &identityv1.Client{})
-					g.Expect(errors.IsNotFound(err)).To(BeTrue())
-				}, timeout, interval).Should(Succeed())
+				// Identity client deletion is handled by K8s garbage collection via owner reference.
+				// EnvTest does not run the GC controller, so we skip the deletion assertion here.
+				// Owner reference correctness is verified in the main test.
 			})
 
 			It("should be ready and all resources created", func() {
@@ -196,7 +194,7 @@ var _ = Describe("Team Reconciler, Group Reconciler and Team Webhook", Ordered, 
 					g.Expect(team.Status.GatewayConsumerRef.String()).To(Equal(expectedTeamNamespaceName + "/" + groupName + "--" + teamName + "--team-user"))
 
 					By("Checking the team identity client ref")
-					g.Expect(team.Status.IdentityClientRef.String()).To(Equal(expectedTeamNamespaceName + "/" + groupName + "--" + teamName + "--team-user"))
+					g.Expect(team.Status.IdentityClientRef.String()).To(Equal(testNamespace + "/" + groupName + "--" + teamName + "--team-user"))
 
 					By("Checking the Webhook changes")
 					By("Checking the set secret")


### PR DESCRIPTION
 ## Summary
 
 Moves the team-user Identity Client from the team namespace (`env--group--team`) to the environment namespace (same as the Team CR), enabling a proper Kubernetes owner reference.
 
 ## Motivation
 
 Previously, the team-user Identity Client was created in the team's dedicated namespace, which is different from the namespace where the Team CR itself lives. Since Kubernetes owner references **cannot cross namespace boundaries**, the Team handler had to:
 - Track the Identity Client manually via `Status.IdentityClientRef`
 - Implement manual deletion logic in the `Delete()` handler
 - Use a custom `Watches` + `mapClientToTeam` mapping function to detect changes
 
 By co-locating the Identity Client with its owning Team CR, we can leverage native Kubernetes mechanisms instead.
 
 ## Changes
 
 ### Identity Client namespace (`identity_client/build.go`)
 - Changed from `owner.Status.Namespace` (team namespace) to `owner.GetNamespace()` (environment namespace)
 
 ### Owner reference (`identity_client/identity_client.go`)
 - Added `ctrl.SetControllerReference(owner, identityClient, k8sClient.Scheme())` in the mutate function
 - `Delete()` is now a no-op — Kubernetes garbage collection handles cleanup automatically when the Team is deleted
 
 ### Controller setup (`team_controller.go`)
 - Replaced `Watches(&identityv1.Client{}, handler.EnqueueRequestsFromMapFunc(r.mapClientToTeam), ...)` with `Owns(&identityv1.Client{}, ...)`
 - Removed the `mapClientToTeam` function (no longer needed — `Owns` reads the owner reference automatically)
 - Removed unused `"strings"` import
 
 ### Tests
 - Updated expected namespace for `IdentityClientRef` assertions (now points to env namespace)
 - Added owner reference verification (checks ownerRef name and UID match the Team)
 - Removed identity client deletion assertions from `AfterAll` blocks — envtest does not run the K8s garbage collector, so owner-reference-based deletion cannot be verified in integration tests
 
 ## Impact Analysis
 
 | Area | Impact |
 |------|--------|
 | Identity controller/handler | ✅ None — `spec.realm` is a full `ObjectRef` with namespace, cross-namespace by design |
 | Rover-ctl token parsing | ✅ None — only uses `clientId` string, not namespace |
 | Webhook/mutator (team token generation) | ✅ None — uses `MakeClientId()` which returns a name, not namespace-dependent |
 | Application domain | ✅ None — creates its own separate Identity Clients |
 | Gateway Consumer | Not in scope — being removed in a separate refactor |
 
 ### Name collision risk
 None. Identity Client names follow the pattern `{group}--{team}--team-user`, which is unique per team even when all clients share the environment namespace.
 
 ### Migration
 Not applicable for current deployments (pre-production). For future reference:
 - Orphaned Identity Clients in old team namespaces can be cleaned up with a manual `kubectl delete`
 - Alternatively, a one-shot migration block could be added to delete the old client (ignoring `NotFound`) during reconciliation