### PR TITLE
fix(controller): use rate-limited retries for reconciliation errors

### DIFF
--- a/common/pkg/controller/controller.go
+++ b/common/pkg/controller/controller.go
@@ -60,11 +60,11 @@ func (c *ControllerImpl[T]) Reconcile(ctx context.Context, req reconcile.Request
 			logger.V(1).Info("Fetched object but it was not found")
 			return reconcile.Result{}, nil
 		}
-		return HandleError(ctx, err, object, c.Recorder), nil
+		return HandleError(ctx, err, object, c.Recorder)
 	}
 
 	if changed, setupErr := FirstSetup(ctx, c.Client, object); setupErr != nil {
-		return HandleError(ctx, setupErr, object, c.Recorder), nil
+		return HandleError(ctx, setupErr, object, c.Recorder)
 	} else if changed {
 		return reconcile.Result{}, nil
 	}
@@ -78,7 +78,7 @@ func (c *ControllerImpl[T]) Reconcile(ctx context.Context, req reconcile.Request
 		if object.SetCondition(condition.NewBlockedCondition("Environment label is missing")) {
 			StampObservedGeneration(object)
 			if updateErr := c.Client.Status().Update(ctx, object); updateErr != nil {
-				return HandleError(ctx, updateErr, object, c.Recorder), nil
+				return HandleError(ctx, updateErr, object, c.Recorder)
 			}
 		}
 		return reconcile.Result{}, nil
@@ -102,12 +102,12 @@ func (c *ControllerImpl[T]) Reconcile(ctx context.Context, req reconcile.Request
 	err = c.Handler.CreateOrUpdate(ctx, object)
 	if err != nil {
 		EnsureNotReadyOnError(ctx, c.Client, object, err)
-		result := HandleError(ctx, err, object, c.Recorder)
+		result, retryErr := HandleError(ctx, err, object, c.Recorder)
 		StampObservedGeneration(object)
 		if statusErr := c.Client.Status().Update(ctx, object); statusErr != nil {
-			return HandleError(ctx, statusErr, object, c.Recorder), nil
+			return HandleError(ctx, statusErr, object, c.Recorder)
 		}
-		return result, nil
+		return result, retryErr
 	}
 
 	// Success
@@ -120,7 +120,7 @@ func (c *ControllerImpl[T]) Reconcile(ctx context.Context, req reconcile.Request
 
 	StampObservedGeneration(object)
 	if err = c.Client.Status().Update(ctx, object); err != nil {
-		return HandleError(ctx, err, object, c.Recorder), nil
+		return HandleError(ctx, err, object, c.Recorder)
 	}
 
 	requeueAfter := config.RequeueWithJitter()
@@ -145,17 +145,17 @@ func (c *ControllerImpl[T]) handleDeletion(ctx context.Context, object T) (recon
 	err := c.Handler.Delete(ctx, object)
 	if err != nil {
 		EnsureNotReadyOnError(ctx, c.Client, object, err)
-		result := HandleError(ctx, err, object, c.Recorder)
+		result, retryErr := HandleError(ctx, err, object, c.Recorder)
 		StampObservedGeneration(object)
 		if statusErr := c.Client.Status().Update(ctx, object); statusErr != nil {
-			return HandleError(ctx, statusErr, object, c.Recorder), nil
+			return HandleError(ctx, statusErr, object, c.Recorder)
 		}
-		return result, nil
+		return result, retryErr
 	}
 
 	if controllerutil.RemoveFinalizer(object, config.FinalizerName) {
 		if updateErr := c.Client.Update(ctx, object); updateErr != nil {
-			return HandleError(ctx, updateErr, object, c.Recorder), nil
+			return HandleError(ctx, updateErr, object, c.Recorder)
 		}
 	}
 
@@ -211,22 +211,20 @@ func FirstSetup(ctx context.Context, c client.Client, object common_types.Object
 	return false, nil
 }
 
-func HandleError(ctx context.Context, err error, obj common_types.Object, recorder record.EventRecorder) reconcile.Result {
+func HandleError(ctx context.Context, err error, obj common_types.Object, recorder record.EventRecorder) (reconcile.Result, error) {
 	if apierrors.IsConflict(err) {
-		logger := log.FromContext(ctx).WithName("controller.error-handler")
-		logger.V(0).Info("Conflict occurred during operation", "error", err)
 		if recorder != nil {
 			recorder.Event(obj, "Warning", "Conflict", err.Error())
 		}
-		return reconcile.Result{RequeueAfter: config.RetryWithJitterOnError()}
+		return reconcile.Result{}, err
 	}
 
-	conditionsUpdated, result := ctrlerrors.HandleError(ctx, obj, err, recorder)
+	conditionsUpdated, result, retryErr := ctrlerrors.HandleError(ctx, obj, err, recorder)
 	if conditionsUpdated {
 		logger := log.FromContext(ctx).WithName("controller.error-handler")
 		logger.V(1).Info("Object conditions updated after error handling", "error", err)
 	}
-	return result
+	return result, retryErr
 }
 
 // EnsureNotReadyOnError sets the Ready condition to false on the object if the error is not nil

--- a/common/pkg/controller/controller_test.go
+++ b/common/pkg/controller/controller_test.go
@@ -161,8 +161,8 @@ var _ = Describe("Controller", func() {
 			controller := NewController(errorHandler, k8sClient, &recorder)
 
 			res, err := controller.Reconcile(ctx, req, &test.TestResource{})
-			Expect(err).ToNot(HaveOccurred())
-			Expect(res.RequeueAfter).To(BeNumerically(">", 0))
+			Expect(err).To(MatchError("test error"))
+			Expect(res).To(Equal(reconcile.Result{}))
 
 			var obj test.TestResource
 			Expect(k8sClient.Get(ctx, req.NamespacedName, &obj)).To(Succeed())

--- a/common/pkg/errors/ctrlerrors/errors.go
+++ b/common/pkg/errors/ctrlerrors/errors.go
@@ -38,56 +38,54 @@ type RetryableWithDelayError interface {
 // HandleError analyzes the given error and updates the object's conditions accordingly.
 // It uses errors.As to unwrap the error chain, which supports both pkg/errors.Wrap and
 // standard fmt.Errorf %w wrapping.
-// It returns a boolean indicating whether the object's conditions were updated and a reconcile.Result
-// that suggests whether to requeue the reconciliation and after what duration.
-func HandleError(ctx context.Context, obj types.Object, err error, recorder record.EventRecorder) (bool, reconcile.Result) {
+// It returns whether conditions were updated, a result for explicit delayed retries, and an error
+// for controller-runtime's rate-limited retry queue.
+func HandleError(ctx context.Context, obj types.Object, err error, recorder record.EventRecorder) (bool, reconcile.Result, error) {
 	var be BlockedError
 	if errors.As(err, &be) && be.IsBlocked() {
-		recordError(ctx, obj, be, "Blocked", recorder)
+		log.FromContext(ctx).WithName("controller.error-handler").V(0).Info("Handling error", "reason", "Blocked", "error", be.Error())
+		recordError(obj, be, "Blocked", recorder)
 		updated := obj.SetCondition(condition.NewBlockedCondition(be.Error()))
 		return updated, reconcile.Result{
 			// Its blocked but we still want to recheck later
 			// However, with the longer interval for normal requeues
 			RequeueAfter: config.RequeueWithJitter(),
-		}
+		}, nil
 	}
 
 	var rde RetryableWithDelayError
 	if errors.As(err, &rde) {
-		recordError(ctx, obj, rde, "Retryable", recorder)
+		recordError(obj, rde, "Retryable", recorder)
 		if rde.IsRetryable() {
 			delay := rde.RetryDelay()
 			if delay <= 0 {
-				delay = config.RetryWithJitterOnError()
+				return false, reconcile.Result{}, err
 			}
-			return false, reconcile.Result{RequeueAfter: config.Jitter(delay)}
+			log.FromContext(ctx).WithName("controller.error-handler").V(0).Info("Handling error", "reason", "Retryable", "error", rde.Error())
+			return false, reconcile.Result{RequeueAfter: config.Jitter(delay)}, nil
 		} else {
-			return false, reconcile.Result{}
+			log.FromContext(ctx).WithName("controller.error-handler").V(0).Info("Handling error", "reason", "Retryable", "error", rde.Error())
+			return false, reconcile.Result{}, nil
 		}
 	}
 
 	var re RetryableError
 	if errors.As(err, &re) {
-		recordError(ctx, obj, re, "Retryable", recorder)
+		recordError(obj, re, "Retryable", recorder)
 		if re.IsRetryable() {
-			return false, reconcile.Result{RequeueAfter: config.RetryWithJitterOnError()}
+			return false, reconcile.Result{}, err
 		} else {
-			return false, reconcile.Result{}
+			// Not retryable, treat as Blocked
+			log.FromContext(ctx).WithName("controller.error-handler").V(0).Info("Handling error", "reason", "Retryable", "error", re.Error())
+			return false, reconcile.Result{RequeueAfter: config.RequeueWithJitter()}, nil
 		}
 	}
 
-	recordError(ctx, obj, err, "Unknown", recorder)
-	return false, reconcile.Result{RequeueAfter: config.RetryWithJitterOnError()}
+	recordError(obj, err, "Unknown", recorder)
+	return false, reconcile.Result{}, err
 }
 
-func recordError(ctx context.Context, obj types.Object, err error, reason string, recorder record.EventRecorder) {
-	logger := log.FromContext(ctx).WithName("controller.error-handler")
-	if reason == "Unknown" {
-		logger.Error(err, "Handling error", "reason", reason)
-	} else {
-		logger.V(0).Info("Handling error", "reason", reason, "error", err.Error())
-	}
-
+func recordError(obj types.Object, err error, reason string, recorder record.EventRecorder) {
 	if err != nil && recorder != nil {
 		recorder.Event(obj, "Warning", reason, err.Error())
 	}

--- a/common/pkg/errors/ctrlerrors/suite_test.go
+++ b/common/pkg/errors/ctrlerrors/suite_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/telekom/controlplane/common/pkg/errors/ctrlerrors"
 	"github.com/telekom/controlplane/common/pkg/test"
@@ -82,8 +83,9 @@ var _ = Describe("Test Suite", func() {
 			Expect(ctrlErr.Error()).To(Equal("This is a blocked error"))
 
 			obj := test.NewObject("blocked-obj", "default")
-			updated, result := ctrlerrors.HandleError(ctx, obj, ctrlErr, recorder)
+			updated, result, retryErr := ctrlerrors.HandleError(ctx, obj, ctrlErr, recorder)
 			Expect(updated).To(BeTrue())
+			Expect(retryErr).NotTo(HaveOccurred())
 			Expect(result.RequeueAfter).To(BeNumerically(">", 30*time.Minute))
 			condition := obj.GetConditions()[0]
 			Expect(condition.Type).To(Equal("Processing"))
@@ -103,7 +105,8 @@ var _ = Describe("Test Suite", func() {
 			Expect(myErr.Error()).To(Equal("Custom blocked error"))
 
 			obj := test.NewObject("custom-blocked-obj", "default")
-			_, result := ctrlerrors.HandleError(ctx, obj, myErr, recorder)
+			_, result, retryErr := ctrlerrors.HandleError(ctx, obj, myErr, recorder)
+			Expect(retryErr).NotTo(HaveOccurred())
 			Expect(result.RequeueAfter).To(BeNumerically(">", 30*time.Minute))
 			condition := obj.GetConditions()[0]
 			Expect(condition.Type).To(Equal("Processing"))
@@ -120,8 +123,9 @@ var _ = Describe("Test Suite", func() {
 			Expect(ctrlErr.Error()).To(Equal("This is a retryable error"))
 
 			obj := test.NewObject("retryable-obj", "default")
-			_, result := ctrlerrors.HandleError(ctx, obj, ctrlErr, recorder)
-			Expect(result.RequeueAfter).NotTo(Equal(time.Duration(0)))
+			_, result, retryErr := ctrlerrors.HandleError(ctx, obj, ctrlErr, recorder)
+			Expect(result).To(Equal(reconcile.Result{}))
+			Expect(retryErr).To(MatchError(ctrlErr))
 		})
 
 		It("should support custom retryable errors", func() {
@@ -130,8 +134,9 @@ var _ = Describe("Test Suite", func() {
 			Expect(myErr.Error()).To(Equal("Custom retryable error"))
 
 			obj := test.NewObject("custom-retryable-obj", "default")
-			_, result := ctrlerrors.HandleError(ctx, obj, myErr, recorder)
-			Expect(result.RequeueAfter).NotTo(Equal(time.Duration(0)))
+			_, result, retryErr := ctrlerrors.HandleError(ctx, obj, myErr, recorder)
+			Expect(result).To(Equal(reconcile.Result{}))
+			Expect(retryErr).To(MatchError(myErr))
 		})
 
 		It("should handle a non-retryable error correctly", func() {
@@ -139,8 +144,9 @@ var _ = Describe("Test Suite", func() {
 			standardErr := fmt.Errorf("This is a standard error")
 
 			obj := test.NewObject("non-retryable-obj", "default")
-			_, result := ctrlerrors.HandleError(ctx, obj, standardErr, recorder)
-			Expect(result.RequeueAfter).NotTo(Equal(time.Duration(0)))
+			_, result, retryErr := ctrlerrors.HandleError(ctx, obj, standardErr, recorder)
+			Expect(result).To(Equal(reconcile.Result{}))
+			Expect(retryErr).To(MatchError(standardErr))
 		})
 	})
 
@@ -153,7 +159,8 @@ var _ = Describe("Test Suite", func() {
 			Expect(ctrlErr.RetryDelay()).To(Equal(specificDelay))
 
 			obj := test.NewObject("retryable-delay-obj", "default")
-			_, result := ctrlerrors.HandleError(ctx, obj, ctrlErr, recorder)
+			_, result, retryErr := ctrlerrors.HandleError(ctx, obj, ctrlErr, recorder)
+			Expect(retryErr).NotTo(HaveOccurred())
 			Expect(result.RequeueAfter).To(BeNumerically(">", specificDelay))
 		})
 
@@ -168,7 +175,8 @@ var _ = Describe("Test Suite", func() {
 			Expect(myErr.Error()).To(Equal("Custom retryable with delay error"))
 
 			obj := test.NewObject("custom-retryable-delay-obj", "default")
-			_, result := ctrlerrors.HandleError(ctx, obj, myErr, recorder)
+			_, result, retryErr := ctrlerrors.HandleError(ctx, obj, myErr, recorder)
+			Expect(retryErr).NotTo(HaveOccurred())
 			Expect(result.RequeueAfter).To(BeNumerically(">", specificDelay))
 		})
 	})
@@ -180,7 +188,8 @@ var _ = Describe("Test Suite", func() {
 			wrappedErr2 := errors.Wrapf(wrappedErr1, "Wrapper 2")
 
 			obj := test.NewObject("cascading-obj", "default")
-			_, result := ctrlerrors.HandleError(ctx, obj, wrappedErr2, recorder)
+			_, result, retryErr := ctrlerrors.HandleError(ctx, obj, wrappedErr2, recorder)
+			Expect(retryErr).NotTo(HaveOccurred())
 			Expect(result.RequeueAfter).To(BeNumerically(">", 30*time.Minute))
 			condition := obj.GetConditions()[0]
 			Expect(condition.Type).To(Equal("Processing"))
@@ -200,8 +209,9 @@ var _ = Describe("Test Suite", func() {
 			wrappedErr := fmt.Errorf("outer context: %w", blockedErr)
 
 			obj := test.NewObject("fmtwrap-blocked-obj", "default")
-			updated, result := ctrlerrors.HandleError(ctx, obj, wrappedErr, recorder)
+			updated, result, retryErr := ctrlerrors.HandleError(ctx, obj, wrappedErr, recorder)
 			Expect(updated).To(BeTrue())
+			Expect(retryErr).NotTo(HaveOccurred())
 			Expect(result.RequeueAfter).To(BeNumerically(">", 30*time.Minute))
 			condition := obj.GetConditions()[0]
 			Expect(condition.Type).To(Equal("Processing"))
@@ -215,8 +225,9 @@ var _ = Describe("Test Suite", func() {
 			wrappedErr := fmt.Errorf("layer1: %w", fmt.Errorf("layer2: %w", retryableErr))
 
 			obj := test.NewObject("fmtwrap-retryable-obj", "default")
-			_, result := ctrlerrors.HandleError(ctx, obj, wrappedErr, recorder)
-			Expect(result.RequeueAfter).NotTo(Equal(time.Duration(0)))
+			_, result, retryErr := ctrlerrors.HandleError(ctx, obj, wrappedErr, recorder)
+			Expect(result).To(Equal(reconcile.Result{}))
+			Expect(retryErr).To(MatchError(wrappedErr))
 		})
 
 		It("must unwrap fmt.Errorf %%w wrapped retryable-with-delay errors", func() {
@@ -225,7 +236,8 @@ var _ = Describe("Test Suite", func() {
 			wrappedErr := fmt.Errorf("outer: %w", delayErr)
 
 			obj := test.NewObject("fmtwrap-delay-obj", "default")
-			_, result := ctrlerrors.HandleError(ctx, obj, wrappedErr, recorder)
+			_, result, retryErr := ctrlerrors.HandleError(ctx, obj, wrappedErr, recorder)
+			Expect(retryErr).NotTo(HaveOccurred())
 			Expect(result.RequeueAfter).To(BeNumerically(">", specificDelay))
 		})
 	})


### PR DESCRIPTION
The current error-handling ignores the rate-limiter of the controller-runtime. Therefore, we are not using the intended exponential backoff. This PR fixes this by propagating the error back to the controller-runtime.