### PR TITLE
fix(admin): enhance populateRealmName tests for default behavior

### DIFF
--- a/admin/internal/handler/zone/handler_test.go
+++ b/admin/internal/handler/zone/handler_test.go
@@ -664,7 +664,18 @@ var _ = Describe("Zone Handler Steps", func() {
 	// ─────────────────────────────────────────────────────────────────────────
 
 	Describe("populateRealmName", func() {
-		It("should set Status.RealmName from environment spec", func() {
+		It("should default realmName to environment name when Spec.RealmName is empty", func() {
+			testCtx := newTestContext(zone)
+			hc := newTestHandlingContext(testCtx, zone)
+
+			Expect(hc.Environment.Spec.RealmName).To(BeEmpty())
+
+			err := populateRealmName(testCtx, hc)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(zone.Status.RealmName).To(Equal(testEnvironment))
+		})
+
+		It("should use Spec.RealmName when it is set", func() {
 			testCtx := newTestContext(zone)
 			hc := newTestHandlingContext(testCtx, zone)
 			hc.Environment.Spec.RealmName = "custom-realm"

--- a/admin/internal/handler/zone/realm.go
+++ b/admin/internal/handler/zone/realm.go
@@ -6,11 +6,7 @@ package zone
 
 import "context"
 
-func populateRealmName(ctx context.Context, hc *HandlingContext) error {
-	hc.Zone.Status.RealmName = hc.Environment.Spec.RealmName
-
-	if hc.Environment.Spec.RealmName == "" {
-		hc.Zone.Status.RealmName = hc.Environment.GetName()
-	}
+func populateRealmName(_ context.Context, hc *HandlingContext) error {
+	hc.Zone.Status.RealmName = hc.Environment.GetRealmName()
 	return nil
 }

--- a/admin/internal/handler/zone/realm.go
+++ b/admin/internal/handler/zone/realm.go
@@ -8,5 +8,9 @@ import "context"
 
 func populateRealmName(ctx context.Context, hc *HandlingContext) error {
 	hc.Zone.Status.RealmName = hc.Environment.Spec.RealmName
+
+	if hc.Environment.Spec.RealmName == "" {
+		hc.Zone.Status.RealmName = hc.Environment.GetName()
+	}
 	return nil
 }


### PR DESCRIPTION
fix: admin-controller should successfully handle if `env.spec.RealmName` is empty, and fallback to `env.Metadata.Name` via :

https://github.com/telekom/controlplane/blob/38e32122b2fe4785ea9e36752a15f109c1a5aff3/admin/api/v1/environment_types.go#L28-L35