### PR TITLE
fix(servers): register logger with controller-runtime in rover/discovery servers

### DIFF
--- a/discovery-server/cmd/main.go
+++ b/discovery-server/cmd/main.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/go-logr/logr"
 	kconfig "sigs.k8s.io/controller-runtime/pkg/client/config"
+	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
 
 	cserver "github.com/telekom/controlplane/common-server/pkg/server"
 	"github.com/telekom/controlplane/common-server/pkg/server/middleware/security"
@@ -29,6 +30,7 @@ func main() {
 	cfg := config.LoadConfig(configFile)
 
 	log.Init(cfg.Log)
+	ctrllog.SetLogger(log.Log) // controller-runtime internals (informer cache) log via its root logger
 	rootCtx := logr.NewContext(context.Background(), log.Log)
 
 	stores := store.NewStores(rootCtx, kconfig.GetConfigOrDie(),

--- a/rover-server/cmd/main.go
+++ b/rover-server/cmd/main.go
@@ -17,6 +17,7 @@ import (
 	roverin "github.com/telekom/controlplane/rover-server/internal/mapper/rover/in"
 	"github.com/telekom/controlplane/rover-server/internal/oaslint"
 	kconfig "sigs.k8s.io/controller-runtime/pkg/client/config"
+	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/telekom/controlplane/rover-server/internal/config"
 	"github.com/telekom/controlplane/rover-server/internal/controller"
@@ -34,6 +35,7 @@ func main() {
 	roverin.MigrationActive = cfg.Migration.Active
 
 	log.Init(cfg.Log)
+	ctrllog.SetLogger(log.Log) // controller-runtime internals (informer cache) log via its root logger
 	rootCtx := logr.NewContext(context.Background(), log.Log)
 
 	stores := store.NewStores(rootCtx, kconfig.GetConfigOrDie(),


### PR DESCRIPTION
Both servers call controller-runtime's log package but never called SetLogger,
so its internals fell back to the unset root logger and emitted a
'log.SetLogger(...) was never called' warning + stack dump.

Add ctrllog.SetLogger(log.Log) after log.Init, reusing the existing zap logger.
