### PR TITLE
fix: we must not rely on readiness for uniqueness check in the singleton logic

### DIFF
--- a/api/internal/handler/apiexposure/util.go
+++ b/api/internal/handler/apiexposure/util.go
@@ -49,9 +49,10 @@ func setAlreadyExposedConditions(existing, candidate *apiv1.ApiExposure) {
 // If there is, it sets appropriate conditions on the new ApiExposure.
 func ApiExposureMustNotAlreadyExist(ctx context.Context, candidate *apiv1.ApiExposure) error {
 	found, existingApiExp, err := util.FindActiveAPIExposure(ctx, candidate.Spec.ApiBasePath)
-	if existingApiExp == nil && err != nil {
-		return err
+	if err != nil {
+		return fmt.Errorf("failed to find active ApiExposure for %q: %w", candidate.Spec.ApiBasePath, err)
 	}
+
 	if !found {
 		// no other active apiExposure found with same basepath
 		candidate.Status.Active = true

--- a/api/internal/handler/apiexposure/util_test.go
+++ b/api/internal/handler/apiexposure/util_test.go
@@ -1,0 +1,63 @@
+// Copyright 2026 Deutsche Telekom IT GmbH
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package apiexposure
+
+import (
+	"context"
+	"errors"
+
+	"github.com/stretchr/testify/mock"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	apiapi "github.com/telekom/controlplane/api/api/v1"
+	cclient "github.com/telekom/controlplane/common/pkg/client"
+	fakeclient "github.com/telekom/controlplane/common/pkg/client/fake"
+	"github.com/telekom/controlplane/common/pkg/util/contextutil"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("ApiExposureMustNotAlreadyExist", func() {
+	var (
+		ctx        context.Context
+		fakeClient *fakeclient.MockJanitorClient
+		candidate  *apiapi.ApiExposure
+	)
+
+	BeforeEach(func() {
+		ctx = contextutil.WithEnv(context.Background(), testEnv)
+		fakeClient = fakeclient.NewMockJanitorClient(GinkgoT())
+		ctx = cclient.WithClient(ctx, fakeClient)
+		candidate = &apiapi.ApiExposure{
+			Spec: apiapi.ApiExposureSpec{ApiBasePath: "/eni/test/v1"},
+		}
+	})
+
+	It("wraps and propagates the error when listing exposures fails", func() {
+		fakeClient.EXPECT().
+			List(ctx, mock.AnythingOfType("*v1.ApiExposureList"), mock.Anything, mock.Anything).
+			Return(errors.New("boom")).Once()
+
+		err := ApiExposureMustNotAlreadyExist(ctx, candidate)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("failed to find active ApiExposure"))
+		Expect(err.Error()).To(ContainSubstring("boom"))
+		Expect(candidate.Status.Active).To(BeFalse())
+	})
+
+	It("marks the candidate active when no other active exposure exists", func() {
+		fakeClient.EXPECT().
+			List(ctx, mock.AnythingOfType("*v1.ApiExposureList"), mock.Anything, mock.Anything).
+			Run(func(_ context.Context, list client.ObjectList, _ ...client.ListOption) {
+				*list.(*apiapi.ApiExposureList) = apiapi.ApiExposureList{}
+			}).
+			Return(nil).Once()
+
+		err := ApiExposureMustNotAlreadyExist(ctx, candidate)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(candidate.Status.Active).To(BeTrue())
+	})
+})

--- a/api/internal/handler/apisubscription/handler.go
+++ b/api/internal/handler/apisubscription/handler.go
@@ -78,6 +78,17 @@ func (h *ApiSubscriptionHandler) CreateOrUpdate(ctx context.Context, apiSub *api
 		return nil
 	}
 
+	// FindActiveAPIExposure selects by Status.Active only and may return a not-ready exposure.
+	// Fail closed here so we don't provision consume routes against a blocked exposure whose
+	// status routes may be stale from a prior reconcile.
+	if err = condition.EnsureReady(apiExposure); err != nil {
+		apiSub.SetCondition(condition.NewNotReadyCondition(condition.ReasonPreconditionNotMet,
+			fmt.Sprintf("ApiExposure %q is not ready", apiExposure.Name)))
+		apiSub.SetCondition(condition.NewBlockedCondition(
+			fmt.Sprintf("ApiExposure %q is not ready. ApiSubscription will be automatically processed when the ApiExposure is ready", apiExposure.Name)))
+		return nil
+	}
+
 	// validate if basepathes of the api and apiexposure are really equal
 	if api.Spec.BasePath != apiSub.Spec.ApiBasePath {
 		// This should never happen as both Api and ApiExposure are looked up by the same basepath

--- a/api/internal/handler/util/getters.go
+++ b/api/internal/handler/util/getters.go
@@ -7,7 +7,7 @@ package util
 import (
 	"context"
 	"fmt"
-	"sort"
+	"slices"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -117,7 +117,9 @@ func GetPresetForZone(ctx context.Context, zoneRef types.ObjectRef, presetName s
 	return preset, zone, nil
 }
 
-// FindAPI checks if there is an active Api corresponding to the given apiBasePath.
+// FindActiveAPI checks if there is an active Api corresponding to the given apiBasePath.
+// It only checks the Status.Active field and does not check readiness. A returned Api may not be ready.
+// Returns (found, api, error). If found is false, there is no active Api.
 func FindActiveAPI(ctx context.Context, apiBasePath string) (bool, *apiv1.Api, error) {
 	logger := log.FromContext(ctx)
 	scopedClient := cclient.ClientFromContextOrDie(ctx)
@@ -133,28 +135,20 @@ func FindActiveAPI(ctx context.Context, apiBasePath string) (bool, *apiv1.Api, e
 			"failed to list corresponding Apis for ApiBasePath: %q", apiBasePathLabelValue)
 	}
 
-	var relevantApi *apiv1.Api
-
 	switch len(apiList.Items) {
 	case 0:
 		return false, nil, nil
 	case 1:
-		relevantApi = &apiList.Items[0]
+		return true, &apiList.Items[0], nil
 	default:
 		// This should never happens as the Api-Handler ensures uniqueness of active Apis per BasePath
 		// sort the list by creation timestamp and get the oldest one
-		sort.Slice(apiList.Items, func(i, j int) bool {
-			return apiList.Items[i].CreationTimestamp.Before(&apiList.Items[j].CreationTimestamp)
+		slices.SortStableFunc(apiList.Items, func(a, b apiv1.Api) int {
+			return a.CreationTimestamp.Compare(b.CreationTimestamp.Time)
 		})
-		relevantApi = &apiList.Items[0]
-		logger.Info("⚠️  Multiple active Apis found for the same BasePath. Using the oldest one.", "basePath", apiBasePathLabelValue, "apiName", relevantApi.Name)
+		logger.Info("⚠️  Multiple active Apis found for the same BasePath. Using the oldest one.", "basePath", apiBasePathLabelValue, "apiName", apiList.Items[0].Name)
+		return true, &apiList.Items[0], nil
 	}
-
-	if err := condition.EnsureReady(relevantApi); err != nil {
-		return false, relevantApi, ctrlerrors.BlockedErrorf("No API %q is ready.", apiBasePath)
-	}
-
-	return true, relevantApi, nil
 }
 
 func ResolveActiveApiCategoryForApi(ctx context.Context, api *apiv1.Api) (*apiv1.ApiCategory, error) {
@@ -204,7 +198,9 @@ func BuildApiCategorySubscriptionDeniedMessage(teamCategory, apiCategoryLabel st
 	return fmt.Sprintf("Team with category %q is not allowed to subscribe to APIs of category %q", teamCategory, apiCategoryLabel)
 }
 
-// FindAPIExposure checks if there is an active ApiExposure corresponding to the given apiBasePath.
+// FindActiveAPIExposure checks if there is an active ApiExposure corresponding to the given apiBasePath.
+// It only checks the Status.Active field and does not check readiness. A returned ApiExposure may not be ready.
+// Returns (found, apiExposure, error). If found is false, there is no active ApiExposure.
 func FindActiveAPIExposure(ctx context.Context, apiBasePath string) (bool, *apiv1.ApiExposure, error) {
 	logger := log.FromContext(ctx)
 	scopedClient := cclient.ClientFromContextOrDie(ctx)
@@ -222,28 +218,22 @@ func FindActiveAPIExposure(ctx context.Context, apiBasePath string) (bool, *apiv
 
 	logger.V(1).Info("found active ApiExposures", "size", len(apiExposureList.Items), "basePath", apiBasePathLabelValue)
 
-	var relevantApiExposure *apiv1.ApiExposure
-
 	switch len(apiExposureList.Items) {
 	case 0:
+		// none found (allowed)
 		return false, nil, nil
 	case 1:
-		relevantApiExposure = &apiExposureList.Items[0]
+		// there already is exactly one active ApiExposure (allowed)
+		return true, &apiExposureList.Items[0], nil
 	default:
 		// This should never happens as the ApiExposure-Handler ensures uniqueness of active ApiExposures per BasePath
 		// sort the list by creation timestamp and get the oldest one
-		sort.Slice(apiExposureList.Items, func(i, j int) bool {
-			return apiExposureList.Items[i].CreationTimestamp.Before(&apiExposureList.Items[j].CreationTimestamp)
+		slices.SortStableFunc(apiExposureList.Items, func(a, b apiv1.ApiExposure) int {
+			return a.CreationTimestamp.Compare(b.CreationTimestamp.Time)
 		})
-		relevantApiExposure = &apiExposureList.Items[0]
-		logger.Info("⚠️  Multiple active ApiExposures found for the same BasePath. Using the oldest one.", "basePath", apiBasePathLabelValue, "apiExposureName", relevantApiExposure.Name)
+		logger.Info("⚠️  Multiple active ApiExposures found for the same BasePath. Using the oldest one.", "basePath", apiBasePathLabelValue, "apiExposureName", apiExposureList.Items[0].Name)
+		return true, &apiExposureList.Items[0], nil
 	}
-
-	if err := condition.EnsureReady(relevantApiExposure); err != nil {
-		return false, relevantApiExposure, ctrlerrors.BlockedErrorf("No ApiExposure %q is ready.", apiBasePath)
-	}
-
-	return true, relevantApiExposure, nil
 }
 
 // FindFailoverEligibleZones lists all zones and returns those that are eligible for failover for a given zone.

--- a/api/internal/handler/util/getters_test.go
+++ b/api/internal/handler/util/getters_test.go
@@ -1,0 +1,181 @@
+// Copyright 2026 Deutsche Telekom IT GmbH
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package util
+
+import (
+	"context"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	crclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	apiv1 "github.com/telekom/controlplane/api/api/v1"
+	cclient "github.com/telekom/controlplane/common/pkg/client"
+	"github.com/telekom/controlplane/common/pkg/condition"
+	"github.com/telekom/controlplane/common/pkg/config"
+	"github.com/telekom/controlplane/common/pkg/util/labelutil"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+const (
+	basePath    = "/eni/test/v1"
+	environment = "test"
+)
+
+// newActiveContext builds a fake-client context with the status.active field indexes
+// that FindActiveAPI / FindActiveAPIExposure rely on.
+func newActiveContext(objects ...crclient.Object) context.Context {
+	sch := runtime.NewScheme()
+	Expect(apiv1.AddToScheme(sch)).To(Succeed())
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(sch).
+		WithObjects(objects...).
+		WithIndex(&apiv1.Api{}, "status.active", func(obj crclient.Object) []string {
+			return []string{boolField(obj.(*apiv1.Api).Status.Active)}
+		}).
+		WithIndex(&apiv1.ApiExposure{}, "status.active", func(obj crclient.Object) []string {
+			return []string{boolField(obj.(*apiv1.ApiExposure).Status.Active)}
+		}).
+		Build()
+	janitorClient := cclient.NewJanitorClient(cclient.NewScopedClient(fakeClient, environment))
+	return cclient.WithClient(context.Background(), janitorClient)
+}
+
+func boolField(b bool) string {
+	if b {
+		return "true"
+	}
+	return "false"
+}
+
+func basePathLabels() map[string]string {
+	return map[string]string{
+		config.EnvironmentLabelKey: environment,
+		apiv1.BasePathLabelKey:     labelutil.NormalizeLabelValue(basePath),
+	}
+}
+
+func setReady(conds *[]metav1.Condition) {
+	*conds = []metav1.Condition{{
+		Type:   condition.ConditionTypeReady,
+		Status: metav1.ConditionTrue,
+		Reason: "Ready",
+	}}
+}
+
+var _ = Describe("FindActiveAPIExposure", func() {
+	// makeExposure builds an active ApiExposure; ready toggles the Ready condition.
+	makeExposure := func(name string, ready bool, created metav1.Time) *apiv1.ApiExposure {
+		exp := &apiv1.ApiExposure{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              name,
+				Namespace:         environment,
+				Labels:            basePathLabels(),
+				CreationTimestamp: created,
+			},
+			Spec:   apiv1.ApiExposureSpec{ApiBasePath: basePath},
+			Status: apiv1.ApiExposureStatus{Active: true},
+		}
+		if ready {
+			setReady(&exp.Status.Conditions)
+		}
+		return exp
+	}
+
+	It("returns found=false when no active exposure exists", func() {
+		ctx := newActiveContext()
+		found, exp, err := FindActiveAPIExposure(ctx, basePath)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(found).To(BeFalse())
+		Expect(exp).To(BeNil())
+	})
+
+	It("returns an active exposure even when it is not ready", func() {
+		notReady := makeExposure("not-ready", false, metav1.Now())
+		ctx := newActiveContext(notReady)
+		found, exp, err := FindActiveAPIExposure(ctx, basePath)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(found).To(BeTrue())
+		Expect(exp).NotTo(BeNil())
+		Expect(exp.Name).To(Equal("not-ready"))
+		// Readiness is no longer checked by the getter.
+		Expect(condition.EnsureReady(exp)).To(HaveOccurred())
+	})
+
+	It("selects the oldest when multiple active exposures exist", func() {
+		old := makeExposure("older", true, metav1.Date(2024, 1, 1, 0, 0, 0, 0, metav1.Now().Location()))
+		newer := makeExposure("newer", true, metav1.Date(2025, 1, 1, 0, 0, 0, 0, metav1.Now().Location()))
+		// Insert newest first to prove sorting, not insertion order, drives the result.
+		ctx := newActiveContext(newer, old)
+		found, exp, err := FindActiveAPIExposure(ctx, basePath)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(found).To(BeTrue())
+		Expect(exp.Name).To(Equal("older"))
+	})
+
+	It("is deterministic on equal creation timestamps (stable order)", func() {
+		ts := metav1.Now()
+		a := makeExposure("a", true, ts)
+		b := makeExposure("b", true, ts)
+		// Same input order across runs must yield the same first element.
+		ctx1 := newActiveContext(a, b)
+		found1, exp1, err1 := FindActiveAPIExposure(ctx1, basePath)
+		Expect(err1).NotTo(HaveOccurred())
+		Expect(found1).To(BeTrue())
+		ctx2 := newActiveContext(a, b)
+		_, exp2, _ := FindActiveAPIExposure(ctx2, basePath)
+		Expect(exp1.Name).To(Equal(exp2.Name))
+	})
+})
+
+var _ = Describe("FindActiveAPI", func() {
+	// makeApi builds an active Api; ready toggles the Ready condition.
+	makeApi := func(name string, ready bool, created metav1.Time) *apiv1.Api {
+		api := &apiv1.Api{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              name,
+				Namespace:         environment,
+				Labels:            basePathLabels(),
+				CreationTimestamp: created,
+			},
+			Spec:   apiv1.ApiSpec{BasePath: basePath},
+			Status: apiv1.ApiStatus{Active: true},
+		}
+		if ready {
+			setReady(&api.Status.Conditions)
+		}
+		return api
+	}
+
+	It("returns found=false when no active Api exists", func() {
+		ctx := newActiveContext()
+		found, api, err := FindActiveAPI(ctx, basePath)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(found).To(BeFalse())
+		Expect(api).To(BeNil())
+	})
+
+	It("returns an active Api even when it is not ready", func() {
+		notReady := makeApi("not-ready", false, metav1.Now())
+		ctx := newActiveContext(notReady)
+		found, api, err := FindActiveAPI(ctx, basePath)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(found).To(BeTrue())
+		Expect(api.Name).To(Equal("not-ready"))
+	})
+
+	It("selects the oldest when multiple active Apis exist", func() {
+		old := makeApi("older", true, metav1.Date(2024, 1, 1, 0, 0, 0, 0, metav1.Now().Location()))
+		newer := makeApi("newer", true, metav1.Date(2025, 1, 1, 0, 0, 0, 0, metav1.Now().Location()))
+		ctx := newActiveContext(newer, old)
+		found, api, err := FindActiveAPI(ctx, basePath)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(found).To(BeTrue())
+		Expect(api.Name).To(Equal("older"))
+	})
+})

--- a/event/internal/handler/util/getters.go
+++ b/event/internal/handler/util/getters.go
@@ -7,7 +7,6 @@ package util
 import (
 	"context"
 	"slices"
-	"sort"
 
 	"github.com/pkg/errors"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -114,8 +113,10 @@ func GetEventStoreForZone(ctx context.Context, zoneName string) (*pubsubv1.Event
 }
 
 // FindActiveEventType finds the active EventType for a given event type string.
+// It only checks the Status.Active field and does not check readiness. A returned EventType may not be ready.
 // Returns (found, eventType, error). If found is false, there is no active EventType.
 func FindActiveEventType(ctx context.Context, eventType string) (bool, *eventv1.EventType, error) {
+	logger := log.FromContext(ctx)
 	c := cclient.ClientFromContextOrDie(ctx)
 
 	eventTypeList := &eventv1.EventTypeList{}
@@ -123,7 +124,7 @@ func FindActiveEventType(ctx context.Context, eventType string) (bool, *eventv1.
 		return false, nil, errors.Wrapf(err, "failed to list EventTypes for type %q", eventType)
 	}
 
-	// Filter to matching type and sort by creation timestamp (oldest first)
+	// Filter to matching, active EventTypes
 	var candidates []eventv1.EventType
 	for i := range eventTypeList.Items {
 		if eventTypeList.Items[i].Spec.Type == eventType && eventTypeList.Items[i].Status.Active {
@@ -131,21 +132,22 @@ func FindActiveEventType(ctx context.Context, eventType string) (bool, *eventv1.
 		}
 	}
 
-	if len(candidates) == 0 {
+	logger.V(1).Info("found active EventTypes", "eventType", eventType, "count", len(candidates))
+
+	switch len(candidates) {
+	case 0:
 		return false, nil, nil
+	case 1:
+		return true, &candidates[0], nil
+	default:
+		// This should never happen as the EventType-Handler ensures uniqueness of active EventTypes per type
+		// sort the list by creation timestamp and get the oldest one
+		slices.SortStableFunc(candidates, func(a, b eventv1.EventType) int {
+			return a.CreationTimestamp.Compare(b.CreationTimestamp.Time)
+		})
+		logger.Info("⚠️  Multiple active EventTypes found for the same type. Using the oldest one.", "eventType", eventType, "eventTypeName", candidates[0].Name)
+		return true, &candidates[0], nil
 	}
-
-	// Sort by CreationTimestamp ascending and return the oldest active one
-	sort.Slice(candidates, func(i, j int) bool {
-		return candidates[i].CreationTimestamp.Before(&candidates[j].CreationTimestamp)
-	})
-
-	activeET := &candidates[0]
-	if err := condition.EnsureReady(activeET); err != nil {
-		return false, activeET, ctrlerrors.BlockedErrorf("EventType %q is not ready", eventType)
-	}
-
-	return true, activeET, nil
 }
 
 // GetApplication retrieves an Application object by ObjectRef and ensures it is ready.
@@ -275,16 +277,17 @@ func FindActiveEventExposure(exposures []eventv1.EventExposure) (bool, *eventv1.
 		}
 	}
 
-	if len(candidates) == 0 {
+	switch len(candidates) {
+	case 0:
 		return false, nil, nil
+	case 1:
+		return true, &candidates[0], nil
+	default:
+		slices.SortStableFunc(candidates, func(a, b eventv1.EventExposure) int {
+			return a.CreationTimestamp.Compare(b.CreationTimestamp.Time)
+		})
+		return true, &candidates[0], nil
 	}
-
-	sort.Slice(candidates, func(i, j int) bool {
-		return candidates[i].CreationTimestamp.Before(&candidates[j].CreationTimestamp)
-	})
-
-	activeExp := &candidates[0]
-	return true, activeExp, nil
 }
 
 func FindCrossZoneCallbackSubscriptions(ctx context.Context, eventType, exposureZoneName string) ([]eventv1.EventSubscription, error) {

--- a/event/internal/handler/util/getters_test.go
+++ b/event/internal/handler/util/getters_test.go
@@ -515,7 +515,7 @@ var _ = Describe("FindActiveEventType", func() {
 		Expect(result.Name).To(Equal("test-type"))
 	})
 
-	It("should return BlockedError when active EventType is not ready", func() {
+	It("should return active EventType even when it is not ready (readiness is not checked)", func() {
 		et := eventv1.EventType{
 			ObjectMeta: metav1.ObjectMeta{Name: "test-type", CreationTimestamp: metav1.Now()},
 			Spec:       eventv1.EventTypeSpec{Type: "de.telekom.test.v1"},
@@ -531,12 +531,10 @@ var _ = Describe("FindActiveEventType", func() {
 			Return(nil)
 
 		found, result, err := util.FindActiveEventType(ctx, "de.telekom.test.v1")
-		Expect(err).To(HaveOccurred())
-		Expect(found).To(BeFalse())
+		Expect(err).ToNot(HaveOccurred())
+		Expect(found).To(BeTrue())
 		Expect(result).ToNot(BeNil())
-		rootCause := unwrapAll(err)
-		Expect(rootCause).To(Satisfy(isBlockedError))
-		Expect(err.Error()).To(ContainSubstring("not ready"))
+		Expect(result.Name).To(Equal("test-type"))
 	})
 })
 

--- a/event/internal/handler/util/getters_test.go
+++ b/event/internal/handler/util/getters_test.go
@@ -536,6 +536,33 @@ var _ = Describe("FindActiveEventType", func() {
 		Expect(result).ToNot(BeNil())
 		Expect(result.Name).To(Equal("test-type"))
 	})
+
+	It("should return the oldest when multiple active EventTypes of the same type exist", func() {
+		older := eventv1.EventType{
+			ObjectMeta: metav1.ObjectMeta{Name: "older", CreationTimestamp: metav1.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)},
+			Spec:       eventv1.EventTypeSpec{Type: "de.telekom.test.v1"},
+			Status:     eventv1.EventTypeStatus{Active: true},
+		}
+		newer := eventv1.EventType{
+			ObjectMeta: metav1.ObjectMeta{Name: "newer", CreationTimestamp: metav1.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)},
+			Spec:       eventv1.EventTypeSpec{Type: "de.telekom.test.v1"},
+			Status:     eventv1.EventTypeStatus{Active: true},
+		}
+
+		fakeClient.EXPECT().
+			List(ctx, &eventv1.EventTypeList{}).
+			Run(func(_ context.Context, list client.ObjectList, _ ...client.ListOption) {
+				// Newest first to prove sorting, not input order, picks the winner.
+				*list.(*eventv1.EventTypeList) = eventv1.EventTypeList{Items: []eventv1.EventType{newer, older}}
+			}).
+			Return(nil)
+
+		found, result, err := util.FindActiveEventType(ctx, "de.telekom.test.v1")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(found).To(BeTrue())
+		Expect(result).ToNot(BeNil())
+		Expect(result.Name).To(Equal("older"))
+	})
 })
 
 // ---------- GetApplication ----------


### PR DESCRIPTION
We cannot use the readiness-check for singleton selection. If - for whatever reason - an Api, ApiExposure, EventType or EventExposure becomes NOT READY, it would result in a singleton switch 