### PR TITLE
fix/set controller runtime logger

### DIFF
--- a/api/internal/handler/apiexposure/handler.go
+++ b/api/internal/handler/apiexposure/handler.go
@@ -109,6 +109,17 @@ func (h *ApiExposureHandler) CreateOrUpdate(ctx context.Context, apiExp *apiapi.
 		return err
 	}
 
+	// 4. Cleanup stale routes for this basepath. Must run after all routes (proxy,
+	// failover, real) are created/updated so only genuinely orphaned routes are deleted.
+	// Catches routes orphaned when a zone change moves the derived route namespace.
+	deleted, err := util.CleanupStaleRoutes(ctx, apiExp.Spec.ApiBasePath)
+	if err != nil {
+		return errors.Wrap(err, "failed to cleanup stale routes")
+	}
+	if deleted > 0 {
+		logger.V(1).Info("Cleaned up stale routes", "deleted", deleted)
+	}
+
 	apiExp.SetCondition(condition.NewReadyCondition(condition.ReasonProvisioned, "Successfully provisioned subresources"))
 	apiExp.SetCondition(condition.NewDoneProcessingCondition("Successfully provisioned subresources"))
 	apiExp.Status.Route = types.ObjectRefFromObject(realRoute)
@@ -221,6 +232,7 @@ func (h *ApiExposureHandler) manageProxyRoutes(ctx context.Context, apiExp *apia
 
 		options := []util.CreateRouteOption{
 			util.WithRealmName(state.realmName),
+			util.WithOwner(apiExp),
 		}
 
 		// Pass provider failover zones if configured (so the proxy route knows the secondary targets)
@@ -256,15 +268,6 @@ func (h *ApiExposureHandler) manageProxyRoutes(ctx context.Context, apiExp *apia
 		return err
 	}
 
-	// Cleanup stale proxy routes that were not touched in this reconciliation
-	deleted, err := util.CleanupStaleProxyRoutes(ctx, apiExp.Spec.ApiBasePath)
-	if err != nil {
-		return errors.Wrap(err, "failed to cleanup stale proxy routes")
-	}
-	if deleted > 0 {
-		logger.V(1).Info("Cleaned up stale proxy routes", "deleted", deleted)
-	}
-
 	return nil
 }
 
@@ -290,6 +293,7 @@ func (h *ApiExposureHandler) createFailoverRoutes(ctx context.Context, apiExp *a
 
 		options := []util.CreateRouteOption{
 			util.WithRealmName(state.realmName),
+			util.WithOwner(apiExp),
 		}
 
 		// If the provider failover zone has the ConsumerFailover feature enabled, enrich the failover route with all consumer failover hostnames, paths, and issuers.

--- a/api/internal/handler/apiexposure/handler_test.go
+++ b/api/internal/handler/apiexposure/handler_test.go
@@ -289,7 +289,7 @@ var _ = Describe("ApiExposureHandler", func() {
 			Return(controllerutil.OperationResultCreated, nil).Times(times)
 	}
 
-	// mockCleanup mocks the Cleanup call for CleanupStaleProxyRoutes.
+	// mockCleanup mocks the Cleanup call for CleanupStaleRoutes.
 	mockCleanup := func() {
 		fakeClient.EXPECT().
 			Cleanup(ctx, mock.AnythingOfType("*v1.RouteList"), mock.Anything).
@@ -365,6 +365,8 @@ var _ = Describe("ApiExposureHandler", func() {
 				// Proxy route (created first)
 				proxy := routes[0]
 				Expect(proxy.Labels).To(HaveKeyWithValue("cp.ei.telekom.de/type", "proxy"))
+				// Proxy route is owner-stamped (informational: records the provisioning owner)
+				Expect(proxy.Labels).To(HaveKeyWithValue("cp.ei.telekom.de/owner.uid", "exp-uid"))
 				Expect(proxy.Namespace).To(Equal("ns-b"))
 				Expect(proxy.Spec.Type).To(Equal(gatewayapi.RouteTypeProxy))
 				Expect(proxy.Spec.Hostnames).To(ContainElement("zone-b.gw.example.com"))
@@ -375,6 +377,8 @@ var _ = Describe("ApiExposureHandler", func() {
 				// Real route (created second)
 				real := routes[1]
 				Expect(real.Labels).To(HaveKeyWithValue("cp.ei.telekom.de/type", "real"))
+				// Real route is owner-stamped as well
+				Expect(real.Labels).To(HaveKeyWithValue("cp.ei.telekom.de/owner.uid", "exp-uid"))
 				Expect(real.Namespace).To(Equal("ns-a"))
 				Expect(real.Spec.Type).To(Equal(gatewayapi.RouteTypePrimary))
 				Expect(real.Spec.Hostnames).To(ContainElement("zone-a.gw.example.com"))
@@ -564,6 +568,127 @@ var _ = Describe("ApiExposureHandler", func() {
 				Expect(obj.Status.Route).ToNot(BeNil())
 			})
 		})
+
+		// Scenario: Zone change orphans the previous real route.
+		//
+		// The exposure lived in zone-b (Status.Route in ns-b) and moves to zone-a.
+		// createRealRoute creates a new real route in ns-a; the stale real route in ns-b is
+		// removed by the CleanupStaleRoutes sweep, which selects by basepath only so it also
+		// covers real routes. The sweep must run only after the real route is created.
+		Context("zone change: sweep cleans up the orphaned real route", func() {
+			It("runs a basepath-only sweep after creating the new real route", func() {
+				obj := newApiExposure(basePath, zoneARef)
+				// Place the real route in zone-b's namespace to represent the pre-move state.
+				obj.Status.Route = &ctypes.ObjectRef{
+					Name:      util.MakeRouteName(basePath),
+					Namespace: "ns-b",
+				}
+
+				// --- Preamble ---
+				mockListApis([]apiapi.Api{makeReadyApi(basePath)})
+				mockListApiExposures([]apiapi.ApiExposure{*obj})
+				mockGetApplication()
+				mockGetTeamNotFound()
+
+				// --- Step 1: determineRoutingState (no subscribers → only real route) ---
+				mockListSubscriptions([]apiapi.ApiSubscription{})
+
+				// --- Step 2/3: Zone Gets for exposure zone (determineRoutingState + real route) ---
+				mockGetZone(zoneARef.K8s(), zoneA(), 2)
+
+				// Track ordering: the real route must be created before the sweep runs.
+				var events []string
+
+				fakeClient.EXPECT().
+					CreateOrUpdate(ctx, mock.AnythingOfType("*v1.Route"), mock.Anything).
+					Run(func(_ context.Context, o client.Object, mutate controllerutil.MutateFn) {
+						Expect(mutate()).To(Succeed())
+						events = append(events, "create:"+o.(*gatewayapi.Route).Namespace)
+					}).
+					Return(controllerutil.OperationResultCreated, nil).Once()
+
+				var cleanupOpts []client.ListOption
+				fakeClient.EXPECT().
+					Cleanup(ctx, mock.AnythingOfType("*v1.RouteList"), mock.Anything).
+					Run(func(_ context.Context, _ ctypes.ObjectList, opts []client.ListOption) {
+						events = append(events, "cleanup")
+						cleanupOpts = opts
+					}).
+					Return(1, nil).Once()
+
+				// --- Execute ---
+				err := h.CreateOrUpdate(ctx, obj)
+				Expect(err).ToNot(HaveOccurred())
+
+				// --- Assertions ---
+				// The real route was created before the cleanup sweep ran.
+				Expect(events).To(Equal([]string{"create:ns-a", "cleanup"}))
+
+				// The sweep selects by basepath only (no type filter), so it can also
+				// delete orphaned real routes.
+				Expect(cleanupOpts).To(HaveLen(1))
+				matchingLabels, ok := cleanupOpts[0].(client.MatchingLabels)
+				Expect(ok).To(BeTrue())
+				Expect(matchingLabels).To(HaveKey(apiapi.BasePathLabelKey))
+				Expect(matchingLabels).ToNot(HaveKey("cp.ei.telekom.de/type"))
+
+				// Status now points at the new route in ns-a
+				Expect(obj.Status.Route).ToNot(BeNil())
+				Expect(obj.Status.Route.Namespace).To(Equal("ns-a"))
+			})
+		})
+	})
+})
+
+var _ = Describe("ApiMustExist route cleanup", func() {
+	const basePath = "/my/api/v1"
+
+	var (
+		ctx        context.Context
+		fakeClient *fakeclient.MockJanitorClient
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		ctx = contextutil.WithEnv(ctx, testEnv)
+		fakeClient = fakeclient.NewMockJanitorClient(GinkgoT())
+		ctx = cclient.WithClient(ctx, fakeClient)
+	})
+
+	// When the corresponding Api is not registered/active, ApiMustExist cleans up all
+	// routes for this basepath (proxy, real, and failover) across namespaces via the same
+	// basepath-scoped sweep (CleanupStaleRoutes) the reconcile path uses.
+	It("cleans up all routes by basepath when the Api is missing", func() {
+		obj := newApiExposure(basePath, ctypes.ObjectRef{Name: "zone-a", Namespace: "ns-a"})
+
+		// FindActiveAPI → empty list → API not found, triggering the cleanup path.
+		fakeClient.EXPECT().
+			List(ctx, mock.AnythingOfType("*v1.ApiList"), mock.Anything, mock.Anything).
+			Run(func(_ context.Context, list client.ObjectList, _ ...client.ListOption) {
+				*list.(*apiapi.ApiList) = apiapi.ApiList{}
+			}).
+			Return(nil).Once()
+
+		var cleanupOpts []client.ListOption
+		fakeClient.EXPECT().
+			Cleanup(ctx, mock.AnythingOfType("*v1.RouteList"), mock.Anything).
+			Run(func(_ context.Context, _ ctypes.ObjectList, opts []client.ListOption) {
+				cleanupOpts = opts
+			}).
+			Return(0, nil).Once()
+
+		api, err := ApiMustExist(ctx, obj)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(api).To(BeNil())
+
+		// Cleanup must be basepath-scoped (matching the reconcile-time stale sweep) and must
+		// NOT filter by type or owner.uid, so it removes proxy, real, and failover routes.
+		Expect(cleanupOpts).To(HaveLen(1))
+		matchingLabels, ok := cleanupOpts[0].(client.MatchingLabels)
+		Expect(ok).To(BeTrue())
+		Expect(matchingLabels).To(HaveKey(apiapi.BasePathLabelKey))
+		Expect(matchingLabels).ToNot(HaveKey("cp.ei.telekom.de/type"))
+		Expect(matchingLabels).ToNot(HaveKey("cp.ei.telekom.de/owner.uid"))
 	})
 })
 

--- a/api/internal/handler/apiexposure/util.go
+++ b/api/internal/handler/apiexposure/util.go
@@ -10,14 +10,13 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	apiv1 "github.com/telekom/controlplane/api/api/v1"
 	"github.com/telekom/controlplane/api/internal/handler/util"
-	cclient "github.com/telekom/controlplane/common/pkg/client"
 	"github.com/telekom/controlplane/common/pkg/condition"
 	"github.com/telekom/controlplane/common/pkg/config"
 	"github.com/telekom/controlplane/common/pkg/types"
-	gatewayapi "github.com/telekom/controlplane/gateway/api/v1"
 )
 
 // setAlreadyExposedConditions sets NotReady and Blocked conditions on the new ApiExposure
@@ -76,20 +75,22 @@ func ApiExposureMustNotAlreadyExist(ctx context.Context, candidate *apiv1.ApiExp
 // ApiMustExist checks if there is an active Api corresponding to the given ApiExposure.
 // If not, it sets appropriate conditions on the ApiExposure and cleans up owned Routes.
 func ApiMustExist(ctx context.Context, apiExp *apiv1.ApiExposure) (*apiv1.Api, error) {
-	janitorClient := cclient.ClientFromContextOrDie(ctx)
-
 	found, api, err := util.FindActiveAPI(ctx, apiExp.Spec.ApiBasePath)
 	if err != nil {
 		return nil, err
 	}
 
 	if !found {
-		routeList := &gatewayapi.RouteList{}
-		// Using ownedByLabel to cleanup all routes that are owned by the ApiExposure
-		_, err := janitorClient.Cleanup(ctx, routeList, cclient.OwnedByLabel(apiExp))
+		// No active Api means no routes should exist for this basepath. Since nothing is
+		// provisioned this reconciliation, the janitor treats every route for the basepath
+		// as stale and removes all of them (proxy, real, and failover).
+		deleted, err := util.CleanupStaleRoutes(ctx, apiExp.Spec.ApiBasePath)
 		if err != nil {
 			return nil, errors.Wrapf(err,
-				"failed to cleanup owned routes for ApiExposure: %s in namespace: %s", apiExp.Name, apiExp.Namespace)
+				"failed to cleanup routes for ApiExposure: %s in namespace: %s", apiExp.Name, apiExp.Namespace)
+		}
+		if deleted > 0 {
+			log.FromContext(ctx).V(1).Info("Cleaned up routes for ApiExposure with missing Api", "deleted", deleted)
 		}
 
 		apiExp.SetCondition(condition.NewNotReadyCondition(condition.ReasonPreconditionNotMet,

--- a/api/internal/handler/apisubscription/handler.go
+++ b/api/internal/handler/apisubscription/handler.go
@@ -347,7 +347,7 @@ func resolveFailoverRouteRef(ctx context.Context, scopedClient cclient.JanitorCl
 func (h *ApiSubscriptionHandler) Delete(ctx context.Context, apiSub *apiapi.ApiSubscription) error {
 	// All route lifecycle (proxy + failover) is managed by ApiExposure.
 	// When this subscription is deleted, ApiExposure reconciles (via watch) and
-	// CleanupStaleProxyRoutes removes routes for zones with no remaining subscribers.
+	// CleanupStaleRoutes removes routes for zones with no remaining subscribers.
 	return nil
 }
 

--- a/api/internal/handler/apisubscription/remote/handler.go
+++ b/api/internal/handler/apisubscription/remote/handler.go
@@ -154,7 +154,7 @@ func HandleRemoteApiSubscription(ctx context.Context, owner *apiapi.ApiSubscript
 	if !remoteOrg.Spec.Zone.Equals(subscriptionZone) {
 		logger.Info("RemoteApiSubscription is in a different zone")
 
-		route, routeErr := util.CreateProxyRoute(ctx, owner.Spec.Zone, remoteOrg.Spec.Zone, owner.Spec.ApiBasePath)
+		route, routeErr := util.CreateProxyRoute(ctx, owner.Spec.Zone, remoteOrg.Spec.Zone, owner.Spec.ApiBasePath, util.WithOwner(owner))
 		if routeErr != nil {
 			return errors.Wrapf(routeErr, "failed to create proxy route")
 		}

--- a/api/internal/handler/util/route_util.go
+++ b/api/internal/handler/util/route_util.go
@@ -70,6 +70,11 @@ type CreateRouteOptions struct {
 	// (ProviderClientId, BasePath) have been resolved to literals in the handler.
 	// When set, it overrides the claims mapped from the exposure's own security spec.
 	ResolvedClaims *apiapi.Claims
+
+	// OwnerUID is the UID of the resource that owns this route. When set, it is stamped
+	// onto the route as the owner.uid label. The label is informational (records which
+	// resource provisioned the route); route cleanup is keyed by basepath, not this label.
+	OwnerUID string
 }
 
 type CreateRouteOption func(*CreateRouteOptions)
@@ -183,6 +188,15 @@ func WithRealmName(realmName string) CreateRouteOption {
 	}
 }
 
+// WithOwner stamps the owner.uid label on the route using the owner's UID.
+// The label is informational (debugging/observability): it records which resource
+// provisioned the route. Route cleanup is keyed by basepath, not by this label.
+func WithOwner(owner metav1.Object) CreateRouteOption {
+	return func(opts *CreateRouteOptions) {
+		opts.OwnerUID = string(owner.GetUID())
+	}
+}
+
 // IsFailoverSecondary checks if the route is a failover secondary route.
 // This means that this route has the real upstream as a failover upstream.
 func (o *CreateRouteOptions) IsFailoverSecondary() bool {
@@ -260,6 +274,9 @@ func CreateProxyRoute(ctx context.Context, downstreamZoneRef, upstreamZoneRef ty
 			apiapi.BasePathLabelKey:      labelutil.NormalizeLabelValue(apiBasePath),
 			config.BuildLabelKey("zone"): labelutil.NormalizeValue(downstreamZone.GetName()),
 			config.BuildLabelKey("type"): "proxy",
+		}
+		if options.OwnerUID != "" {
+			proxyRoute.Labels[config.OwnerUidLabelKey] = options.OwnerUID
 		}
 
 		// Upstream for proxy route: points at the upstream zone's gateway URL for this basepath
@@ -484,24 +501,26 @@ func CleanupProxyRoute(ctx context.Context, routeRef *types.ObjectRef, opts ...C
 	return nil
 }
 
-// CleanupStaleProxyRoutes uses the JanitorClient's Cleanup() to delete any stale proxy Routes
-// for the given apiBasePath that were NOT created/updated in this reconciliation cycle.
-// This handles zone changes: when subscriptions move or are deleted, old proxy routes are cleaned up.
-// NOTE: This does NOT delete provider failover routes (labeled with failover.secondary=true),
-// as those are managed separately by ApiExposure and should not be cleaned up here.
-func CleanupStaleProxyRoutes(ctx context.Context, apiBasePath string) (int, error) {
+// CleanupStaleRoutes deletes any Routes (proxy, secondary/failover, and real) for the
+// given apiBasePath that were not created/updated in this reconciliation cycle, using the
+// JanitorClient's Cleanup(). This removes routes orphaned when a zone change moves their
+// derived namespace: the janitor tracks routes touched via CreateOrUpdate this cycle, so
+// listing all routes for the basepath and deleting the untouched ones sweeps up orphans.
+//
+// IMPORTANT: Call only AFTER all routes for this reconciliation (proxy, failover, and
+// real) have been created/updated, otherwise routes not yet provisioned this cycle would
+// be deleted.
+func CleanupStaleRoutes(ctx context.Context, apiBasePath string) (int, error) {
 	c := cclient.ClientFromContextOrDie(ctx)
 
-	// Use janitor's Cleanup for all proxy routes with this basepath
-	// The janitor will only delete routes that were NOT touched in this reconciliation cycle
+	// Cleanup deletes only routes for this basepath not touched this cycle.
 	deleted, err := c.Cleanup(ctx, &gatewayapi.RouteList{}, []client.ListOption{
 		client.MatchingLabels{
-			apiapi.BasePathLabelKey:      labelutil.NormalizeLabelValue(apiBasePath),
-			config.BuildLabelKey("type"): "proxy",
+			apiapi.BasePathLabelKey: labelutil.NormalizeLabelValue(apiBasePath),
 		},
 	})
 	if err != nil {
-		return deleted, errors.Wrapf(err, "failed to cleanup stale proxy routes for basepath %q", apiBasePath)
+		return deleted, errors.Wrapf(err, "failed to cleanup stale routes for basepath %q", apiBasePath)
 	}
 
 	return deleted, nil
@@ -536,6 +555,9 @@ func CreateRealRoute(ctx context.Context, downstreamZoneRef types.ObjectRef, api
 			apiapi.BasePathLabelKey:      labelutil.NormalizeLabelValue(apiExposure.Spec.ApiBasePath),
 			config.BuildLabelKey("zone"): labelutil.NormalizeValue(zone.Name),
 			config.BuildLabelKey("type"): "real",
+		}
+		if apiExposure.GetUID() != "" {
+			route.Labels[config.OwnerUidLabelKey] = string(apiExposure.GetUID())
 		}
 
 		gatewayUpstreams := make([]gatewayapi.Upstream, 0, len(apiExposure.Spec.Upstreams))

--- a/discovery-server/cmd/main.go
+++ b/discovery-server/cmd/main.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/go-logr/logr"
 	kconfig "sigs.k8s.io/controller-runtime/pkg/client/config"
+	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
 
 	cserver "github.com/telekom/controlplane/common-server/pkg/server"
 	"github.com/telekom/controlplane/common-server/pkg/server/middleware/security"
@@ -29,6 +30,7 @@ func main() {
 	cfg := config.LoadConfig(configFile)
 
 	log.Init(cfg.Log)
+	ctrllog.SetLogger(log.Log) // controller-runtime internals (informer cache) log via its root logger
 	rootCtx := logr.NewContext(context.Background(), log.Log)
 
 	stores := store.NewStores(rootCtx, kconfig.GetConfigOrDie(),

--- a/rover-server/cmd/main.go
+++ b/rover-server/cmd/main.go
@@ -17,6 +17,7 @@ import (
 	roverin "github.com/telekom/controlplane/rover-server/internal/mapper/rover/in"
 	"github.com/telekom/controlplane/rover-server/internal/oaslint"
 	kconfig "sigs.k8s.io/controller-runtime/pkg/client/config"
+	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/telekom/controlplane/rover-server/internal/config"
 	"github.com/telekom/controlplane/rover-server/internal/controller"
@@ -34,6 +35,7 @@ func main() {
 	roverin.MigrationActive = cfg.Migration.Active
 
 	log.Init(cfg.Log)
+	ctrllog.SetLogger(log.Log) // controller-runtime internals (informer cache) log via its root logger
 	rootCtx := logr.NewContext(context.Background(), log.Log)
 
 	stores := store.NewStores(rootCtx, kconfig.GetConfigOrDie(),


### PR DESCRIPTION
- **fix(api): clean up stale ApiExposure routes on zone change**
- **fix(servers): register logger with controller-runtime in rover/discovery servers**
