### PR TITLE
feat: harden deployment config especially securityContext

### DIFF
--- a/admin/config/manager/manager.yaml
+++ b/admin/config/manager/manager.yaml
@@ -85,7 +85,7 @@ spec:
               cpu: 500m
               memory: 128Mi
             requests:
-              cpu: 10m
+              cpu: 30m
               memory: 64Mi
           volumeMounts: []
       volumes: []

--- a/admin/config/manager/manager.yaml
+++ b/admin/config/manager/manager.yaml
@@ -52,8 +52,8 @@ spec:
         # More info: https://kubernetes.io/docs/concepts/security/pod-security-standards/#restricted
         # Please uncomment the following code if your project does NOT have to work on old Kubernetes
         # versions < 1.19 or on vendors versions which do NOT support this field by default (i.e. Openshift < 4.11 ).
-        # seccompProfile:
-        #   type: RuntimeDefault
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - args:
             - --leader-elect

--- a/admin/config/manager/manager.yaml
+++ b/admin/config/manager/manager.yaml
@@ -47,11 +47,8 @@ spec:
       #               - linux
       securityContext:
         runAsNonRoot: true
-        # TODO(user): For common cases that do not require escalating privileges
-        # it is recommended to ensure that all your Pods/Containers are restrictive.
+        # Requires Kubernetes >= 1.19 or OpenShift >= 4.11.
         # More info: https://kubernetes.io/docs/concepts/security/pod-security-standards/#restricted
-        # Please uncomment the following code if your project does NOT have to work on old Kubernetes
-        # versions < 1.19 or on vendors versions which do NOT support this field by default (i.e. Openshift < 4.11 ).
         seccompProfile:
           type: RuntimeDefault
       containers:

--- a/api/config/manager/manager.yaml
+++ b/api/config/manager/manager.yaml
@@ -45,11 +45,8 @@ spec:
       #               - linux
       securityContext:
         runAsNonRoot: true
-        # TODO(user): For common cases that do not require escalating privileges
-        # it is recommended to ensure that all your Pods/Containers are restrictive.
+        # Requires Kubernetes >= 1.19 or OpenShift >= 4.11.
         # More info: https://kubernetes.io/docs/concepts/security/pod-security-standards/#restricted
-        # Please uncomment the following code if your project does NOT have to work on old Kubernetes
-        # versions < 1.19 or on vendors versions which do NOT support this field by default (i.e. Openshift < 4.11 ).
         seccompProfile:
           type: RuntimeDefault
       containers:

--- a/api/config/manager/manager.yaml
+++ b/api/config/manager/manager.yaml
@@ -82,7 +82,7 @@ spec:
               cpu: 500m
               memory: 128Mi
             requests:
-              cpu: 10m
+              cpu: 30m
               memory: 64Mi
       serviceAccountName: controller-manager
       terminationGracePeriodSeconds: 10

--- a/api/config/manager/manager.yaml
+++ b/api/config/manager/manager.yaml
@@ -50,8 +50,8 @@ spec:
         # More info: https://kubernetes.io/docs/concepts/security/pod-security-standards/#restricted
         # Please uncomment the following code if your project does NOT have to work on old Kubernetes
         # versions < 1.19 or on vendors versions which do NOT support this field by default (i.e. Openshift < 4.11 ).
-        # seccompProfile:
-        #   type: RuntimeDefault
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - args:
             - --leader-elect

--- a/application/config/manager/manager.yaml
+++ b/application/config/manager/manager.yaml
@@ -85,7 +85,7 @@ spec:
               cpu: 500m
               memory: 128Mi
             requests:
-              cpu: 10m
+              cpu: 30m
               memory: 64Mi
           volumeMounts: []
       volumes: []

--- a/application/config/manager/manager.yaml
+++ b/application/config/manager/manager.yaml
@@ -52,8 +52,8 @@ spec:
         # More info: https://kubernetes.io/docs/concepts/security/pod-security-standards/#restricted
         # Please uncomment the following code if your project does NOT have to work on old Kubernetes
         # versions < 1.19 or on vendors versions which do NOT support this field by default (i.e. Openshift < 4.11 ).
-        # seccompProfile:
-        #   type: RuntimeDefault
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - args:
             - --leader-elect

--- a/application/config/manager/manager.yaml
+++ b/application/config/manager/manager.yaml
@@ -47,11 +47,8 @@ spec:
       #               - linux
       securityContext:
         runAsNonRoot: true
-        # TODO(user): For common cases that do not require escalating privileges
-        # it is recommended to ensure that all your Pods/Containers are restrictive.
+        # Requires Kubernetes >= 1.19 or OpenShift >= 4.11.
         # More info: https://kubernetes.io/docs/concepts/security/pod-security-standards/#restricted
-        # Please uncomment the following code if your project does NOT have to work on old Kubernetes
-        # versions < 1.19 or on vendors versions which do NOT support this field by default (i.e. Openshift < 4.11 ).
         seccompProfile:
           type: RuntimeDefault
       containers:

--- a/approval/config/manager/manager.yaml
+++ b/approval/config/manager/manager.yaml
@@ -84,7 +84,7 @@ spec:
               cpu: 500m
               memory: 128Mi
             requests:
-              cpu: 10m
+              cpu: 30m
               memory: 64Mi
       serviceAccountName: controller-manager
       terminationGracePeriodSeconds: 10

--- a/controlplane-api/config/manager/manager.yaml
+++ b/controlplane-api/config/manager/manager.yaml
@@ -84,7 +84,7 @@ spec:
               cpu: 500m
               memory: 128Mi
             requests:
-              cpu: 10m
+              cpu: 30m
               memory: 32Mi
           volumeMounts:
             - name: controlplane-api-config

--- a/controlplane-api/config/manager/manager.yaml
+++ b/controlplane-api/config/manager/manager.yaml
@@ -41,6 +41,8 @@ spec:
         runAsGroup: 65534
         runAsNonRoot: true
         runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: manager
           args:

--- a/discovery-server/config/server/server.yaml
+++ b/discovery-server/config/server/server.yaml
@@ -25,6 +25,8 @@ spec:
     spec:
       securityContext:
         runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - args: []
           env: []

--- a/discovery-server/config/server/server.yaml
+++ b/discovery-server/config/server/server.yaml
@@ -55,7 +55,7 @@ spec:
               cpu: 500m
               memory: 128Mi
             requests:
-              cpu: 10m
+              cpu: 30m
               memory: 64Mi
           volumeMounts:
             - name: db-data

--- a/event/config/manager/manager.yaml
+++ b/event/config/manager/manager.yaml
@@ -84,7 +84,7 @@ spec:
             cpu: 500m
             memory: 128Mi
           requests:
-            cpu: 10m
+            cpu: 30m
             memory: 64Mi
         volumeMounts: []
       volumes: []

--- a/file-manager/config/manager/manager.yaml
+++ b/file-manager/config/manager/manager.yaml
@@ -79,7 +79,7 @@ spec:
               cpu: 500m
               memory: 128Mi
             requests:
-              cpu: 10m
+              cpu: 30m
               memory: 32Mi
           volumeMounts:
             - name: file-manager-config

--- a/file-manager/config/manager/manager.yaml
+++ b/file-manager/config/manager/manager.yaml
@@ -39,6 +39,8 @@ spec:
         runAsGroup: 65534
         runAsNonRoot: true
         runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: manager
           args:

--- a/gateway/config/manager/manager.yaml
+++ b/gateway/config/manager/manager.yaml
@@ -82,7 +82,7 @@ spec:
             cpu: 500m
             memory: 128Mi
           requests:
-            cpu: 10m
+            cpu: 30m
             memory: 64Mi
         volumeMounts: []
       serviceAccountName: controller-manager

--- a/gateway/config/manager/manager.yaml
+++ b/gateway/config/manager/manager.yaml
@@ -45,11 +45,8 @@ spec:
       #               - linux
       securityContext:
         runAsNonRoot: true
-        # TODO(user): For common cases that do not require escalating privileges
-        # it is recommended to ensure that all your Pods/Containers are restrictive.
+        # Requires Kubernetes >= 1.19 or OpenShift >= 4.11.
         # More info: https://kubernetes.io/docs/concepts/security/pod-security-standards/#restricted
-        # Please uncomment the following code if your project does NOT have to work on old Kubernetes
-        # versions < 1.19 or on vendors versions which do NOT support this field by default (i.e. Openshift < 4.11 ).
         seccompProfile:
           type: RuntimeDefault
       containers:

--- a/gateway/config/manager/manager.yaml
+++ b/gateway/config/manager/manager.yaml
@@ -50,8 +50,8 @@ spec:
         # More info: https://kubernetes.io/docs/concepts/security/pod-security-standards/#restricted
         # Please uncomment the following code if your project does NOT have to work on old Kubernetes
         # versions < 1.19 or on vendors versions which do NOT support this field by default (i.e. Openshift < 4.11 ).
-        # seccompProfile:
-        #   type: RuntimeDefault
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - args:
           - --leader-elect

--- a/identity/config/manager/manager.yaml
+++ b/identity/config/manager/manager.yaml
@@ -82,7 +82,7 @@ spec:
             cpu: 500m
             memory: 128Mi
           requests:
-            cpu: 10m
+            cpu: 30m
             memory: 64Mi
         volumeMounts: []
       serviceAccountName: controller-manager

--- a/identity/config/manager/manager.yaml
+++ b/identity/config/manager/manager.yaml
@@ -45,11 +45,8 @@ spec:
       #               - linux
       securityContext:
         runAsNonRoot: true
-        # TODO(user): For common cases that do not require escalating privileges
-        # it is recommended to ensure that all your Pods/Containers are restrictive.
+        # Requires Kubernetes >= 1.19 or OpenShift >= 4.11.
         # More info: https://kubernetes.io/docs/concepts/security/pod-security-standards/#restricted
-        # Please uncomment the following code if your project does NOT have to work on old Kubernetes
-        # versions < 1.19 or on vendors versions which do NOT support this field by default (i.e. Openshift < 4.11 ).
         seccompProfile:
           type: RuntimeDefault
       containers:

--- a/identity/config/manager/manager.yaml
+++ b/identity/config/manager/manager.yaml
@@ -50,8 +50,8 @@ spec:
         # More info: https://kubernetes.io/docs/concepts/security/pod-security-standards/#restricted
         # Please uncomment the following code if your project does NOT have to work on old Kubernetes
         # versions < 1.19 or on vendors versions which do NOT support this field by default (i.e. Openshift < 4.11 ).
-        # seccompProfile:
-        #   type: RuntimeDefault
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - args:
           - --leader-elect

--- a/install/components/database/postgres.yaml
+++ b/install/components/database/postgres.yaml
@@ -57,7 +57,10 @@ spec:
       securityContext:
         fsGroup: 999
         runAsGroup: 999
+        runAsNonRoot: true
         runAsUser: 999
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: postgres
           image: postgres:16-alpine

--- a/install/components/database/postgres.yaml
+++ b/install/components/database/postgres.yaml
@@ -64,6 +64,15 @@ spec:
       containers:
         - name: postgres
           image: postgres:16-alpine
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            privileged: false
+            runAsGroup: 999
+            runAsNonRoot: true
+            runAsUser: 999
           env:
             - name: POSTGRES_DB
               value: controlplane

--- a/install/components/database/postgres.yaml
+++ b/install/components/database/postgres.yaml
@@ -54,6 +54,7 @@ spec:
         app.kubernetes.io/name: controlplane-postgres
         app.kubernetes.io/component: database
     spec:
+      automountServiceAccountToken: false
       securityContext:
         fsGroup: 999
         runAsGroup: 999

--- a/install/components/mailpit/mailpit.yaml
+++ b/install/components/mailpit/mailpit.yaml
@@ -40,9 +40,19 @@ spec:
         app.kubernetes.io/name: mailpit
         app.kubernetes.io/component: mail
     spec:
+      securityContext:
+        runAsUser: 1000
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: mailpit
           image: axllent/mailpit:latest
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - "ALL"
           ports:
             - name: smtp
               containerPort: 1025

--- a/notification/config/manager/manager.yaml
+++ b/notification/config/manager/manager.yaml
@@ -80,7 +80,7 @@ spec:
             cpu: 500m
             memory: 128Mi
           requests:
-            cpu: 10m
+            cpu: 30m
             memory: 64Mi
         volumeMounts: []
       volumes: []

--- a/organization/config/manager/manager.yaml
+++ b/organization/config/manager/manager.yaml
@@ -83,7 +83,7 @@ spec:
               cpu: 500m
               memory: 128Mi
             requests:
-              cpu: 10m
+              cpu: 30m
               memory: 64Mi
           volumeMounts: []
       volumes: []

--- a/permission/config/manager/manager.yaml
+++ b/permission/config/manager/manager.yaml
@@ -84,7 +84,7 @@ spec:
             cpu: 500m
             memory: 128Mi
           requests:
-            cpu: 10m
+            cpu: 30m
             memory: 64Mi
         volumeMounts: []
       volumes: []

--- a/projector/config/manager/manager.yaml
+++ b/projector/config/manager/manager.yaml
@@ -61,7 +61,7 @@ spec:
               cpu: 500m
               memory: 256Mi
             requests:
-              cpu: 10m
+              cpu: 30m
               memory: 128Mi
       serviceAccountName: projector-controller-manager
       terminationGracePeriodSeconds: 10

--- a/pubsub/config/manager/manager.yaml
+++ b/pubsub/config/manager/manager.yaml
@@ -84,7 +84,7 @@ spec:
             cpu: 500m
             memory: 128Mi
           requests:
-            cpu: 10m
+            cpu: 30m
             memory: 64Mi
         volumeMounts: []
       volumes: []

--- a/rover-server/config/server/server.yaml
+++ b/rover-server/config/server/server.yaml
@@ -25,6 +25,8 @@ spec:
     spec:
       securityContext:
         runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - args: []
           env: []

--- a/rover-server/config/server/server.yaml
+++ b/rover-server/config/server/server.yaml
@@ -55,7 +55,7 @@ spec:
               cpu: 500m
               memory: 128Mi
             requests:
-              cpu: 10m
+              cpu: 30m
               memory: 64Mi
           volumeMounts:
             - name: db-data

--- a/rover/config/manager/manager.yaml
+++ b/rover/config/manager/manager.yaml
@@ -87,7 +87,7 @@ spec:
               cpu: 500m
               memory: 128Mi
             requests:
-              cpu: 10m
+              cpu: 30m
               memory: 64Mi
           volumeMounts: []
       volumes: []

--- a/rover/config/manager/manager.yaml
+++ b/rover/config/manager/manager.yaml
@@ -52,8 +52,8 @@ spec:
         # More info: https://kubernetes.io/docs/concepts/security/pod-security-standards/#restricted
         # Please uncomment the following code if your project does NOT have to work on old Kubernetes
         # versions < 1.19 or on vendors versions which do NOT support this field by default (i.e. Openshift < 4.11 ).
-        # seccompProfile:
-        #   type: RuntimeDefault
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - args:
             - --leader-elect

--- a/rover/config/manager/manager.yaml
+++ b/rover/config/manager/manager.yaml
@@ -47,11 +47,8 @@ spec:
       #               - linux
       securityContext:
         runAsNonRoot: true
-        # TODO(user): For common cases that do not require escalating privileges
-        # it is recommended to ensure that all your Pods/Containers are restrictive.
+        # Requires Kubernetes >= 1.19 or OpenShift >= 4.11.
         # More info: https://kubernetes.io/docs/concepts/security/pod-security-standards/#restricted
-        # Please uncomment the following code if your project does NOT have to work on old Kubernetes
-        # versions < 1.19 or on vendors versions which do NOT support this field by default (i.e. Openshift < 4.11 ).
         seccompProfile:
           type: RuntimeDefault
       containers:

--- a/secret-manager/config/manager/manager.yaml
+++ b/secret-manager/config/manager/manager.yaml
@@ -39,6 +39,8 @@ spec:
         runAsGroup: 65534
         runAsNonRoot: true
         runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: manager
           args:

--- a/secret-manager/config/manager/manager.yaml
+++ b/secret-manager/config/manager/manager.yaml
@@ -79,7 +79,7 @@ spec:
               cpu: 500m
               memory: 128Mi
             requests:
-              cpu: 10m
+              cpu: 30m
               memory: 32Mi
           volumeMounts:
             - name: secret-manager-config


### PR DESCRIPTION
Integrate learnings from cluster policies on the platform:
- Set "resources.requests.cpu" to be 30m minimum (from 10m before)
- Apply the dedicated-non-prod securityContext hardening to implementation manifests by enabling seccompProfile RuntimeDefault on remaining deployments and adding additions for postgres and mailpit