### PR TITLE
ci: splitting the single gomod Dependabot update definition

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,34 +21,61 @@ updates:
       - application/api
       - approval
       - approval/api
+      - cpapi/api
+    groups:
+      minor-patch:
+        update-types:
+          - patch
+          - minor
+  - package-ecosystem: "gomod"
+    schedule:
+      interval: "monthly"
+    directories:
       - common
       - common-server
       - controlplane-api
-      - cpapi/api
       - discovery-server
       - event
       - event/api
       - file-manager
+      - projector
+      - secret-manager
+    groups:
+      minor-patch:
+        update-types:
+          - patch
+          - minor
+  - package-ecosystem: "gomod"
+    schedule:
+      interval: "monthly"
+    directories:
       - gateway
       - gateway/api
       - identity
       - identity/api
+      - notification
+      - notification/api
       - organization
       - organization/api
+      - permission
+      - permission/api
+    groups:
+      minor-patch:
+        update-types:
+          - patch
+          - minor
+  - package-ecosystem: "gomod"
+    schedule:
+      interval: "monthly"
+    directories:
       - pubsub
       - pubsub/api
       - rover
       - rover/api
       - rover-ctl
       - rover-server
-      - secret-manager
       - tools/route-tester
       - tools/snapshotter
-      - notification
-      - notification/api
-      - projector
-      - permission
-      - permission/api
     groups:
       minor-patch:
         update-types:


### PR DESCRIPTION
splitting the single gomod Dependabot update definition into 4 smaller gomod update blocks 
(all still monthly, all still using the same minor-patch grouping)