### PR TITLE
fix(common): preserve original error when status update fails

### DIFF
--- a/common/pkg/controller/controller.go
+++ b/common/pkg/controller/controller.go
@@ -6,6 +6,7 @@ package controller
 
 import (
 	"context"
+	"errors"
 	"reflect"
 
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
@@ -108,7 +109,8 @@ func (c *ControllerImpl[T]) Reconcile(ctx context.Context, req reconcile.Request
 		EnsureNotReadyOnError(ctx, c.Client, object, err)
 		result, retryErr := HandleError(ctx, err, object, c.Recorder)
 		if statusErr := c.updateStatusIfChanged(ctx, original, object); statusErr != nil {
-			return HandleError(ctx, statusErr, object, c.Recorder)
+			result, statusErr = HandleError(ctx, statusErr, object, c.Recorder)
+			retryErr = errors.Join(retryErr, statusErr)
 		}
 		return result, retryErr
 	}
@@ -185,7 +187,8 @@ func (c *ControllerImpl[T]) handleDeletion(ctx context.Context, object T) (recon
 		result, retryErr := HandleError(ctx, err, object, c.Recorder)
 		StampObservedGeneration(object)
 		if statusErr := c.Client.Status().Update(ctx, object); statusErr != nil {
-			return HandleError(ctx, statusErr, object, c.Recorder)
+			result, statusErr = HandleError(ctx, statusErr, object, c.Recorder)
+			retryErr = errors.Join(retryErr, statusErr)
 		}
 		return result, retryErr
 	}


### PR DESCRIPTION
When the status update after a reconcile error also failed, the original error was discarded and replaced by the status update error. This caused the original failure to be silently lost, masking the root cause.

Join both errors so the controller returns and logs all failure context.