### PR TITLE
feat(projector-expired-filter): internal state Expired is filtered by

### DIFF
--- a/projector/internal/domain/approval/translator.go
+++ b/projector/internal/domain/approval/translator.go
@@ -214,7 +214,7 @@ func mapAvailableTransitions(transitions approvalv1.AvailableTransitions) []mode
 	}
 	result := make([]model.AvailableTransition, 0, len(transitions))
 	for _, at := range transitions {
-		if strings.EqualFold(string(at.To), "expired") {
+		if at.To == approvalv1.ApprovalStateExpired {
 			continue
 		}
 		result = append(result, model.AvailableTransition{

--- a/projector/internal/domain/approval/translator.go
+++ b/projector/internal/domain/approval/translator.go
@@ -205,16 +205,22 @@ func mapDecisions(decisions []approvalv1.Decision) []model.Decision {
 
 // mapAvailableTransitions converts CR AvailableTransitions (from Status) to
 // model AvailableTransition DTOs. Note: CR field .To maps to DTO .ToState.
+//
+// Transitions targeting "Expired" are filtered out — Expired is currently an
+// internal state that must not be displayed to users via the query layer.
 func mapAvailableTransitions(transitions approvalv1.AvailableTransitions) []model.AvailableTransition {
 	if len(transitions) == 0 {
 		return []model.AvailableTransition{}
 	}
-	result := make([]model.AvailableTransition, len(transitions))
-	for i, at := range transitions {
-		result[i] = model.AvailableTransition{
+	result := make([]model.AvailableTransition, 0, len(transitions))
+	for _, at := range transitions {
+		if strings.EqualFold(string(at.To), "expired") {
+			continue
+		}
+		result = append(result, model.AvailableTransition{
 			Action:  string(at.Action),
 			ToState: string(at.To),
-		}
+		})
 	}
 	return result
 }

--- a/projector/internal/domain/approval/translator_test.go
+++ b/projector/internal/domain/approval/translator_test.go
@@ -386,6 +386,67 @@ var _ = Describe("Approval Translator", func() {
 		})
 	})
 
+	Describe("AvailableTransitions filtering", func() {
+		newObj := func(transitions approvalv1.AvailableTransitions) *approvalv1.Approval {
+			return &approvalv1.Approval{
+				ObjectMeta: metav1.ObjectMeta{Name: "a", Namespace: "ns"},
+				Spec: approvalv1.ApprovalSpec{
+					Action:   "subscribe",
+					Strategy: approvalv1.ApprovalStrategySimple,
+					State:    approvalv1.ApprovalStateGranted,
+					Target: ctypes.TypedObjectRef{
+						TypeMeta:  metav1.TypeMeta{Kind: "ApiSubscription"},
+						ObjectRef: ctypes.ObjectRef{Name: "sub"},
+					},
+					Requester: approvalv1.Requester{TeamName: "t"},
+					Decider:   approvalv1.Decider{TeamName: "d"},
+				},
+				Status: approvalv1.ApprovalStatus{
+					AvailableTransitions: transitions,
+				},
+			}
+		}
+
+		It("should filter out Expired transitions", func() {
+			obj := newObj(approvalv1.AvailableTransitions{
+				{Action: approvalv1.ApprovalActionSuspend, To: approvalv1.ApprovalStateSuspended},
+				{Action: approvalv1.ApprovalActionExpire, To: approvalv1.ApprovalStateExpired},
+				{Action: approvalv1.ApprovalActionDeny, To: approvalv1.ApprovalStateRejected},
+			})
+
+			data, err := t.Translate(context.Background(), obj)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(data.AvailableTransitions).To(HaveLen(2))
+			Expect(data.AvailableTransitions).To(ConsistOf(
+				model.AvailableTransition{Action: "Suspend", ToState: "Suspended"},
+				model.AvailableTransition{Action: "Deny", ToState: "Rejected"},
+			))
+		})
+
+		It("should return empty slice when only Expired is available", func() {
+			obj := newObj(approvalv1.AvailableTransitions{
+				{Action: approvalv1.ApprovalActionExpire, To: approvalv1.ApprovalStateExpired},
+			})
+
+			data, err := t.Translate(context.Background(), obj)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(data.AvailableTransitions).To(Equal([]model.AvailableTransition{}))
+		})
+
+		It("should pass through non-Expired transitions unchanged", func() {
+			obj := newObj(approvalv1.AvailableTransitions{
+				{Action: approvalv1.ApprovalActionSuspend, To: approvalv1.ApprovalStateSuspended},
+			})
+
+			data, err := t.Translate(context.Background(), obj)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(data.AvailableTransitions).To(HaveLen(1))
+			Expect(data.AvailableTransitions[0]).To(Equal(
+				model.AvailableTransition{Action: "Suspend", ToState: "Suspended"},
+			))
+		})
+	})
+
 	Describe("KeyFromObject", func() {
 		It("should derive all key fields from the live object", func() {
 			obj := &approvalv1.Approval{


### PR DESCRIPTION
The 'Expired' state of an approval is internal and has special logic. Currently we do not want to make the transition into Expired visible to the CP API consumers and thus projector filters it out