### PR TITLE
fix: improve failover handling; add mesh-flag to routing-config

### DIFF
--- a/api/internal/handler/apiexposure/handler.go
+++ b/api/internal/handler/apiexposure/handler.go
@@ -82,6 +82,10 @@ func (h *ApiExposureHandler) CreateOrUpdate(ctx context.Context, apiExp *apiapi.
 		return nil
 	}
 
+	if !validateFailover(ctx, apiExp) {
+		return nil
+	}
+
 	// --- Route Provisioning Pipeline ---
 
 	// 1. Determine routing state (subscribers, flags, exposure zone)
@@ -107,90 +111,6 @@ func (h *ApiExposureHandler) CreateOrUpdate(ctx context.Context, apiExp *apiapi.
 	logger.Info("✅ ApiExposure is processed")
 
 	return nil
-}
-
-// ──────────────────────────────────────────────────────────────────────────────
-// Route Provisioning Pipeline
-// ──────────────────────────────────────────────────────────────────────────────
-//
-// The route provisioning pipeline runs in three steps:
-//
-//  1. determineRoutingState — fetches subscribers and zone data, derives flags.
-//  2. manageProxyRoutes    — creates proxy routes, collects consumer failover enrichment.
-//  3. createRealRoute      — creates the real route using the enriched state.
-//
-// All steps share a single routingState instance to avoid redundant API calls
-// and make the data flow between steps explicit.
-
-// routingState holds pre-computed data used across the route provisioning pipeline.
-//
-// The distinction between "consumer failover" and "provider failover" is important:
-//   - Consumer failover (a.k.a. DTC/DNS failover): all proxy routes AND the real route are
-//     enriched with additional hostnames and IDP issuers from ALL zones that have the
-//     ConsumerFailover feature enabled. This allows external DNS to switch consumers
-//     between zone gateways transparently.
-//   - Provider failover: creates a secondary route in a backup zone with the provider's
-//     upstreams, allowing traffic to be served from a different zone if the provider fails.
-//     Managed separately via WithFailoverUpstreams/WithFailoverSecurity.
-type routingState struct {
-	// ──────────────────────────────────────────────────────────────────────────
-	// Determined up front by determineRoutingState
-	// ──────────────────────────────────────────────────────────────────────────
-
-	// realmName is the environment/realm name used for token validation on all routes.
-	realmName string
-
-	// subscribers is the full list of approved, non-deleted ApiSubscriptions for this exposure.
-	// Used to determine which zones need proxy routes and whether consumer failover is active.
-	subscribers []*apiapi.ApiSubscription
-
-	// hasCrossZoneSubs is true if at least one subscriber is in a different zone than the exposure.
-	// Drives: real route gets GatewayConsumerName in DefaultConsumers (mesh-client access).
-	hasCrossZoneSubs bool
-
-	// hasLocalSubs is true if at least one subscriber is in the same zone as the exposure.
-	// Drives: real route trusts the exposure zone's own IDP issuer (direct consumer access).
-	hasLocalSubs bool
-
-	// hasConsumerFailover is true if at least one subscriber has consumer failover configured.
-	// When true, ALL proxy routes and the real route are enriched with failover hostnames/issuers.
-	hasConsumerFailover bool
-
-	// exposureZone is the Zone object where the API is exposed (provider zone).
-	// Used to read the zone's IDP issuer and to identify which zone is "self" in the failover loop.
-	exposureZone *adminv1.Zone
-
-	// ──────────────────────────────────────────────────────────────────────────
-	// Consumer failover enrichment — produced by manageProxyRoutes
-	// Applied to ALL proxy routes AND the real route.
-	// Collected from every zone that has the ConsumerFailover feature enabled
-	// (including the exposure zone itself).
-	// ──────────────────────────────────────────────────────────────────────────
-
-	// consumerFailoverHosts are the hostnames from the ConsumerFailover gateway presets of all
-	// eligible zones. Added as additional hostnames so that any zone's gateway can accept
-	// traffic for any other zone's failover hostname after a DNS switch.
-	consumerFailoverHosts []string
-
-	// consumerFailoverPaths are the paths from the ConsumerFailover gateway presets of all
-	// eligible zones. Added alongside consumerFailoverHosts.
-	consumerFailoverPaths []string
-
-	// consumerFailoverIssuers are the IDP issuers from all eligible zones.
-	// Added as trusted issuers so that when a consumer fails over to a different zone's
-	// gateway, the route can validate the consumer's home-zone IDP token directly.
-	consumerFailoverIssuers []string
-
-	// ──────────────────────────────────────────────────────────────────────────
-	// Mesh trust — produced by manageProxyRoutes
-	// Only for the real route. NOT related to consumer failover.
-	// ──────────────────────────────────────────────────────────────────────────
-
-	// crossZoneLmsIssuers are the LMS (Last-Mile-Security) issuers from all non-exposure
-	// zones that have proxy routes. The real route must trust these because proxy gateways
-	// in other zones stamp an LMS token before forwarding traffic to the provider zone.
-	// This is a mesh concern, not a consumer failover concern.
-	crossZoneLmsIssuers []string
 }
 
 // determineRoutingState fetches and pre-computes all data needed for route provisioning.
@@ -246,6 +166,8 @@ func (h *ApiExposureHandler) manageProxyRoutes(ctx context.Context, apiExp *apia
 
 	// Build the set of zones that need a proxy route.
 	// Starts with cross-zone subscriber zones, then extended by consumer failover zones.
+
+	logger.V(1).Info("collecting cross zone subscribers", "subs", len(state.subscribers))
 	allRelevantZones := h.collectCrossZoneSubscriberZones(apiExp, state)
 
 	// --- Consumer failover: collect enrichment data from all eligible zones ---
@@ -257,26 +179,43 @@ func (h *ApiExposureHandler) manageProxyRoutes(ctx context.Context, apiExp *apia
 		if err != nil {
 			return err
 		}
+	} else {
+		logger.V(1).Info("Consumer failover is not enabled for any subscriber")
 	}
 
 	// --- Collect LMS issuers from all cross-zone proxy route zones ---
 	// Proxy gateways stamp an LMS token before forwarding traffic to the provider zone,
 	// so the real route must trust the LMS issuer of every zone that has a proxy route.
 	scopedClient := cclient.ClientFromContextOrDie(ctx)
-	for _, zoneRef := range allRelevantZones {
-		z, err := util.GetZone(ctx, scopedClient, zoneRef.K8s())
-		if err != nil {
-			return errors.Wrapf(err, "failed to get zone %s for LMS issuer collection", zoneRef.Name)
-		}
-		if z.Status.Links.LmsIssuer != "" {
-			state.crossZoneLmsIssuers = append(state.crossZoneLmsIssuers, z.Status.Links.LmsIssuer)
-		}
-	}
 
 	// --- Create proxy routes ---
 	apiExp.Status.ProxyRoutes = nil
 
 	for _, subscriberZoneRef := range allRelevantZones {
+		subscriberZone, err := util.GetZone(ctx, scopedClient, subscriberZoneRef.K8s())
+		if err != nil {
+			return errors.Wrapf(err, "failed to get zone %s for LMS issuer collection", subscriberZoneRef.Name)
+		}
+		if subscriberZone.Status.Links.LmsIssuer != "" {
+			state.AddCrossZoneLmsIssuer(subscriberZoneRef, subscriberZone.Status.Links.LmsIssuer)
+		}
+
+		if subscriberZoneRef.Equals(&apiExp.Spec.Zone) {
+			logger.V(1).Info("Skipping proxy route creation for exposure zone itself", "zone", subscriberZoneRef.Name)
+			continue
+		}
+		if apiExp.HasFailover() {
+			alreadySecondaryRoute := slices.ContainsFunc(apiExp.Spec.Traffic.Failover.Zones, func(failoverZone types.ObjectRef) bool {
+				return failoverZone.Equals(&subscriberZoneRef)
+			})
+			if alreadySecondaryRoute {
+				logger.V(1).Info("Skipping proxy route creation for zone that is already a provider failover zone (secondary)", "zone", subscriberZoneRef.Name)
+				continue
+			}
+		}
+
+		logger.V(1).Info("Creating/updating proxy route for subscriber zone", "zone", subscriberZoneRef.Name)
+
 		options := []util.CreateRouteOption{
 			util.WithRealmName(state.realmName),
 		}
@@ -291,7 +230,8 @@ func (h *ApiExposureHandler) manageProxyRoutes(ctx context.Context, apiExp *apia
 		}
 
 		// Consumer failover enrichment: add all failover hostnames, paths, and IDP issuers
-		if state.hasConsumerFailover {
+		// We need to check if the subscriber zone has the consumer failover feature enabled
+		if state.hasConsumerFailover && subscriberZone.IsFeatureEnabled(adminv1.FeatureConsumerFailover) {
 			options = append(options,
 				util.WithAdditionalHostnames(state.consumerFailoverHosts...),
 				util.WithAdditionalPaths(state.consumerFailoverPaths...),
@@ -312,12 +252,36 @@ func (h *ApiExposureHandler) manageProxyRoutes(ctx context.Context, apiExp *apia
 	apiExp.Status.FailoverRoutes = nil
 	if apiExp.HasFailover() {
 		for _, failoverZone := range apiExp.Spec.Traffic.Failover.Zones {
-			failoverRoute, err := util.CreateProxyRoute(ctx, failoverZone, apiExp.Spec.Zone, apiExp.Spec.ApiBasePath,
+			providerFailoverZone, err := util.GetZone(ctx, scopedClient, failoverZone.K8s())
+			if err != nil {
+				if !apierrors.IsNotFound(err) {
+					return errors.Wrapf(err, "failed to get provider failover zone %q for apiExposure", failoverZone.Name)
+				}
+				return ctrlerrors.BlockedErrorf("Provider failover zone %q does not exist", failoverZone.Name)
+			}
+
+			options := []util.CreateRouteOption{
+				util.WithRealmName(state.realmName),
+			}
+
+			// If the provider failover zone has the ConsumerFailover feature enabled, enrich the failover route with all consumer failover hostnames, paths, and issuers.
+			// This is necessary because we skipped the route creation in the previous loop.
+			// We need to check this explicitly as consumer-failover-zones and provider-failover-zones could be disjoint sets.
+			if state.hasConsumerFailover && providerFailoverZone.IsFeatureEnabled(adminv1.FeatureConsumerFailover) {
+				options = append(options,
+					util.WithAdditionalHostnames(state.consumerFailoverHosts...),
+					util.WithAdditionalPaths(state.consumerFailoverPaths...),
+					util.WithTrustedIssuers(state.consumerFailoverIssuers),
+				)
+			}
+
+			options = append(options,
 				util.WithFailoverUpstreams(apiExp.Spec.Upstreams...),
 				util.WithFailoverSecurity(apiExp.Spec.Security),
-				util.WithTrustedIssuers(state.crossZoneLmsIssuers),
-				util.WithRealmName(state.realmName),
+				util.AddTrustedIssuers(state.CrossZoneLmsIssuers(failoverZone)...),
 			)
+
+			failoverRoute, err := util.CreateProxyRoute(ctx, failoverZone, apiExp.Spec.Zone, apiExp.Spec.ApiBasePath, options...)
 			if err != nil {
 				return errors.Wrapf(err, "unable to create failover route for apiExposure: %s in zone: %s", apiExp.Name, failoverZone.Name)
 			}
@@ -347,16 +311,8 @@ func (h *ApiExposureHandler) collectCrossZoneSubscriberZones(apiExp *apiapi.ApiE
 		if sub.Spec.Zone.Equals(&apiExp.Spec.Zone) {
 			continue
 		}
-		if apiExp.HasFailover() {
-			alreadySecondaryRoute := slices.ContainsFunc(apiExp.Spec.Traffic.Failover.Zones, func(failoverZone types.ObjectRef) bool {
-				return failoverZone.Equals(&sub.Spec.Zone)
-			})
-			if alreadySecondaryRoute {
-				continue
-			}
-		}
 
-		if !slices.Contains(zones, sub.Spec.Zone) {
+		if !slices.ContainsFunc(zones, func(z types.ObjectRef) bool { return z.Equals(&sub.Spec.Zone) }) {
 			zones = append(zones, sub.Spec.Zone)
 		}
 	}
@@ -379,17 +335,9 @@ func (h *ApiExposureHandler) collectConsumerFailoverEnrichment(ctx context.Conte
 		logger.Info("No zones with consumer failover feature enabled found, skipping failover configuration")
 		return allRelevantZones, nil
 	}
+	logger.V(1).Info("Collecting consumer failover enrichment from eligible zones", "count", len(availableFailoverZones))
 
 	for _, zone := range availableFailoverZones {
-		if apiExp.HasFailover() {
-			alreadySecondaryRoute := slices.ContainsFunc(apiExp.Spec.Traffic.Failover.Zones, func(failoverZone types.ObjectRef) bool {
-				return failoverZone.Equals(zone)
-			})
-			if alreadySecondaryRoute {
-				continue
-			}
-		}
-
 		preset, err := zone.SelectGatewayPreset(adminv1.FeatureConsumerFailover)
 		if err != nil {
 			return nil, ctrlerrors.BlockedErrorf("Zone %q does not have a gateway preset with consumer failover feature enabled", zone.Name)
@@ -401,11 +349,12 @@ func (h *ApiExposureHandler) collectConsumerFailoverEnrichment(ctx context.Conte
 		state.consumerFailoverIssuers = append(state.consumerFailoverIssuers, zone.Status.Links.Issuer)
 
 		if apiExp.Spec.Zone.Equals(zone) {
+			// return here to avoid adding the exposure zone itself to the list of allRelevantZones, which is only for proxy routes
 			continue
 		}
 
 		objRef := types.ObjectRefFromObject(zone)
-		if !slices.Contains(allRelevantZones, *objRef) {
+		if !slices.ContainsFunc(allRelevantZones, func(z types.ObjectRef) bool { return z.Equals(objRef) }) {
 			allRelevantZones = append(allRelevantZones, *objRef)
 		}
 	}
@@ -430,18 +379,26 @@ func (h *ApiExposureHandler) createRealRoute(ctx context.Context, apiExp *apiapi
 		util.WithProxyTarget(state.hasCrossZoneSubs),
 	}
 
+	// The exposure zone only participates in the consumer failover pool if it has the
+	// feature enabled. Only then may its real route accept other
+	// zones' failover hostnames and trust their home-zone IDP issuers directly. Mirrors the
+	// per-zone gating applied to proxy/provider-failover routes in manageProxyRoutes.
+	exposureZoneHasFailover := state.exposureZone.IsFeatureEnabled(adminv1.FeatureConsumerFailover)
+
 	// Build TrustedIssuers for the real route
 	var trustedIssuers []string
 	if state.hasLocalSubs && state.exposureZone.Status.Links.Issuer != "" {
 		trustedIssuers = append(trustedIssuers, state.exposureZone.Status.Links.Issuer)
 	}
-	trustedIssuers = append(trustedIssuers, state.crossZoneLmsIssuers...)
-	trustedIssuers = append(trustedIssuers, state.consumerFailoverIssuers...)
+	trustedIssuers = append(trustedIssuers, state.CrossZoneLmsIssuers()...)
+	if exposureZoneHasFailover {
+		trustedIssuers = append(trustedIssuers, state.consumerFailoverIssuers...)
+	}
 	options = append(options, util.WithTrustedIssuers(trustedIssuers))
 
 	// Consumer failover: the real route also gets all failover hostnames/paths so that
 	// consumers failing over directly to the provider zone's gateway can reach it.
-	if len(state.consumerFailoverHosts) > 0 {
+	if exposureZoneHasFailover && len(state.consumerFailoverHosts) > 0 {
 		options = append(options,
 			util.WithAdditionalHostnames(state.consumerFailoverHosts...),
 			util.WithAdditionalPaths(state.consumerFailoverPaths...),
@@ -588,4 +545,20 @@ func validateApiCategoryPolicy(ctx context.Context, api *apiapi.Api, application
 		apiExp.SetCondition(condition.NewBlockedCondition(msg))
 	}
 	return false
+}
+
+func validateFailover(ctx context.Context, apiExp *apiapi.ApiExposure) bool {
+	if !apiExp.HasFailover() {
+		return true
+	}
+
+	for _, failoverZone := range apiExp.Spec.Traffic.Failover.Zones {
+		if failoverZone.Equals(&apiExp.Spec.Zone) {
+			msg := fmt.Sprintf("cannot use the same zone %q as both primary and failover zone for apiExposure: %s", failoverZone.Name, apiExp.Name)
+			apiExp.SetCondition(condition.NewNotReadyCondition(condition.ReasonPreconditionNotMet, msg))
+			apiExp.SetCondition(condition.NewBlockedCondition(msg))
+			return false
+		}
+	}
+	return true
 }

--- a/api/internal/handler/apiexposure/handler.go
+++ b/api/internal/handler/apiexposure/handler.go
@@ -82,7 +82,7 @@ func (h *ApiExposureHandler) CreateOrUpdate(ctx context.Context, apiExp *apiapi.
 		return nil
 	}
 
-	if !validateFailover(ctx, apiExp) {
+	if !validateFailover(apiExp) {
 		return nil
 	}
 
@@ -249,45 +249,8 @@ func (h *ApiExposureHandler) manageProxyRoutes(ctx context.Context, apiExp *apia
 	}
 
 	// --- Provider failover (secondary) routes ---
-	apiExp.Status.FailoverRoutes = nil
-	if apiExp.HasFailover() {
-		for _, failoverZone := range apiExp.Spec.Traffic.Failover.Zones {
-			providerFailoverZone, err := util.GetZone(ctx, scopedClient, failoverZone.K8s())
-			if err != nil {
-				if !apierrors.IsNotFound(err) {
-					return errors.Wrapf(err, "failed to get provider failover zone %q for apiExposure", failoverZone.Name)
-				}
-				return ctrlerrors.BlockedErrorf("Provider failover zone %q does not exist", failoverZone.Name)
-			}
-
-			options := []util.CreateRouteOption{
-				util.WithRealmName(state.realmName),
-			}
-
-			// If the provider failover zone has the ConsumerFailover feature enabled, enrich the failover route with all consumer failover hostnames, paths, and issuers.
-			// This is necessary because we skipped the route creation in the previous loop.
-			// We need to check this explicitly as consumer-failover-zones and provider-failover-zones could be disjoint sets.
-			if state.hasConsumerFailover && providerFailoverZone.IsFeatureEnabled(adminv1.FeatureConsumerFailover) {
-				options = append(options,
-					util.WithAdditionalHostnames(state.consumerFailoverHosts...),
-					util.WithAdditionalPaths(state.consumerFailoverPaths...),
-					util.WithTrustedIssuers(state.consumerFailoverIssuers),
-				)
-			}
-
-			options = append(options,
-				util.WithFailoverUpstreams(apiExp.Spec.Upstreams...),
-				util.WithFailoverSecurity(apiExp.Spec.Security),
-				util.AddTrustedIssuers(state.CrossZoneLmsIssuers(failoverZone)...),
-			)
-
-			failoverRoute, err := util.CreateProxyRoute(ctx, failoverZone, apiExp.Spec.Zone, apiExp.Spec.ApiBasePath, options...)
-			if err != nil {
-				return errors.Wrapf(err, "unable to create failover route for apiExposure: %s in zone: %s", apiExp.Name, failoverZone.Name)
-			}
-			apiExp.Status.FailoverRoutes = append(apiExp.Status.FailoverRoutes, *types.ObjectRefFromObject(failoverRoute))
-			logger.V(1).Info("Failover secondary route created/updated", "zone", failoverZone.Name, "route", failoverRoute.Name)
-		}
+	if err := h.createFailoverRoutes(ctx, apiExp, state); err != nil {
+		return err
 	}
 
 	// Cleanup stale proxy routes that were not touched in this reconciliation
@@ -299,6 +262,57 @@ func (h *ApiExposureHandler) manageProxyRoutes(ctx context.Context, apiExp *apia
 		logger.V(1).Info("Cleaned up stale proxy routes", "deleted", deleted)
 	}
 
+	return nil
+}
+
+// createFailoverRoutes creates the provider failover (secondary) routes for each
+// configured failover zone, enriching them with consumer failover data where applicable.
+func (h *ApiExposureHandler) createFailoverRoutes(ctx context.Context, apiExp *apiapi.ApiExposure, state *routingState) error {
+	logger := log.FromContext(ctx)
+	scopedClient := cclient.ClientFromContextOrDie(ctx)
+
+	apiExp.Status.FailoverRoutes = nil
+	if !apiExp.HasFailover() {
+		return nil
+	}
+
+	for _, failoverZone := range apiExp.Spec.Traffic.Failover.Zones {
+		providerFailoverZone, err := util.GetZone(ctx, scopedClient, failoverZone.K8s())
+		if err != nil {
+			if !apierrors.IsNotFound(err) {
+				return errors.Wrapf(err, "failed to get provider failover zone %q for apiExposure", failoverZone.Name)
+			}
+			return ctrlerrors.BlockedErrorf("Provider failover zone %q does not exist", failoverZone.Name)
+		}
+
+		options := []util.CreateRouteOption{
+			util.WithRealmName(state.realmName),
+		}
+
+		// If the provider failover zone has the ConsumerFailover feature enabled, enrich the failover route with all consumer failover hostnames, paths, and issuers.
+		// This is necessary because we skipped the route creation in the previous loop.
+		// We need to check this explicitly as consumer-failover-zones and provider-failover-zones could be disjoint sets.
+		if state.hasConsumerFailover && providerFailoverZone.IsFeatureEnabled(adminv1.FeatureConsumerFailover) {
+			options = append(options,
+				util.WithAdditionalHostnames(state.consumerFailoverHosts...),
+				util.WithAdditionalPaths(state.consumerFailoverPaths...),
+				util.WithTrustedIssuers(state.consumerFailoverIssuers),
+			)
+		}
+
+		options = append(options,
+			util.WithFailoverUpstreams(apiExp.Spec.Upstreams...),
+			util.WithFailoverSecurity(apiExp.Spec.Security),
+			util.AddTrustedIssuers(state.CrossZoneLmsIssuers(failoverZone)...),
+		)
+
+		failoverRoute, err := util.CreateProxyRoute(ctx, failoverZone, apiExp.Spec.Zone, apiExp.Spec.ApiBasePath, options...)
+		if err != nil {
+			return errors.Wrapf(err, "unable to create failover route for apiExposure: %s in zone: %s", apiExp.Name, failoverZone.Name)
+		}
+		apiExp.Status.FailoverRoutes = append(apiExp.Status.FailoverRoutes, *types.ObjectRefFromObject(failoverRoute))
+		logger.V(1).Info("Failover secondary route created/updated", "zone", failoverZone.Name, "route", failoverRoute.Name)
+	}
 	return nil
 }
 
@@ -547,7 +561,7 @@ func validateApiCategoryPolicy(ctx context.Context, api *apiapi.Api, application
 	return false
 }
 
-func validateFailover(ctx context.Context, apiExp *apiapi.ApiExposure) bool {
+func validateFailover(apiExp *apiapi.ApiExposure) bool {
 	if !apiExp.HasFailover() {
 		return true
 	}

--- a/api/internal/handler/apiexposure/handler_test.go
+++ b/api/internal/handler/apiexposure/handler_test.go
@@ -168,10 +168,6 @@ var _ = Describe("ApiExposureHandler", func() {
 			return makeReadyZone("zone-b", "ns-b",
 				"https://idp.zone-b.example.com", "https://lms.zone-b.example.com")
 		}
-		zoneC = func() *adminv1.Zone {
-			return makeReadyZone("zone-c", "ns-c",
-				"https://idp.zone-c.example.com", "https://lms.zone-c.example.com")
-		}
 		zoneF = func() *adminv1.Zone {
 			return makeReadyZone("zone-f", "ns-f",
 				"https://idp.zone-f.example.com", "https://lms.zone-f.example.com")
@@ -399,10 +395,11 @@ var _ = Describe("ApiExposureHandler", func() {
 		// Scenario 2: Consumer failover
 		//
 		// Exposure in zone-a, subscriber in zone-b with HasFailover()=true.
-		// Zones A and C have ConsumerFailover feature enabled with dedicated presets.
-		// Expects: 2 proxy routes (zone-b + zone-c) + 1 real route, all enriched.
-		Context("consumer failover: enriches all routes with failover hostnames and issuers", func() {
-			It("creates enriched proxy routes and a real route with consumer failover data", func() {
+		// Zones A and C have ConsumerFailover feature enabled with dedicated presets; zone-b does not.
+		// Expects: 2 proxy routes (zone-b + zone-c) + 1 real route. Only CF-capable zones (A, C) are
+		// enriched with failover hostnames/issuers; the plain zone-b proxy route is not.
+		Context("consumer failover: enriches only CF-capable zones with failover hostnames and issuers", func() {
+			It("enriches the CF-capable proxy route and the real route, but not the plain subscriber zone", func() {
 				obj := newApiExposure(basePath, zoneARef)
 
 				// --- Preamble ---
@@ -424,8 +421,8 @@ var _ = Describe("ApiExposureHandler", func() {
 				//            downstream-proxy-B(B) + upstream-proxy-B(A) +
 				//            downstream-proxy-C(C) + upstream-proxy-C(A) + real-route(A)
 				mockGetZone(zoneARef.K8s(), zoneACF(), 4) // determineRoutingState + upstream×2 + real route
-				mockGetZone(zoneBRef.K8s(), zoneB(), 2)   // LMS collection + downstream proxy-B
-				mockGetZone(zoneCRef.K8s(), zoneC(), 2)   // LMS collection + downstream proxy-C
+				mockGetZone(zoneBRef.K8s(), zoneB(), 2)   // LMS collection + downstream proxy-B (plain zone, no CF feature)
+				mockGetZone(zoneCRef.K8s(), zoneCCF(), 2) // LMS collection + downstream proxy-C (CF-enabled zone)
 
 				var routes []*gatewayapi.Route
 				capturedRoutes(&routes, 3) // 2 proxy + 1 real
@@ -443,13 +440,13 @@ var _ = Describe("ApiExposureHandler", func() {
 				proxyB := routes[0]
 				Expect(proxyB.Namespace).To(Equal("ns-b"))
 				Expect(proxyB.Spec.Type).To(Equal(gatewayapi.RouteTypeProxy))
-				// Enriched with consumer failover hostnames
-				Expect(proxyB.Spec.Hostnames).To(ContainElements("zone-a.cf.example.com", "zone-c.cf.example.com"))
-				// Proxy route trusts downstream IDP + consumer failover IDP issuers
+				// zone-b lacks the ConsumerFailover feature, so its proxy route is NOT enriched
+				// with failover hostnames — it cannot serve hostnames it has no gateway preset for.
+				Expect(proxyB.Spec.Hostnames).To(ContainElement("zone-b.gw.example.com"))
+				Expect(proxyB.Spec.Hostnames).ToNot(ContainElements("zone-a.cf.example.com", "zone-c.cf.example.com"))
+				// Proxy route trusts only its own downstream IDP issuer
 				Expect(proxyB.Spec.Security.TrustedIssuers).To(ConsistOf(
 					"https://idp.zone-b.example.com", // downstream zone's own issuer
-					"https://idp.zone-a.example.com", // consumer failover from zone-a
-					"https://idp.zone-c.example.com", // consumer failover from zone-c
 				))
 
 				// Proxy route for zone-c (index 1)
@@ -520,7 +517,7 @@ var _ = Describe("ApiExposureHandler", func() {
 				//            real-route(A)
 				mockGetZone(zoneARef.K8s(), zoneA(), 4) // determineRoutingState + upstream×2 + real route
 				mockGetZone(zoneBRef.K8s(), zoneB(), 2) // LMS collection + downstream proxy
-				mockGetZone(zoneFRef.K8s(), zoneF(), 2) // addFailoverFallback + downstream secondary
+				mockGetZone(zoneFRef.K8s(), zoneF(), 3) // provider failover existence/feature check + addFailoverFallback + downstream secondary
 
 				var routes []*gatewayapi.Route
 				capturedRoutes(&routes, 3) // proxy + secondary + real

--- a/api/internal/handler/apiexposure/types.go
+++ b/api/internal/handler/apiexposure/types.go
@@ -1,0 +1,121 @@
+// Copyright 2025 Deutsche Telekom IT GmbH
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package apiexposure
+
+import (
+	"slices"
+
+	adminv1 "github.com/telekom/controlplane/admin/api/v1"
+	apiapi "github.com/telekom/controlplane/api/api/v1"
+	"github.com/telekom/controlplane/common/pkg/types"
+)
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Route Provisioning Pipeline
+// ──────────────────────────────────────────────────────────────────────────────
+//
+// The route provisioning pipeline runs in three steps:
+//
+//  1. determineRoutingState — fetches subscribers and zone data, derives flags.
+//  2. manageProxyRoutes    — creates proxy routes, collects consumer failover enrichment.
+//  3. createRealRoute      — creates the real route using the enriched state.
+//
+// All steps share a single routingState instance to avoid redundant API calls
+// and make the data flow between steps explicit.
+
+// routingState holds pre-computed data used across the route provisioning pipeline.
+//
+// The distinction between "consumer failover" and "provider failover" is important:
+//   - Consumer failover (a.k.a. DTC/DNS failover): all proxy routes AND the real route are
+//     enriched with additional hostnames and IDP issuers from ALL zones that have the
+//     ConsumerFailover feature enabled. This allows external DNS to switch consumers
+//     between zone gateways transparently.
+//   - Provider failover: creates a secondary route in a backup zone with the provider's
+//     upstreams, allowing traffic to be served from a different zone if the provider fails.
+//     Managed separately via WithFailoverUpstreams/WithFailoverSecurity.
+type routingState struct {
+	// ──────────────────────────────────────────────────────────────────────────
+	// Determined up front by determineRoutingState
+	// ──────────────────────────────────────────────────────────────────────────
+
+	// realmName is the environment/realm name used for token validation on all routes.
+	realmName string
+
+	// subscribers is the full list of approved, non-deleted ApiSubscriptions for this exposure.
+	// Used to determine which zones need proxy routes and whether consumer failover is active.
+	subscribers []*apiapi.ApiSubscription
+
+	// hasCrossZoneSubs is true if at least one subscriber is in a different zone than the exposure.
+	// Drives: real route gets GatewayConsumerName in DefaultConsumers (mesh-client access).
+	hasCrossZoneSubs bool
+
+	// hasLocalSubs is true if at least one subscriber is in the same zone as the exposure.
+	// Drives: real route trusts the exposure zone's own IDP issuer (direct consumer access).
+	hasLocalSubs bool
+
+	// hasConsumerFailover is true if at least one subscriber has consumer failover configured.
+	// When true, ALL proxy routes and the real route are enriched with failover hostnames/issuers.
+	hasConsumerFailover bool
+
+	// exposureZone is the Zone object where the API is exposed (provider zone).
+	// Used to read the zone's IDP issuer and to identify which zone is "self" in the failover loop.
+	exposureZone *adminv1.Zone
+
+	// ──────────────────────────────────────────────────────────────────────────
+	// Consumer failover enrichment — produced by manageProxyRoutes
+	// Applied to ALL proxy routes AND the real route.
+	// Collected from every zone that has the ConsumerFailover feature enabled
+	// (including the exposure zone itself).
+	// ──────────────────────────────────────────────────────────────────────────
+
+	// consumerFailoverHosts are the hostnames from the ConsumerFailover gateway presets of all
+	// eligible zones. Added as additional hostnames so that any zone's gateway can accept
+	// traffic for any other zone's failover hostname after a DNS switch.
+	consumerFailoverHosts []string
+
+	// consumerFailoverPaths are the paths from the ConsumerFailover gateway presets of all
+	// eligible zones. Added alongside consumerFailoverHosts.
+	consumerFailoverPaths []string
+
+	// consumerFailoverIssuers are the IDP issuers from all eligible zones.
+	// Added as trusted issuers so that when a consumer fails over to a different zone's
+	// gateway, the route can validate the consumer's home-zone IDP token directly.
+	consumerFailoverIssuers []string
+
+	// ──────────────────────────────────────────────────────────────────────────
+	// Mesh trust — produced by manageProxyRoutes
+	// Only for the real route. NOT related to consumer failover.
+	// ──────────────────────────────────────────────────────────────────────────
+
+	// crossZoneLmsIssuers are the LMS (Last-Mile-Security) issuers from all non-exposure
+	// zones that have proxy routes. The real route must trust these because proxy gateways
+	// in other zones stamp an LMS token before forwarding traffic to the provider zone.
+	// This is a mesh concern, not a consumer failover concern.
+	crossZoneLmsIssuers map[types.ObjectRef]string
+}
+
+// CrossZoneLmsIssuers returns the cross-zone LMS issuers, optionally excluding
+// the given zones (e.g. a failover zone whose issuer is already trusted through
+// another path).
+func (s *routingState) CrossZoneLmsIssuers(withoutZones ...types.ObjectRef) []string {
+	res := make([]string, 0, len(s.crossZoneLmsIssuers))
+	for zone, issuer := range s.crossZoneLmsIssuers {
+		if slices.ContainsFunc(withoutZones, func(z types.ObjectRef) bool { return z.Equals(&zone) }) {
+			continue
+		}
+		res = append(res, issuer)
+	}
+	slices.Sort(res)
+	return slices.Clip(res)
+}
+
+// AddCrossZoneLmsIssuer records the LMS issuer for a proxy route's zone,
+// lazily initializing the map on first use.
+func (s *routingState) AddCrossZoneLmsIssuer(zone types.ObjectRef, issuer string) {
+	if s.crossZoneLmsIssuers == nil {
+		s.crossZoneLmsIssuers = make(map[types.ObjectRef]string)
+	}
+	s.crossZoneLmsIssuers[zone] = issuer
+}

--- a/api/internal/handler/util/getters.go
+++ b/api/internal/handler/util/getters.go
@@ -47,10 +47,6 @@ func GetZone(ctx context.Context, scopedClient cclient.ScopedClient, ref client.
 		}
 		return nil, ctrlerrors.BlockedErrorf("zone %q not found", ref.String())
 	}
-	// TODO: figure out if we actually want to check this. Do we really care?
-	// if err := condition.EnsureReady(zone); err != nil {
-	// 	return nil, ctrlerrors.BlockedErrorf("zone %q is not ready", ref.String())
-	// }
 
 	return zone, nil
 }
@@ -327,13 +323,6 @@ func FindAllZonesWithFeatureEnabled(ctx context.Context, featureName adminapi.Fe
 		if controller.IsBeingDeleted(zone) {
 			continue
 		}
-
-		// TODO: Consider whether we should skip zones that are not ready. For now, we will include them in the list, but this may change in the future.
-		// Only consider zones that are ready ...
-		// if err := condition.EnsureReady(zone); err != nil {
-		// 	logger.V(1).Info("Skipping zone that is not ready", "zone", zone.Name)
-		// 	continue
-		// }
 
 		if zone.IsFeatureEnabled(featureName) {
 			zonesWithFeature = append(zonesWithFeature, zone)

--- a/api/internal/handler/util/route_util.go
+++ b/api/internal/handler/util/route_util.go
@@ -153,7 +153,7 @@ func WithProxyTarget(isProxyTarget bool) CreateRouteOption {
 // These issuers are used by the gateway's JWT plugin to validate incoming tokens.
 func WithTrustedIssuers(issuers []string) CreateRouteOption {
 	return func(opts *CreateRouteOptions) {
-		opts.TrustedIssuers = issuers
+		opts.TrustedIssuers = slices.Clone(issuers)
 	}
 }
 
@@ -270,10 +270,11 @@ func CreateProxyRoute(ctx context.Context, downstreamZoneRef, upstreamZoneRef ty
 			Traffic:    gatewayapi.Traffic{},
 		}
 		proxyRoute.Spec.Hostnames = slices.Concat(hostnames, options.AdditionalHostnames)
-		proxyRoute.Spec.Paths = slices.Concat(paths, options.AdditionalPaths)
 		slices.Sort(proxyRoute.Spec.Hostnames)
-		slices.Sort(proxyRoute.Spec.Paths)
 		proxyRoute.Spec.Hostnames = slices.Compact(slices.Clip(proxyRoute.Spec.Hostnames))
+
+		proxyRoute.Spec.Paths = slices.Concat(paths, options.AdditionalPaths)
+		slices.Sort(proxyRoute.Spec.Paths)
 		proxyRoute.Spec.Paths = slices.Compact(slices.Clip(proxyRoute.Spec.Paths))
 
 		// Set trusted issuers for consumer token validation on the proxy route.

--- a/api/internal/handler/util/route_util.go
+++ b/api/internal/handler/util/route_util.go
@@ -267,10 +267,14 @@ func CreateProxyRoute(ctx context.Context, downstreamZoneRef, upstreamZoneRef ty
 			GatewayRef: *downstreamZone.Status.Gateway,
 			Type:       gatewayapi.RouteTypeProxy,
 			Backend:    gatewayapi.Backend{Upstreams: []gatewayapi.Upstream{upstream}},
-			Hostnames:  slices.Compact(slices.Clip(slices.Concat(hostnames, options.AdditionalHostnames))),
-			Paths:      slices.Compact(slices.Clip(slices.Concat(paths, options.AdditionalPaths))),
 			Traffic:    gatewayapi.Traffic{},
 		}
+		proxyRoute.Spec.Hostnames = slices.Concat(hostnames, options.AdditionalHostnames)
+		proxyRoute.Spec.Paths = slices.Concat(paths, options.AdditionalPaths)
+		slices.Sort(proxyRoute.Spec.Hostnames)
+		slices.Sort(proxyRoute.Spec.Paths)
+		proxyRoute.Spec.Hostnames = slices.Compact(slices.Clip(proxyRoute.Spec.Hostnames))
+		proxyRoute.Spec.Paths = slices.Compact(slices.Clip(proxyRoute.Spec.Paths))
 
 		// Set trusted issuers for consumer token validation on the proxy route.
 		// The proxy route lives in the subscriber zone and accepts consumer traffic,
@@ -537,10 +541,15 @@ func CreateRealRoute(ctx context.Context, downstreamZoneRef types.ObjectRef, api
 			GatewayRef: *zone.Status.Gateway,
 			Type:       gatewayapi.RouteTypePrimary,
 			Backend:    gatewayapi.Backend{Upstreams: gatewayUpstreams},
-			Hostnames:  slices.Compact(slices.Clip(slices.Concat(hostnames, options.AdditionalHostnames))),
-			Paths:      slices.Compact(slices.Clip(slices.Concat(paths, options.AdditionalPaths))),
 			Traffic:    gatewayapi.Traffic{},
 		}
+		route.Spec.Hostnames = slices.Concat(hostnames, options.AdditionalHostnames)
+		route.Spec.Paths = slices.Concat(paths, options.AdditionalPaths)
+		slices.Sort(route.Spec.Hostnames)
+		slices.Sort(route.Spec.Paths)
+		route.Spec.Hostnames = slices.Compact(slices.Clip(route.Spec.Hostnames))
+		route.Spec.Paths = slices.Compact(slices.Clip(route.Spec.Paths))
+
 		route.Spec.Transformation = mapTransformation(apiExposure.Spec.Transformation)
 		route.Spec.Security = mapSecurity(apiExposure.Spec.Security)
 

--- a/event/internal/handler/util/callback_route.go
+++ b/event/internal/handler/util/callback_route.go
@@ -59,7 +59,7 @@ func CreateProxyCallbackRoute(
 
 	// Build upstream: points at target zone's gateway URL for callback path
 	callbackPath := makeCallbackRoutePath(targetZone.Name)
-	upstreamUrl, err := url.JoinPath(targetPreset.Urls[0].GetFullUrl(), callbackPath)
+	upstreamUrl, err := url.JoinPath(targetPreset.GetDefaultUrl(), callbackPath)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to build upstream URL for proxy callback Route")
 	}

--- a/event/internal/handler/util/sse_route.go
+++ b/event/internal/handler/util/sse_route.go
@@ -160,7 +160,7 @@ func CreateSSEProxyRoute(
 
 	// Build upstream: points at provider zone's gateway URL for SSE path
 	ssePath := makeSSERoutePath(eventType)
-	upstreamUrl, err := url.JoinPath(providerPreset.Urls[0].GetFullUrl(), ssePath)
+	upstreamUrl, err := url.JoinPath(providerPreset.GetDefaultUrl(), ssePath)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to build upstream URL for SSE proxy route")
 	}

--- a/event/internal/handler/util/voyager_route.go
+++ b/event/internal/handler/util/voyager_route.go
@@ -149,7 +149,7 @@ func CreateProxyVoyagerRoute(
 
 	// Build upstream: points at target zone's gateway URL for voyager path
 	voyagerPath := makeVoyagerRoutePath(targetZone.Name)
-	upstreamUrl, err := url.JoinPath(targetPreset.Urls[0].GetFullUrl(), voyagerPath)
+	upstreamUrl, err := url.JoinPath(targetPreset.GetDefaultUrl(), voyagerPath)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to build upstream URL for proxy voyager Route")
 	}

--- a/gateway/internal/features/feature/failover.go
+++ b/gateway/internal/features/feature/failover.go
@@ -105,6 +105,8 @@ func (f *FailoverFeature) Apply(ctx context.Context, builder features.FeaturesBu
 		// This is a proxy route. Each failover target is a secondary zone's gateway.
 		// The jumper iterates the list and picks the first one whose zone is healthy.
 		jumperCfg := builder.JumperConfig()
+		// In failover-scenario, this is also a proxy-route so we need to set mesh=true to allow the jumper to route to other zones.
+		jumperCfg.Mesh = true
 		for _, target := range failover.Targets {
 			routingCfg := &plugin.RoutingConfig{
 				JumperConfig:   jumperCfg,

--- a/gateway/internal/features/feature/failover.go
+++ b/gateway/internal/features/feature/failover.go
@@ -63,6 +63,7 @@ func (f *FailoverFeature) Apply(ctx context.Context, builder features.FeaturesBu
 		Environment:    envName,
 		TargetZoneName: failover.TargetZoneName, // The zone where the API is exposed on
 		JumperConfig:   nil,                     // JumperConfig is not needed for the proxy routing config
+		Mesh:           true,                    // proxy to upstream
 	}
 	routingConfigs.Add(proxyRoutingCfg)
 
@@ -78,11 +79,14 @@ func (f *FailoverFeature) Apply(ctx context.Context, builder features.FeaturesBu
 
 	if isFailoverSecondary {
 		// This route is a failover secondary route. Its failover targets are the real backend upstreams.
+		// We need to copy the jumperConfig so that we have the same configuration as the primary route.
 		jumperCfg := builder.JumperConfig()
+		jumperCfg.Mesh = false // In failover-secondary routes, the jumper should not route to other zones.
 		routingCfg := &plugin.RoutingConfig{
 			JumperConfig: jumperCfg,
 			Realm:        failoverRealm,
 			Environment:  envName,
+			Mesh:         false,
 		}
 		routingConfigs.Add(routingCfg)
 
@@ -104,17 +108,15 @@ func (f *FailoverFeature) Apply(ctx context.Context, builder features.FeaturesBu
 	} else {
 		// This is a proxy route. Each failover target is a secondary zone's gateway.
 		// The jumper iterates the list and picks the first one whose zone is healthy.
-		jumperCfg := builder.JumperConfig()
-		// In failover-scenario, this is also a proxy-route so we need to set mesh=true to allow the jumper to route to other zones.
-		jumperCfg.Mesh = true
 		for _, target := range failover.Targets {
 			routingCfg := &plugin.RoutingConfig{
-				JumperConfig:   jumperCfg,
 				Realm:          failoverRealm,
 				Environment:    envName,
 				RemoteApiUrl:   target.Upstream.Url(),
 				ApiBasePath:    target.Upstream.Path,
 				TargetZoneName: target.ZoneName,
+				JumperConfig:   nil,  // JumperConfig is not needed for the failover target routing config
+				Mesh:           true, // proxy to upstream
 			}
 			routingConfigs.Add(routingCfg)
 		}

--- a/gateway/internal/features/feature/failover_test.go
+++ b/gateway/internal/features/feature/failover_test.go
@@ -254,12 +254,10 @@ var _ = Describe("FailoverFeature", func() {
 					}
 
 					routingConfigs := &plugin.RoutingConfigs{}
-					jumperConfig := plugin.NewJumperConfig()
 
 					builder.EXPECT().GetRoute().Return(route, true)
 					builder.EXPECT().RoutingConfigs().Return(routingConfigs)
 					builder.EXPECT().SetUpstream(mock.Anything).Return()
-					builder.EXPECT().JumperConfig().Return(jumperConfig)
 
 					err := f.Apply(ctx, builder)
 					Expect(err).ToNot(HaveOccurred())
@@ -364,12 +362,10 @@ var _ = Describe("FailoverFeature", func() {
 					}
 
 					routingConfigs := &plugin.RoutingConfigs{}
-					jumperConfig := plugin.NewJumperConfig()
 
 					builder.EXPECT().GetRoute().Return(route, true)
 					builder.EXPECT().RoutingConfigs().Return(routingConfigs)
 					builder.EXPECT().SetUpstream(mock.Anything).Return()
-					builder.EXPECT().JumperConfig().Return(jumperConfig)
 
 					err := f.Apply(ctx, builder)
 					Expect(err).ToNot(HaveOccurred())
@@ -381,6 +377,7 @@ var _ = Describe("FailoverFeature", func() {
 					proxyConfig := routingConfigs.Get(0)
 					Expect(proxyConfig.RemoteApiUrl).To(Equal("https://primary.example.com:443/api"))
 					Expect(proxyConfig.TargetZoneName).To(Equal("zone-a"))
+					Expect(proxyConfig.Mesh).To(BeTrue())
 					Expect(proxyConfig.JumperConfig).To(BeNil())
 
 					// index 1: first failover target (zone-b)
@@ -388,16 +385,16 @@ var _ = Describe("FailoverFeature", func() {
 					Expect(target1.RemoteApiUrl).To(Equal("https://failover-a.example.com:443/v1"))
 					Expect(target1.ApiBasePath).To(Equal("/v1"))
 					Expect(target1.TargetZoneName).To(Equal("zone-b"))
-					Expect(target1.JumperConfig).To(Equal(jumperConfig))
-					Expect(target1.LoadBalancing).To(BeNil())
+					Expect(target1.Mesh).To(BeTrue())
+					Expect(target1.JumperConfig).To(BeNil())
 
 					// index 2: second failover target (zone-c)
 					target2 := routingConfigs.Get(2)
 					Expect(target2.RemoteApiUrl).To(Equal("https://failover-b.example.com:443/v1"))
 					Expect(target2.ApiBasePath).To(Equal("/v1"))
 					Expect(target2.TargetZoneName).To(Equal("zone-c"))
-					Expect(target2.JumperConfig).To(Equal(jumperConfig))
-					Expect(target2.LoadBalancing).To(BeNil())
+					Expect(target2.Mesh).To(BeTrue())
+					Expect(target2.JumperConfig).To(BeNil())
 				})
 			})
 		})

--- a/gateway/pkg/kong/client/plugin/jumper.go
+++ b/gateway/pkg/kong/client/plugin/jumper.go
@@ -73,7 +73,10 @@ type RoutingConfig struct {
 	// TargetZoneName is used to determine if the zone is currently available using zoneHealthCheckService
 	TargetZoneName string `json:"targetZoneName,omitempty"`
 
+	// TokenEndpoint is used for external-IDP
 	TokenEndpoint string `json:"tokenEndpoint,omitempty"`
+	// Mesh indicates whether this routing config is for a mesh scenario.
+	Mesh bool `json:"mesh,omitempty"`
 }
 
 type RoutingConfigs []*RoutingConfig

--- a/hack/demo-failover-spec.yaml
+++ b/hack/demo-failover-spec.yaml
@@ -1,0 +1,23 @@
+# Copyright 2026 Deutsche Telekom IT GmbH
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Shared API specification for the failover demos (demo-pf.sh and demo-cf.sh).
+# Rover-CTL auto-detects this as an ApiSpecification via the `openapi` field and
+# derives the Api name from the server base path. Both demos expose/subscribe to
+# this same base path, so it must be registered (roverctl apply) before the Rover.
+openapi: 3.0.0
+info:
+  title: Failover Demo API
+  version: 1.0.0
+  x-api-category: Other
+servers:
+  - url: https://httpbin.org/eni/failover-demo/v1
+    description: Failover demo backend
+paths:
+  /anything:
+    get:
+      summary: Echo endpoint
+      responses:
+        '200':
+          description: Successful response

--- a/hack/demo-failover.sh
+++ b/hack/demo-failover.sh
@@ -1,0 +1,217 @@
+#!/bin/bash
+
+# Copyright 2026 Deutsche Telekom IT GmbH
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Failover demo — provider failover (PF) + consumer failover (CF) in one run,
+# via roverctl (deployed environment). Both use the same shared API.
+#
+# PROVIDER FAILOVER (PF)  — on the *exposure*: exposures[].failover.zones: [<zone>]
+#   The api-controller provisions a SECONDARY gateway Route in each failover zone
+#   carrying the provider's real upstream and points the primary route's
+#   traffic.failover.targets at the failover-zone gateway
+#   (api/internal/handler/apiexposure/handler.go:311). If the primary provider
+#   zone is unavailable, traffic is served from the backup zone.
+#
+# CONSUMER FAILOVER (CF)  — on the *Rover spec*: failoverEnabled: true
+#   (rover-server Rover.EnableFailoverOnAllSubscriptions). The api-controller
+#   enriches ALL routes of the exposure with the DTC hostnames/paths and trusted
+#   IDP issuers of every zone that has the "ConsumerFailover" gateway preset
+#   (handler.go:370; admin/api/v1/zone_types.go:499). External DNS/DTC can then
+#   transparently switch a consumer between zone gateways.
+#   PRECONDITION: at least one zone must expose a "ConsumerFailover" gateway preset.
+#
+# HOW THIS DEMO PROVES IT (roverctl-only, like demo-gsr.sh)
+#   roverctl cannot read gateway Route / ApiExposure CRs
+#   (rover-ctl/pkg/handlers/registry.go registers only Rover/ApiSpecification/…),
+#   so the observable proof is: both Rovers are ACCEPTED, reconcile to status
+#   "complete", their failover config round-trips into the persisted spec, and a
+#   real token-authenticated request through the gateway succeeds.
+# ─────────────────────────────────────────────────────────────────────────────
+
+set -eo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# ── Config / flags ───────────────────────────────────────────────────────────
+PROVIDER_NAME="rover-failover-provider"
+CONSUMER_NAME="rover-failover-consumer"
+PROVIDER_ZONE="dataplane1"
+PROVIDER_FAILOVER_ZONE="dataplane2"
+CONSUMER_ZONE="dataplane2"
+BASE_PATH="/eni/failover-demo/v1"
+UPSTREAM="https://httpbin.org/anything"
+SPEC_FILE="${SCRIPT_DIR}/demo-failover-spec.yaml"
+ROVER_FILE=""
+SKIP_SPEC=false
+TIMEOUT=120
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -f|--file)                ROVER_FILE="$2"; shift 2 ;;
+    --spec)                   SPEC_FILE="$2"; shift 2 ;;
+    --skip-spec)              SKIP_SPEC=true; shift ;;
+    --provider-name)          PROVIDER_NAME="$2"; shift 2 ;;
+    --consumer-name)          CONSUMER_NAME="$2"; shift 2 ;;
+    --provider-zone)          PROVIDER_ZONE="$2"; shift 2 ;;
+    --provider-failover-zone) PROVIDER_FAILOVER_ZONE="$2"; shift 2 ;;
+    --consumer-zone)          CONSUMER_ZONE="$2"; shift 2 ;;
+    --base-path)              BASE_PATH="$2"; shift 2 ;;
+    --timeout)                TIMEOUT="$2"; shift 2 ;;
+    -h|--help)
+      echo "Usage: $0 [options]"
+      echo "  -f, --file <path>              Use an existing Rover file instead of the generated one"
+      echo "      --spec <path>              ApiSpecification file (default: $SPEC_FILE)"
+      echo "      --skip-spec                Do not apply the ApiSpecification (assume already registered)"
+      echo "      --provider-name <n>        Provider Rover name (default: $PROVIDER_NAME)"
+      echo "      --consumer-name <n>        Consumer Rover name (default: $CONSUMER_NAME)"
+      echo "      --provider-zone <z>        Provider zone (default: $PROVIDER_ZONE)"
+      echo "      --provider-failover-zone <z> Provider backup zone (default: $PROVIDER_FAILOVER_ZONE)"
+      echo "      --consumer-zone <z>        Consumer zone (default: $CONSUMER_ZONE)"
+      echo "      --base-path <p>            API base path (default: $BASE_PATH)"
+      echo "      --timeout <s>              Seconds to wait for 'complete' (default: $TIMEOUT)"
+      exit 0 ;;
+    *) echo "Unknown option: $1 (use -h)"; exit 1 ;;
+  esac
+done
+
+GREEN='\033[0;32m'; RED='\033[0;31m'; BOLD='\033[1m'; RESET='\033[0m'
+pass() { echo -e "  ${GREEN}✓ $1${RESET}"; }
+fail() { echo -e "  ${RED}✗ $1${RESET}"; exit 1; }
+
+app_info() { roverctl get-info --name "$1" --format json 2>/dev/null | jq -r '.applications[0]'; }
+
+wait_complete() {
+  local name="$1" elapsed=0 info status
+  while [ "$elapsed" -lt "$TIMEOUT" ]; do
+    info="$(app_info "$name")"
+    status="$(echo "$info" | jq -r '.status // empty')"
+    case "$status" in
+      complete) pass "$name: complete"; return 0 ;;
+      blocked|failed)
+        echo "$info" | jq -r '.errors[]?.message' 2>/dev/null | sed 's/^/     /'
+        fail "$name reconciliation $status" ;;
+      *) sleep 3; elapsed=$((elapsed + 3)) ;;
+    esac
+  done
+  fail "$name timed out after ${TIMEOUT}s (last status: ${status:-unknown})"
+}
+
+echo -e "${BOLD}=== Failover Demo (provider + consumer) ===${RESET}"
+echo "   Provider:          $PROVIDER_NAME (zone $PROVIDER_ZONE, failover $PROVIDER_FAILOVER_ZONE)"
+echo "   Consumer:          $CONSUMER_NAME (zone $CONSUMER_ZONE, failoverEnabled)"
+echo "   Base path:         $BASE_PATH"
+echo ""
+
+# ── Step 1: Register the shared API specification ────────────────────────────
+echo -e "${BOLD}1. Registering API specification...${RESET}"
+if [ "$SKIP_SPEC" = true ]; then
+  pass "skipped (--skip-spec)"
+else
+  [ -f "$SPEC_FILE" ] || fail "spec file not found: $SPEC_FILE"
+  roverctl apply -f "$SPEC_FILE" && pass "ApiSpecification applied ($SPEC_FILE)" \
+    || fail "failed to apply ApiSpecification"
+fi
+
+# ── Step 2: Build the Rover manifest (roverctl / tcp.ei.telekom.de format) ────
+echo -e "\n${BOLD}2. Preparing provider (PF) + consumer (CF) manifest...${RESET}"
+if [ -z "$ROVER_FILE" ]; then
+  ROVER_FILE="$(mktemp --suffix=.yaml)"
+  trap 'rm -f "$ROVER_FILE"' EXIT
+  cat > "$ROVER_FILE" <<EOF
+apiVersion: tcp.ei.telekom.de/v1
+kind: Rover
+metadata:
+  name: $PROVIDER_NAME
+spec:
+  zone: $PROVIDER_ZONE
+  exposures:
+    - type: api
+      basePath: $BASE_PATH
+      upstream: $UPSTREAM
+      visibility: WORLD
+      approval: AUTO
+      failover:
+        zones:
+          - $PROVIDER_FAILOVER_ZONE
+---
+apiVersion: tcp.ei.telekom.de/v1
+kind: Rover
+metadata:
+  name: $CONSUMER_NAME
+spec:
+  zone: $CONSUMER_ZONE
+  failoverEnabled: true
+  subscriptions:
+    - type: api
+      basePath: $BASE_PATH
+EOF
+  pass "Generated $ROVER_FILE"
+else
+  pass "Using provided file $ROVER_FILE"
+fi
+
+# ── Step 3: Apply ────────────────────────────────────────────────────────────
+echo -e "\n${BOLD}3. Applying Rovers via roverctl...${RESET}"
+roverctl apply -f "$ROVER_FILE" && pass "apply accepted" \
+  || fail "roverctl apply was rejected"
+
+# ── Step 4: Wait for both to reconcile ───────────────────────────────────────
+echo -e "\n${BOLD}4. Waiting for provider exposure (incl. failover routes)...${RESET}"
+wait_complete "$PROVIDER_NAME"
+
+echo -e "\n${BOLD}5. Waiting for consumer subscription (with failover enrichment)...${RESET}"
+wait_complete "$CONSUMER_NAME"
+
+# ── Step 6: Prove provider failover.zones round-tripped into the stored spec ──
+echo -e "\n${BOLD}6. Verifying provider failover config persisted...${RESET}"
+ZONES="$(roverctl resource get --kind Rover --api-version tcp.ei.telekom.de/v1 \
+  --name "$PROVIDER_NAME" --format json 2>/dev/null \
+  | jq -r '.exposures[]?.failover.zones[]?' 2>/dev/null | paste -sd, -)"
+if echo "$ZONES" | grep -qw "$PROVIDER_FAILOVER_ZONE"; then
+  pass "exposure failover.zones persisted: [$ZONES]"
+else
+  fail "provider failover zone '$PROVIDER_FAILOVER_ZONE' not in persisted spec (got: [${ZONES:-none}])"
+fi
+
+# ── Step 7: Prove consumer failoverEnabled round-tripped into the stored spec ─
+echo -e "\n${BOLD}7. Verifying consumer failover flag persisted...${RESET}"
+ENABLED="$(roverctl resource get --kind Rover --api-version tcp.ei.telekom.de/v1 \
+  --name "$CONSUMER_NAME" --format json 2>/dev/null | jq -r '.failoverEnabled' 2>/dev/null)"
+if [ "$ENABLED" = "true" ]; then
+  pass "consumer failoverEnabled = true (persisted)"
+else
+  fail "consumer failover flag not set in persisted spec (got: ${ENABLED:-none})"
+fi
+
+# ── Step 8: Send a real request through the gateway with a fetched token ──────
+echo -e "\n${BOLD}8. Calling the subscribed API through the gateway...${RESET}"
+INFO="$(app_info "$CONSUMER_NAME")"
+CLIENT_ID="$(echo "$INFO" | jq -r '.irisClientId')"
+CLIENT_SECRET="$(echo "$INFO" | jq -r '.secretInfo.clientSecret // .irisClientSecret')"
+TOKEN_URL="$(echo "$INFO" | jq -r '.irisTokenEndpointUrl')"
+GATEWAY_URL="$(echo "$INFO" | jq -r '.stargateUrl')"
+CALL_URL="${GATEWAY_URL%/}${BASE_PATH}/foo"
+
+TOKEN="$(curl -s --max-time 10 -X POST "$TOKEN_URL" \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  -d "grant_type=client_credentials" \
+  -d "client_id=$CLIENT_ID" \
+  -d "client_secret=$CLIENT_SECRET" | jq -r '.access_token // empty')"
+[ -n "$TOKEN" ] || fail "could not obtain access token from $TOKEN_URL"
+pass "access token obtained"
+
+echo "   GATEWAY_URL: $GATEWAY_URL"
+echo "   TOKEN (first 20): ${TOKEN:0:20}..."
+echo "   GET $CALL_URL"
+curl -sS -i --max-time 15 \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Accept: application/json" \
+  -w '\n--- HTTP %{http_code}, %{size_download} bytes, %{time_total}s ---\n' \
+  "$CALL_URL"
+
+echo -e "\n${BOLD}=== Result: Provider + consumer failover verified ✓ ===${RESET}"
+echo "Exposure '$BASE_PATH' served from '$PROVIDER_ZONE' with a secondary route in '$PROVIDER_FAILOVER_ZONE';"
+echo "consumer '$CONSUMER_NAME' subscribed with failover enrichment enabled."

--- a/rover/api/v1/rover_types.go
+++ b/rover/api/v1/rover_types.go
@@ -65,23 +65,30 @@ func (r *Rover) SetCondition(condition metav1.Condition) bool {
 	return meta.SetStatusCondition(&r.Status.Conditions, condition)
 }
 
+// HasFailoverEnabledOnAnySubscription checks if any of the Rover's subscriptions have failover enabled
 func (r *Rover) HasFailoverEnabledOnAnySubscription() bool {
 	return slices.ContainsFunc(r.Spec.Subscriptions, func(sub Subscription) bool {
-		if sub.Type() == TypeApi && sub.Api != nil && sub.Api.Traffic.Failover != nil {
-			return true
+		switch sub.Type() {
+		case TypeApi:
+			return sub.Api != nil && sub.Api.Traffic.Failover != nil && sub.Api.Traffic.Failover.Enabled
+		default:
+			return false
 		}
-		return false
 	})
 }
 
+// EnableFailoverOnAllSubscriptions enables failover on all API subscriptions of the Rover
 func (r *Rover) EnableFailoverOnAllSubscriptions() {
 	for i := range r.Spec.Subscriptions {
 		sub := &r.Spec.Subscriptions[i]
-		if sub.Type() == TypeApi && sub.Api != nil {
-			if sub.Api.Traffic.Failover == nil {
-				sub.Api.Traffic.Failover = &SubscriberFailover{}
+		switch sub.Type() {
+		case TypeApi:
+			if sub.Api != nil {
+				if sub.Api.Traffic.Failover == nil {
+					sub.Api.Traffic.Failover = &SubscriberFailover{}
+				}
+				sub.Api.Traffic.Failover.Enabled = true
 			}
-			sub.Api.Traffic.Failover.Enabled = true
 		}
 	}
 }

--- a/rover/internal/webhook/v1/rover_webhook.go
+++ b/rover/internal/webhook/v1/rover_webhook.go
@@ -121,6 +121,15 @@ func (r *RoverValidator) ValidateCreateOrUpdate(ctx context.Context, rover *rove
 		return nil, valErr.BuildError()
 	}
 
+	// Validate ConsumerFailover: feature must be enabled on this zone if ConsumerFailover is configured
+	if !zone.IsFeatureEnabled(adminv1.FeatureConsumerFailover) && rover.HasFailoverEnabledOnAnySubscription() {
+		valErr.AddInvalidError(
+			field.NewPath("spec").Child("zone"),
+			rover.Spec.Zone,
+			fmt.Sprintf("zone %q does not support consumer failover. Either disable it or select a different zone", rover.Spec.Zone))
+		return nil, valErr.BuildError()
+	}
+
 	// Validate permissions: feature must be enabled if permissions are configured
 	if !cconfig.FeaturePermission.IsEnabled() && len(rover.Spec.Permissions) > 0 {
 		valErr.AddInvalidError(


### PR DESCRIPTION
This PR improve the handling of ConsumerFailover (CF) in the api module. It now checks for each Route if the zone supports the feature, e. g. it could be that the API is exposed on a Zone that does not support CF, however, the subscriberZone and others do support it. Then CF must be configured on those routes but cannot be configured on the primary-route.