### PR TITLE
fix(projector): back-link subscriptions to fix race-condition exposure vs subscription

### DIFF
--- a/controlplane-api/internal/resolvers/ent.generated.go
+++ b/controlplane-api/internal/resolvers/ent.generated.go
@@ -2609,10 +2609,10 @@ func (ec *executionContext) _ApiSubscription_target(ctx context.Context, field g
 		},
 		nil,
 		func(ctx context.Context, selections ast.SelectionSet, v *model.ApiExposureInfo) graphql.Marshaler {
-			return ec.marshalNApiExposureInfo2ᚖgithubᚗcomᚋtelekomᚋcontrolplaneᚋcontrolplaneᚑapiᚋpkgᚋmodelᚐApiExposureInfo(ctx, selections, v)
+			return ec.marshalOApiExposureInfo2ᚖgithubᚗcomᚋtelekomᚋcontrolplaneᚋcontrolplaneᚑapiᚋpkgᚋmodelᚐApiExposureInfo(ctx, selections, v)
 		},
 		true,
-		true,
+		false,
 	)
 }
 func (ec *executionContext) fieldContext_ApiSubscription_target(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -5735,10 +5735,10 @@ func (ec *executionContext) _EventSubscription_target(ctx context.Context, field
 		},
 		nil,
 		func(ctx context.Context, selections ast.SelectionSet, v *model.EventExposureInfo) graphql.Marshaler {
-			return ec.marshalNEventExposureInfo2ᚖgithubᚗcomᚋtelekomᚋcontrolplaneᚋcontrolplaneᚑapiᚋpkgᚋmodelᚐEventExposureInfo(ctx, selections, v)
+			return ec.marshalOEventExposureInfo2ᚖgithubᚗcomᚋtelekomᚋcontrolplaneᚋcontrolplaneᚑapiᚋpkgᚋmodelᚐEventExposureInfo(ctx, selections, v)
 		},
 		true,
-		true,
+		false,
 	)
 }
 func (ec *executionContext) fieldContext_EventSubscription_target(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -20341,16 +20341,13 @@ func (ec *executionContext) _ApiSubscription(ctx context.Context, sel ast.Select
 		case "target":
 			field := field
 
-			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+			innerFunc := func(ctx context.Context, _ *graphql.FieldSet) (res graphql.Marshaler) {
 				defer func() {
 					if r := recover(); r != nil {
 						ec.Error(ctx, ec.Recover(ctx, r))
 					}
 				}()
 				res = ec._ApiSubscription_target(ctx, field, obj)
-				if res == graphql.Null {
-					atomic.AddUint32(&fs.Invalids, 1)
-				}
 				return res
 			}
 
@@ -21859,16 +21856,13 @@ func (ec *executionContext) _EventSubscription(ctx context.Context, sel ast.Sele
 		case "target":
 			field := field
 
-			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+			innerFunc := func(ctx context.Context, _ *graphql.FieldSet) (res graphql.Marshaler) {
 				defer func() {
 					if r := recover(); r != nil {
 						ec.Error(ctx, ec.Recover(ctx, r))
 					}
 				}()
 				res = ec._EventSubscription_target(ctx, field, obj)
-				if res == graphql.Null {
-					atomic.AddUint32(&fs.Invalids, 1)
-				}
 				return res
 			}
 

--- a/controlplane-api/internal/resolvers/root_.generated.go
+++ b/controlplane-api/internal/resolvers/root_.generated.go
@@ -7743,8 +7743,8 @@ extend type Zone {
 }
 
 extend type ApiSubscription {
-  "Target exposure (reduced view — cross-tenant boundary)"
-  target: ApiExposureInfo! @goField(forceResolver: true)
+  "Target exposure (reduced view — cross-tenant boundary). Null when the target API is not yet exposed."
+  target: ApiExposureInfo @goField(forceResolver: true)
 }
 
 extend type ApiExposure {
@@ -7753,8 +7753,8 @@ extend type ApiExposure {
 }
 
 extend type EventSubscription {
-  "Target exposure (reduced view — cross-tenant boundary)"
-  target: EventExposureInfo! @goField(forceResolver: true)
+  "Target exposure (reduced view — cross-tenant boundary). Null when the target event is not yet exposed."
+  target: EventExposureInfo @goField(forceResolver: true)
 }
 
 extend type EventExposure {

--- a/controlplane-api/internal/resolvers/schema.generated.go
+++ b/controlplane-api/internal/resolvers/schema.generated.go
@@ -4940,20 +4940,6 @@ func (ec *executionContext) marshalNApiExposureFeature2ᚕgithubᚗcomᚋtelekom
 	return ret
 }
 
-func (ec *executionContext) marshalNApiExposureInfo2githubᚗcomᚋtelekomᚋcontrolplaneᚋcontrolplaneᚑapiᚋpkgᚋmodelᚐApiExposureInfo(ctx context.Context, sel ast.SelectionSet, v model.ApiExposureInfo) graphql.Marshaler {
-	return ec._ApiExposureInfo(ctx, sel, &v)
-}
-
-func (ec *executionContext) marshalNApiExposureInfo2ᚖgithubᚗcomᚋtelekomᚋcontrolplaneᚋcontrolplaneᚑapiᚋpkgᚋmodelᚐApiExposureInfo(ctx context.Context, sel ast.SelectionSet, v *model.ApiExposureInfo) graphql.Marshaler {
-	if v == nil {
-		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
-			graphql.AddErrorf(ctx, "the requested element is null which the schema does not allow")
-		}
-		return graphql.Null
-	}
-	return ec._ApiExposureInfo(ctx, sel, v)
-}
-
 func (ec *executionContext) marshalNApiSubscriptionInfo2ᚕᚖgithubᚗcomᚋtelekomᚋcontrolplaneᚋcontrolplaneᚑapiᚋpkgᚋmodelᚐApiSubscriptionInfoᚄ(ctx context.Context, sel ast.SelectionSet, v []*model.ApiSubscriptionInfo) graphql.Marshaler {
 	ret := graphql.MarshalSliceConcurrently(ctx, len(v), 0, false, func(ctx context.Context, i int) graphql.Marshaler {
 		fc := graphql.GetFieldContext(ctx)
@@ -5024,20 +5010,6 @@ func (ec *executionContext) marshalNDecision2ᚕgithubᚗcomᚋtelekomᚋcontrol
 
 func (ec *executionContext) marshalNEventDelivery2githubᚗcomᚋtelekomᚋcontrolplaneᚋcontrolplaneᚑapiᚋpkgᚋmodelᚐEventDelivery(ctx context.Context, sel ast.SelectionSet, v model.EventDelivery) graphql.Marshaler {
 	return ec._EventDelivery(ctx, sel, &v)
-}
-
-func (ec *executionContext) marshalNEventExposureInfo2githubᚗcomᚋtelekomᚋcontrolplaneᚋcontrolplaneᚑapiᚋpkgᚋmodelᚐEventExposureInfo(ctx context.Context, sel ast.SelectionSet, v model.EventExposureInfo) graphql.Marshaler {
-	return ec._EventExposureInfo(ctx, sel, &v)
-}
-
-func (ec *executionContext) marshalNEventExposureInfo2ᚖgithubᚗcomᚋtelekomᚋcontrolplaneᚋcontrolplaneᚑapiᚋpkgᚋmodelᚐEventExposureInfo(ctx context.Context, sel ast.SelectionSet, v *model.EventExposureInfo) graphql.Marshaler {
-	if v == nil {
-		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
-			graphql.AddErrorf(ctx, "the requested element is null which the schema does not allow")
-		}
-		return graphql.Null
-	}
-	return ec._EventExposureInfo(ctx, sel, v)
 }
 
 func (ec *executionContext) marshalNEventSubscriptionInfo2ᚕᚖgithubᚗcomᚋtelekomᚋcontrolplaneᚋcontrolplaneᚑapiᚋpkgᚋmodelᚐEventSubscriptionInfoᚄ(ctx context.Context, sel ast.SelectionSet, v []*model.EventSubscriptionInfo) graphql.Marshaler {

--- a/controlplane-api/schema.graphql
+++ b/controlplane-api/schema.graphql
@@ -280,8 +280,8 @@ extend type Zone {
 }
 
 extend type ApiSubscription {
-  "Target exposure (reduced view — cross-tenant boundary)"
-  target: ApiExposureInfo! @goField(forceResolver: true)
+  "Target exposure (reduced view — cross-tenant boundary). Null when the target API is not yet exposed."
+  target: ApiExposureInfo @goField(forceResolver: true)
 }
 
 extend type ApiExposure {
@@ -290,8 +290,8 @@ extend type ApiExposure {
 }
 
 extend type EventSubscription {
-  "Target exposure (reduced view — cross-tenant boundary)"
-  target: EventExposureInfo! @goField(forceResolver: true)
+  "Target exposure (reduced view — cross-tenant boundary). Null when the target event is not yet exposed."
+  target: EventExposureInfo @goField(forceResolver: true)
 }
 
 extend type EventExposure {

--- a/projector/internal/domain/apiexposure/repository.go
+++ b/projector/internal/domain/apiexposure/repository.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/telekom/controlplane/controlplane-api/ent"
 	"github.com/telekom/controlplane/controlplane-api/ent/apiexposure"
+	"github.com/telekom/controlplane/controlplane-api/ent/apisubscription"
 	"github.com/telekom/controlplane/controlplane-api/ent/application"
 	"github.com/telekom/controlplane/controlplane-api/ent/team"
 	"github.com/telekom/controlplane/controlplane-api/pkg/model"
@@ -126,6 +127,25 @@ func (r *Repository) Upsert(ctx context.Context, data *APIExposureData) error {
 
 	et, lk := cachekeys.APIExposure(data.BasePath, data.AppName, data.TeamName)
 	r.cache.Set(et, lk, exposureID)
+
+	// Back-link subscriptions that were projected before this exposure existed.
+	// A subscription targets an active exposure by base path (see
+	// FindAPIExposureByBasePath). If the subscription was reconciled first, it
+	// was stored with a NULL target FK and nothing re-links it when the exposure
+	// later appears — the subscription CR is not re-reconciled. Here we adopt any
+	// such orphaned subscriptions so their target resolves.
+	if data.Active {
+		if err := r.client.ApiSubscription.Update().
+			Where(
+				apisubscription.BasePathEQ(data.BasePath),
+				apisubscription.Not(apisubscription.HasTarget()),
+			).
+			SetTargetID(exposureID).
+			Exec(ctx); err != nil {
+			return fmt.Errorf("back-link subscriptions to api_exposure %q (app %q, team %q): %w",
+				data.BasePath, data.AppName, data.TeamName, err)
+		}
+	}
 	return nil
 }
 

--- a/projector/internal/domain/apiexposure/repository_test.go
+++ b/projector/internal/domain/apiexposure/repository_test.go
@@ -147,6 +147,68 @@ var _ = Describe("ApiExposure Repository", func() {
 			Expect(owner.ID).To(Equal(appID))
 		})
 
+		It("should back-link orphaned subscriptions projected before the exposure", func() {
+			// Subscription created first, before its target exposure exists →
+			// stored with a NULL target FK (the create-order race).
+			sub, err := client.ApiSubscription.Create().
+				SetBasePath("/api/v1/orphan").
+				SetEnvironment("prod").
+				SetNamespace("prod--platform--narvi").
+				SetName("orphan-sub").
+				SetOwnerID(appID).
+				Save(ctx)
+			Expect(err).NotTo(HaveOccurred())
+			_, err = sub.QueryTarget().Only(ctx)
+			Expect(ent.IsNotFound(err)).To(BeTrue())
+
+			// Exposure appears later → should adopt the orphaned subscription.
+			data := &apiexposure.APIExposureData{
+				Meta:          shared.NewMetadata("prod--platform--narvi", "orphan-exp", nil),
+				StatusPhase:   "READY",
+				StatusMessage: "ok",
+				BasePath:      "/api/v1/orphan",
+				Visibility:    "WORLD",
+				Active:        true,
+				Features:      []string{},
+				Upstreams:     []model.Upstream{{URL: "https://backend.example.com", Weight: 100}},
+				AppName:       "my-app",
+				TeamName:      "platform--narvi",
+			}
+			Expect(repo.Upsert(ctx, data)).To(Succeed())
+
+			target, err := sub.QueryTarget().Only(ctx)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(target.BasePath).To(Equal("/api/v1/orphan"))
+		})
+
+		It("should not back-link subscriptions when the exposure is inactive", func() {
+			sub, err := client.ApiSubscription.Create().
+				SetBasePath("/api/v1/inactive").
+				SetEnvironment("prod").
+				SetNamespace("prod--platform--narvi").
+				SetName("inactive-sub").
+				SetOwnerID(appID).
+				Save(ctx)
+			Expect(err).NotTo(HaveOccurred())
+
+			data := &apiexposure.APIExposureData{
+				Meta:          shared.NewMetadata("prod--platform--narvi", "inactive-exp", nil),
+				StatusPhase:   "READY",
+				StatusMessage: "ok",
+				BasePath:      "/api/v1/inactive",
+				Visibility:    "WORLD",
+				Active:        false,
+				Features:      []string{},
+				Upstreams:     []model.Upstream{{URL: "https://backend.example.com", Weight: 100}},
+				AppName:       "my-app",
+				TeamName:      "platform--narvi",
+			}
+			Expect(repo.Upsert(ctx, data)).To(Succeed())
+
+			_, err = sub.QueryTarget().Only(ctx)
+			Expect(ent.IsNotFound(err)).To(BeTrue())
+		})
+
 		It("should persist security and rate_limit fields", func() {
 			clientSecret := "ext-client-secret"
 			clientKey := "ext-client-key"

--- a/projector/internal/domain/eventexposure/repository.go
+++ b/projector/internal/domain/eventexposure/repository.go
@@ -13,6 +13,7 @@ import (
 	"github.com/telekom/controlplane/controlplane-api/ent"
 	"github.com/telekom/controlplane/controlplane-api/ent/application"
 	"github.com/telekom/controlplane/controlplane-api/ent/eventexposure"
+	"github.com/telekom/controlplane/controlplane-api/ent/eventsubscription"
 	"github.com/telekom/controlplane/controlplane-api/ent/team"
 	"github.com/telekom/controlplane/projector/internal/infrastructure"
 	"github.com/telekom/controlplane/projector/internal/infrastructure/cachekeys"
@@ -99,6 +100,25 @@ func (r *Repository) Upsert(ctx context.Context, data *EventExposureData) error 
 
 	et, lk := cachekeys.EventExposure(data.EventType, data.AppName, data.TeamName)
 	r.cache.Set(et, lk, exposureID)
+
+	// Back-link subscriptions that were projected before this exposure existed.
+	// A subscription targets an active exposure by event type (see
+	// FindEventExposureByEventType). If the subscription was reconciled first, it
+	// was stored with a NULL target FK and nothing re-links it when the exposure
+	// later appears — the subscription CR is not re-reconciled. Here we adopt any
+	// such orphaned subscriptions so their target resolves.
+	if data.Active {
+		if err := r.client.EventSubscription.Update().
+			Where(
+				eventsubscription.EventTypeEQ(data.EventType),
+				eventsubscription.Not(eventsubscription.HasTarget()),
+			).
+			SetTargetID(exposureID).
+			Exec(ctx); err != nil {
+			return fmt.Errorf("back-link subscriptions to event_exposure %q (app %q, team %q): %w",
+				data.EventType, data.AppName, data.TeamName, err)
+		}
+	}
 	return nil
 }
 

--- a/projector/internal/domain/eventexposure/repository_test.go
+++ b/projector/internal/domain/eventexposure/repository_test.go
@@ -161,6 +161,68 @@ var _ = Describe("EventExposure Repository", func() {
 			Expect(exp.EventScopes[0].Trigger.SelectionFilter.Expression).To(Equal(`{"op":"eq","path":"$.source","value":"my-app"}`))
 		})
 
+		It("should back-link orphaned subscriptions projected before the exposure", func() {
+			// Subscription created first, before its target exposure exists →
+			// stored with a NULL target FK (the create-order race).
+			sub, err := client.EventSubscription.Create().
+				SetEventType("de.telekom.orphan.v1").
+				SetEnvironment("prod").
+				SetNamespace("prod--platform--narvi").
+				SetName("orphan-sub").
+				SetOwnerID(appID).
+				Save(ctx)
+			Expect(err).NotTo(HaveOccurred())
+			_, err = sub.QueryTarget().Only(ctx)
+			Expect(ent.IsNotFound(err)).To(BeTrue())
+
+			// Exposure appears later → should adopt the orphaned subscription.
+			data := &eventexposure.EventExposureData{
+				Meta:           shared.NewMetadata("prod--platform--narvi", "orphan-exp", nil),
+				StatusPhase:    "READY",
+				StatusMessage:  "ok",
+				EventType:      "de.telekom.orphan.v1",
+				Visibility:     "WORLD",
+				Active:         true,
+				ApprovalConfig: model.ApprovalConfig{Strategy: "AUTO"},
+				Scopes:         []model.EventScope{},
+				AppName:        "my-app",
+				TeamName:       "platform--narvi",
+			}
+			Expect(repo.Upsert(ctx, data)).To(Succeed())
+
+			target, err := sub.QueryTarget().Only(ctx)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(target.EventType).To(Equal("de.telekom.orphan.v1"))
+		})
+
+		It("should not back-link subscriptions when the exposure is inactive", func() {
+			sub, err := client.EventSubscription.Create().
+				SetEventType("de.telekom.inactive.v1").
+				SetEnvironment("prod").
+				SetNamespace("prod--platform--narvi").
+				SetName("inactive-sub").
+				SetOwnerID(appID).
+				Save(ctx)
+			Expect(err).NotTo(HaveOccurred())
+
+			data := &eventexposure.EventExposureData{
+				Meta:           shared.NewMetadata("prod--platform--narvi", "inactive-exp", nil),
+				StatusPhase:    "READY",
+				StatusMessage:  "ok",
+				EventType:      "de.telekom.inactive.v1",
+				Visibility:     "WORLD",
+				Active:         false,
+				ApprovalConfig: model.ApprovalConfig{Strategy: "AUTO"},
+				Scopes:         []model.EventScope{},
+				AppName:        "my-app",
+				TeamName:       "platform--narvi",
+			}
+			Expect(repo.Upsert(ctx, data)).To(Succeed())
+
+			_, err = sub.QueryTarget().Only(ctx)
+			Expect(ent.IsNotFound(err)).To(BeTrue())
+		})
+
 		It("should return ErrDependencyMissing when application is missing", func() {
 			data := &eventexposure.EventExposureData{
 				Meta:           shared.NewMetadata("prod--platform--narvi", "fail-exp", nil),


### PR DESCRIPTION
Subscriptions that were projected before the targeted Exposure are allowed (Blocked until exposure is ready).
However, the back-link was never set afterwards. Therefore the Subscriptions remains without a target. 