### PR TITLE
docs(admin): fix repeat field name in secret rotation thresholds

### DIFF
--- a/docs/docs/admin-journey/features/secret-rotation.md
+++ b/docs/docs/admin-journey/features/secret-rotation.md
@@ -23,8 +23,8 @@ spec:
       gracePeriod: 168h          # 7 days
       notificationThresholds:
         - before: 720h           # exactly once with 30 days remaining
-        - before: 168h           # the for last 7 days
-          repeat: 24h       # daily
+        - before: 168h           # for the last 7 days
+          repeat: 24h            # daily
 ```
 
 ### Configuration Reference
@@ -43,7 +43,7 @@ Each threshold entry defines when a reminder email is sent relative to the secre
 | Field | Description | Example |
 | ----- | ----------- | ------- |
 | `before` | Time before expiry when the first notification is sent. | `720h` (30 days) |
-| `repeatEvery` | *(Optional)* If set, the notification repeats at this interval until expiry or the next threshold takes over. | `24h` |
+| `repeat` | *(Optional)* If set, the notification repeats at this interval until expiry or the next threshold takes over. | `24h` |
 
 :::info Duration format
 All duration fields use Go's standard duration format. Supported units are `h` (hours), `m` (minutes), and `s` (seconds). Day-based units like `d` are **not** supported — use hours instead (e.g. 7 days = `168h`, 30 days = `720h`).
@@ -55,7 +55,7 @@ All duration fields use Go's standard duration format. Supported units are `h` (
 notificationThresholds:
   - before: 720h             # Single reminder 30 days before expiry
   - before: 168h             # Daily reminders starting 7 days before expiry
-    repeatEvery: 24h
+    repeat: 24h
 ```
 
 With this configuration, a team receives a single email at 30 days, then daily emails starting at 7 days until the secret expires or is rotated.


### PR DESCRIPTION
## Summary

The admin-journey secret rotation page contradicted itself on the notification threshold repeat field: the first YAML example used `repeat`, while the configuration reference table and the example schedule used `repeatEvery`. The correct field is `repeat` — this PR aligns the table and second example with the API, and fixes a garbled comment ("the for last 7 days") in the first example.

## Evidence

The threshold type in `common/pkg/reminder/types.go` defines the field as `repeat`:

```go
Repeat *metav1.Duration `json:"repeat,omitempty"`
```

The generated Zone CRD schema (`admin/config/crd/bases`) confirms it and even documents the intended usage:

```
Example: [{before: "720h"}, {before: "168h", repeat: "24h"}]
→ single reminder at 30 days, then daily reminders starting at 7 days.
```

A Zone manifest written with `repeatEvery` would be rejected by CRD schema validation. A repo-wide search confirms no other `repeatEvery` occurrences remain.