### PR TITLE
fix(common): always requeue reconcilation after FirstSetup

### DIFF
--- a/common/pkg/controller/controller.go
+++ b/common/pkg/controller/controller.go
@@ -66,7 +66,7 @@ func (c *ControllerImpl[T]) Reconcile(ctx context.Context, req reconcile.Request
 	if changed, setupErr := FirstSetup(ctx, c.Client, object); setupErr != nil {
 		return HandleError(ctx, setupErr, object, c.Recorder)
 	} else if changed {
-		// Generation predicate will block the next reconcile loop until the object is updated, so we can requeue here to avoid a no-op reconcile.
+		// FirstSetup may only change metadata/status (e.g., add a finalizer), which might not trigger a follow-up reconcile when using a GenerationChangedPredicate; explicitly requeue to continue reconciliation.
 		return reconcile.Result{Requeue: true}, nil
 	}
 

--- a/common/pkg/controller/controller.go
+++ b/common/pkg/controller/controller.go
@@ -66,7 +66,8 @@ func (c *ControllerImpl[T]) Reconcile(ctx context.Context, req reconcile.Request
 	if changed, setupErr := FirstSetup(ctx, c.Client, object); setupErr != nil {
 		return HandleError(ctx, setupErr, object, c.Recorder)
 	} else if changed {
-		return reconcile.Result{}, nil
+		// Generation predicate will block the next reconcile loop until the object is updated, so we can requeue here to avoid a no-op reconcile.
+		return reconcile.Result{Requeue: true}, nil
 	}
 
 	logger.V(1).Info("Fetched object")

--- a/common/pkg/controller/controller_test.go
+++ b/common/pkg/controller/controller_test.go
@@ -138,7 +138,7 @@ var _ = Describe("Controller", func() {
 
 			res, err := controller.Reconcile(ctx, req, &test.TestResource{})
 			Expect(err).ToNot(HaveOccurred())
-			Expect(res).To(Equal(reconcile.Result{}))
+			Expect(res).To(Equal(reconcile.Result{Requeue: true}))
 
 			Expect(k8sClient.Get(ctx, req.NamespacedName, obj)).To(Succeed())
 			Expect(controllerutil.ContainsFinalizer(obj, config.FinalizerName)).To(BeTrue())


### PR DESCRIPTION
When FirstSetup modifies an object (e.g. adds a finalizer or initializes conditions), the controller was returning reconcile.Result{} — effectively stopping reconciliation. This relied on the generation predicate to trigger a follow-up reconcile, but the generation predicate only fires on spec changes, not on metadata or status changes produced by FirstSetup.

As a result, objects could get stuck after initial setup — the finalizer and conditions would be written, but the full reconciliation loop would never run.

Fix by returning Requeue: true after FirstSetup reports a change, so the object is always reconciled again immediately regardless of which predicates are registered on the controller.