### PR TITLE
fix(projector): stability improvements

### DIFF
--- a/projector/internal/domain/apisubscription/deps.go
+++ b/projector/internal/domain/apisubscription/deps.go
@@ -20,4 +20,7 @@ import "context"
 type APISubscriptionDeps interface {
 	FindApplicationID(ctx context.Context, name, teamName string) (int, error)
 	FindAPIExposureByBasePath(ctx context.Context, basePath string) (int, error)
+	// EvictAPIExposureByBasePath clears a stale cached exposure ID after a FK
+	// violation, forcing the next resolve to hit the DB.
+	EvictAPIExposureByBasePath(basePath string)
 }

--- a/projector/internal/domain/apisubscription/repository.go
+++ b/projector/internal/domain/apisubscription/repository.go
@@ -111,6 +111,14 @@ func (r *Repository) Upsert(ctx context.Context, data *APISubscriptionData) erro
 		UpdateNewValues().
 		ID(ctx)
 	if upsertErr != nil {
+		// A FK violation on the target means the cached exposure ID is stale:
+		// the api_exposures row was deleted/re-created after we resolved it.
+		// Evict the stale cache entry and requeue as dependency-missing so the
+		// next reconcile re-resolves (or stores a NULL target).
+		if targetExposureID != nil && infrastructure.IsFKViolation(upsertErr) {
+			r.deps.EvictAPIExposureByBasePath(data.TargetBasePath)
+			return runtime.WrapDependencyMissing("api_exposure", data.TargetBasePath)
+		}
 		return fmt.Errorf("upsert api_subscription (owner %q, basePath %q): %w",
 			data.OwnerAppName, data.BasePath, upsertErr)
 	}

--- a/projector/internal/domain/apisubscription/repository.go
+++ b/projector/internal/domain/apisubscription/repository.go
@@ -23,6 +23,11 @@ import (
 // entityType is the cache key prefix for ApiSubscription entities in the EdgeCache.
 const entityType = "apisubscription"
 
+// fkTargetExposure is the DB FK constraint linking an ApiSubscription to its
+// target ApiExposure. Matched by name so an FK violation on the (required)
+// owner FK is not misread as a stale target. See ent migrate schema.
+const fkTargetExposure = "api_subscriptions_api_exposures_target"
+
 // Repository performs typed persistence operations for ApiSubscription entities.
 // It implements runtime.Repository[APISubscriptionKey, *APISubscriptionData].
 //
@@ -115,7 +120,7 @@ func (r *Repository) Upsert(ctx context.Context, data *APISubscriptionData) erro
 		// the api_exposures row was deleted/re-created after we resolved it.
 		// Evict the stale cache entry and requeue as dependency-missing so the
 		// next reconcile re-resolves (or stores a NULL target).
-		if targetExposureID != nil && infrastructure.IsFKViolation(upsertErr) {
+		if targetExposureID != nil && infrastructure.IsFKViolation(upsertErr, fkTargetExposure) {
 			r.deps.EvictAPIExposureByBasePath(data.TargetBasePath)
 			return runtime.WrapDependencyMissing("api_exposure", data.TargetBasePath)
 		}

--- a/projector/internal/domain/apisubscription/repository_test.go
+++ b/projector/internal/domain/apisubscription/repository_test.go
@@ -384,6 +384,33 @@ var _ = Describe("ApiSubscription Repository", func() {
 			Expect(sub.M2mAuthMethod.String()).To(Equal("OAUTH2_CLIENT"))
 		})
 
+		It("should return an error when the cached target exposure ID is stale", func() {
+			// Cached exposure ID points to a row that does not exist. On a
+			// Postgres backend this surfaces as an FK violation (23503) which
+			// the repository maps to ErrDependencyMissing after evicting the
+			// stale cache entry (see IsFKViolation + fkTargetExposure).
+			// ponytail: the repo test harness is SQLite, whose FK error is not
+			// a *pgconn.PgError, so the pg-specific remap branch cannot fire
+			// here; the constraint-name matching itself is unit-tested in
+			// infrastructure/errors_test.go. We assert the stale ID is not
+			// silently persisted.
+			staleDeps := &mockSubscriptionDeps{
+				appIDs:      map[string]int{"consumer-app:platform--narvi": appID},
+				exposureIDs: map[string]int{"/api/v1/users": exposureID + 9999}, // nonexistent
+			}
+			repo = apisubscription.NewRepository(client, cache, staleDeps)
+
+			err := repo.Upsert(ctx, baseData())
+			Expect(err).To(HaveOccurred())
+
+			// The bad target FK must not have been persisted.
+			count, err := client.ApiSubscription.Query().
+				Where(entapisub.BasePathEQ("/api/v1/users")).
+				Count(ctx)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(count).To(Equal(0))
+		})
+
 		It("should maintain meta cache entry", func() {
 			data := baseData()
 			Expect(repo.Upsert(ctx, data)).To(Succeed())

--- a/projector/internal/domain/apisubscription/repository_test.go
+++ b/projector/internal/domain/apisubscription/repository_test.go
@@ -53,6 +53,10 @@ func (m *mockSubscriptionDeps) FindAPIExposureByBasePath(_ context.Context, base
 	return 0, fmt.Errorf("api_exposure basePath %q: %w", basePath, infrastructure.ErrEntityNotFound)
 }
 
+func (m *mockSubscriptionDeps) EvictAPIExposureByBasePath(basePath string) {
+	delete(m.exposureIDs, basePath)
+}
+
 var _ = Describe("ApiSubscription Repository", func() {
 	var (
 		client     *ent.Client

--- a/projector/internal/domain/approval/repository.go
+++ b/projector/internal/domain/approval/repository.go
@@ -130,7 +130,7 @@ func (r *Repository) Upsert(ctx context.Context, data *ApprovalData) error {
 		UpdateNewValues().
 		ID(ctx)
 	if upsertErr != nil {
-		if infrastructure.IsFKViolation(upsertErr) {
+		if infrastructure.IsFKViolation(upsertErr, "") {
 			r.evictSubscriptionCache(data)
 			return runtime.WrapDependencyMissing("api_subscription",
 				data.SubscriptionNamespace+"/"+data.SubscriptionName)
@@ -152,7 +152,7 @@ func (r *Repository) Upsert(ctx context.Context, data *ApprovalData) error {
 		update = update.SetAPISubscriptionID(subID).ClearEventSubscription()
 	}
 	if err := update.Exec(ctx); err != nil {
-		if infrastructure.IsFKViolation(err) {
+		if infrastructure.IsFKViolation(err, "") {
 			r.evictSubscriptionCache(data)
 			return runtime.WrapDependencyMissing("api_subscription",
 				data.SubscriptionNamespace+"/"+data.SubscriptionName)

--- a/projector/internal/domain/approvalrequest/repository.go
+++ b/projector/internal/domain/approvalrequest/repository.go
@@ -130,7 +130,7 @@ func (r *Repository) Upsert(ctx context.Context, data *ApprovalRequestData) erro
 		UpdateNewValues().
 		ID(ctx)
 	if upsertErr != nil {
-		if infrastructure.IsFKViolation(upsertErr) {
+		if infrastructure.IsFKViolation(upsertErr, "") {
 			r.evictSubscriptionCache(data)
 			return runtime.WrapDependencyMissing("api_subscription",
 				data.SubscriptionNamespace+"/"+data.SubscriptionName)
@@ -152,7 +152,7 @@ func (r *Repository) Upsert(ctx context.Context, data *ApprovalRequestData) erro
 		update = update.SetAPISubscriptionID(subID).ClearEventSubscription()
 	}
 	if err := update.Exec(ctx); err != nil {
-		if infrastructure.IsFKViolation(err) {
+		if infrastructure.IsFKViolation(err, "") {
 			r.evictSubscriptionCache(data)
 			return runtime.WrapDependencyMissing("api_subscription",
 				data.SubscriptionNamespace+"/"+data.SubscriptionName)

--- a/projector/internal/infrastructure/errors.go
+++ b/projector/internal/infrastructure/errors.go
@@ -15,13 +15,14 @@ import (
 var ErrEntityNotFound = errors.New("entity not found")
 
 // IsFKViolation reports whether err (or any error in its chain) is a
-// PostgreSQL foreign-key constraint violation (SQLSTATE 23503).
-// This is used to detect races where a cached FK ID points to a row that
-// no longer exists in the database.
-func IsFKViolation(err error) bool {
+// PostgreSQL foreign-key constraint violation (SQLSTATE 23503) on the named
+// constraint. This is used to detect races where a cached FK ID points to a
+// row that no longer exists in the database. Passing an empty constraint
+// matches any FK violation.
+func IsFKViolation(err error, constraint string) bool {
 	var pgErr *pgconn.PgError
 	if errors.As(err, &pgErr) {
-		return pgErr.Code == "23503"
+		return pgErr.Code == "23503" && (constraint == "" || pgErr.ConstraintName == constraint)
 	}
 	return false
 }

--- a/projector/internal/infrastructure/errors_test.go
+++ b/projector/internal/infrastructure/errors_test.go
@@ -18,25 +18,35 @@ import (
 var _ = Describe("IsFKViolation", func() {
 	It("should return true for a PostgreSQL foreign key violation (23503)", func() {
 		pgErr := &pgconn.PgError{Code: "23503"}
-		Expect(infrastructure.IsFKViolation(pgErr)).To(BeTrue())
+		Expect(infrastructure.IsFKViolation(pgErr, "")).To(BeTrue())
 	})
 
 	It("should return true for a wrapped foreign key violation", func() {
 		pgErr := &pgconn.PgError{Code: "23503"}
 		wrapped := fmt.Errorf("upsert failed: %w", pgErr)
-		Expect(infrastructure.IsFKViolation(wrapped)).To(BeTrue())
+		Expect(infrastructure.IsFKViolation(wrapped, "")).To(BeTrue())
+	})
+
+	It("should match a named constraint", func() {
+		pgErr := &pgconn.PgError{Code: "23503", ConstraintName: "fk_target"}
+		Expect(infrastructure.IsFKViolation(pgErr, "fk_target")).To(BeTrue())
+	})
+
+	It("should return false for a different constraint name", func() {
+		pgErr := &pgconn.PgError{Code: "23503", ConstraintName: "fk_owner"}
+		Expect(infrastructure.IsFKViolation(pgErr, "fk_target")).To(BeFalse())
 	})
 
 	It("should return false for a different PostgreSQL error code", func() {
 		pgErr := &pgconn.PgError{Code: "23505"} // unique_violation
-		Expect(infrastructure.IsFKViolation(pgErr)).To(BeFalse())
+		Expect(infrastructure.IsFKViolation(pgErr, "")).To(BeFalse())
 	})
 
 	It("should return false for a non-PostgreSQL error", func() {
-		Expect(infrastructure.IsFKViolation(errors.New("some error"))).To(BeFalse())
+		Expect(infrastructure.IsFKViolation(errors.New("some error"), "")).To(BeFalse())
 	})
 
 	It("should return false for nil", func() {
-		Expect(infrastructure.IsFKViolation(nil)).To(BeFalse())
+		Expect(infrastructure.IsFKViolation(nil, "")).To(BeFalse())
 	})
 })

--- a/projector/internal/infrastructure/idresolver.go
+++ b/projector/internal/infrastructure/idresolver.go
@@ -407,6 +407,16 @@ func (r *IDResolver) EvictAPISubscription(namespace, name string) {
 	r.clearNegCache(et + ":" + lk)
 }
 
+// EvictAPIExposureByBasePath removes the cached DB primary key for an
+// ApiExposure identified by base path. Called when a FK constraint violation
+// indicates the cached exposure ID is stale (e.g. the exposure row was deleted
+// out from under a subscription that still had it cached).
+func (r *IDResolver) EvictAPIExposureByBasePath(basePath string) {
+	et, lk := cachekeys.APIExposureByBasePath(basePath)
+	r.cache.Del(et, lk)
+	r.clearNegCache(et + ":" + lk)
+}
+
 // EvictEventSubscription removes the cached DB primary key for an
 // EventSubscription identified by namespace + name.
 func (r *IDResolver) EvictEventSubscription(namespace, name string) {

--- a/projector/internal/util/security.go
+++ b/projector/internal/util/security.go
@@ -31,6 +31,9 @@ func MapCrOAuthToCpApi(oauth *apiv1.OAuth2ClientCredentials) *model.OAuth2Client
 }
 
 func MapCrExternalIdpToCpApi(externalIdp *apiv1.ExternalIdentityProvider) *model.ExternalIdentityProvider {
+	if externalIdp == nil {
+		return nil
+	}
 	tokenRequest := string(externalIdp.TokenRequest)
 	grantType := string(externalIdp.GrantType)
 	return &model.ExternalIdentityProvider{

--- a/projector/internal/util/security.go
+++ b/projector/internal/util/security.go
@@ -10,6 +10,9 @@ import (
 )
 
 func MapCrBasicAuthToCpApi(basic *apiv1.BasicAuthCredentials) *model.BasicAuthCredentials {
+	if basic == nil {
+		return nil
+	}
 	return &model.BasicAuthCredentials{
 		Username: basic.Username,
 		Password: basic.Password,
@@ -17,6 +20,9 @@ func MapCrBasicAuthToCpApi(basic *apiv1.BasicAuthCredentials) *model.BasicAuthCr
 }
 
 func MapCrOAuthToCpApi(oauth *apiv1.OAuth2ClientCredentials) *model.OAuth2ClientCredentials {
+	if oauth == nil {
+		return nil
+	}
 	return &model.OAuth2ClientCredentials{
 		ClientId:     oauth.ClientId,
 		ClientSecret: &oauth.ClientSecret,

--- a/projector/internal/util/security_test.go
+++ b/projector/internal/util/security_test.go
@@ -1,0 +1,43 @@
+// Copyright 2026 Deutsche Telekom IT GmbH
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package util_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	apiv1 "github.com/telekom/controlplane/api/api/v1"
+	"github.com/telekom/controlplane/projector/internal/util"
+)
+
+func TestSecurity(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Security Util Suite")
+}
+
+var _ = Describe("Credential mappers nil-safety", func() {
+	It("MapCrBasicAuthToCpApi returns nil for nil input", func() {
+		Expect(util.MapCrBasicAuthToCpApi(nil)).To(BeNil())
+	})
+
+	It("MapCrOAuthToCpApi returns nil for nil input", func() {
+		Expect(util.MapCrOAuthToCpApi(nil)).To(BeNil())
+	})
+
+	It("MapCrExternalIdpToCpApi returns nil for nil input", func() {
+		Expect(util.MapCrExternalIdpToCpApi(nil)).To(BeNil())
+	})
+
+	It("MapCrExternalIdpToCpApi maps nil nested creds to nil without panic", func() {
+		idp := util.MapCrExternalIdpToCpApi(&apiv1.ExternalIdentityProvider{
+			TokenEndpoint: "https://idp/token",
+		})
+		Expect(idp).NotTo(BeNil())
+		Expect(idp.Basic).To(BeNil())
+		Expect(idp.Client).To(BeNil())
+	})
+})


### PR DESCRIPTION
- **fix(projector): make api-sub and api-exp relation more stable by evicting stale keys in cache**
- **fix(projector): make security-mapping nil-safe**
