### PR TITLE
feat(cpapi): add permissionsURL to application

### DIFF
--- a/controlplane-api/ent.graphql
+++ b/controlplane-api/ent.graphql
@@ -3741,6 +3741,7 @@ type Zone implements Node {
   name: String!
   gatewayURL: String
   issuerURL: String
+  permissionURL: String
   visibility: ZoneVisibility!
   applications: [Application!]
 }
@@ -3840,6 +3841,24 @@ input ZoneWhereInput {
   issuerURLNotNil: Boolean
   issuerURLEqualFold: String
   issuerURLContainsFold: String
+  """
+  permission_url field predicates
+  """
+  permissionURL: String
+  permissionURLNEQ: String
+  permissionURLIn: [String!]
+  permissionURLNotIn: [String!]
+  permissionURLGT: String
+  permissionURLGTE: String
+  permissionURLLT: String
+  permissionURLLTE: String
+  permissionURLContains: String
+  permissionURLHasPrefix: String
+  permissionURLHasSuffix: String
+  permissionURLIsNil: Boolean
+  permissionURLNotNil: Boolean
+  permissionURLEqualFold: String
+  permissionURLContainsFold: String
   """
   visibility field predicates
   """

--- a/controlplane-api/ent.graphql
+++ b/controlplane-api/ent.graphql
@@ -3741,7 +3741,7 @@ type Zone implements Node {
   name: String!
   gatewayURL: String
   issuerURL: String
-  permissionURL: String
+  permissionsURL: String
   visibility: ZoneVisibility!
   applications: [Application!]
 }
@@ -3842,23 +3842,23 @@ input ZoneWhereInput {
   issuerURLEqualFold: String
   issuerURLContainsFold: String
   """
-  permission_url field predicates
+  permissions_url field predicates
   """
-  permissionURL: String
-  permissionURLNEQ: String
-  permissionURLIn: [String!]
-  permissionURLNotIn: [String!]
-  permissionURLGT: String
-  permissionURLGTE: String
-  permissionURLLT: String
-  permissionURLLTE: String
-  permissionURLContains: String
-  permissionURLHasPrefix: String
-  permissionURLHasSuffix: String
-  permissionURLIsNil: Boolean
-  permissionURLNotNil: Boolean
-  permissionURLEqualFold: String
-  permissionURLContainsFold: String
+  permissionsURL: String
+  permissionsURLNEQ: String
+  permissionsURLIn: [String!]
+  permissionsURLNotIn: [String!]
+  permissionsURLGT: String
+  permissionsURLGTE: String
+  permissionsURLLT: String
+  permissionsURLLTE: String
+  permissionsURLContains: String
+  permissionsURLHasPrefix: String
+  permissionsURLHasSuffix: String
+  permissionsURLIsNil: Boolean
+  permissionsURLNotNil: Boolean
+  permissionsURLEqualFold: String
+  permissionsURLContainsFold: String
   """
   visibility field predicates
   """

--- a/controlplane-api/ent/gql_collection.go
+++ b/controlplane-api/ent/gql_collection.go
@@ -2715,6 +2715,11 @@ func (_q *ZoneQuery) collectField(ctx context.Context, oneNode bool, opCtx *grap
 				selectedFields = append(selectedFields, zone.FieldIssuerURL)
 				fieldSeen[zone.FieldIssuerURL] = struct{}{}
 			}
+		case "permissionURL":
+			if _, ok := fieldSeen[zone.FieldPermissionURL]; !ok {
+				selectedFields = append(selectedFields, zone.FieldPermissionURL)
+				fieldSeen[zone.FieldPermissionURL] = struct{}{}
+			}
 		case "visibility":
 			if _, ok := fieldSeen[zone.FieldVisibility]; !ok {
 				selectedFields = append(selectedFields, zone.FieldVisibility)

--- a/controlplane-api/ent/gql_collection.go
+++ b/controlplane-api/ent/gql_collection.go
@@ -2715,10 +2715,10 @@ func (_q *ZoneQuery) collectField(ctx context.Context, oneNode bool, opCtx *grap
 				selectedFields = append(selectedFields, zone.FieldIssuerURL)
 				fieldSeen[zone.FieldIssuerURL] = struct{}{}
 			}
-		case "permissionURL":
-			if _, ok := fieldSeen[zone.FieldPermissionURL]; !ok {
-				selectedFields = append(selectedFields, zone.FieldPermissionURL)
-				fieldSeen[zone.FieldPermissionURL] = struct{}{}
+		case "permissionsURL":
+			if _, ok := fieldSeen[zone.FieldPermissionsURL]; !ok {
+				selectedFields = append(selectedFields, zone.FieldPermissionsURL)
+				fieldSeen[zone.FieldPermissionsURL] = struct{}{}
 			}
 		case "visibility":
 			if _, ok := fieldSeen[zone.FieldVisibility]; !ok {

--- a/controlplane-api/ent/gql_where_input.go
+++ b/controlplane-api/ent/gql_where_input.go
@@ -8140,22 +8140,22 @@ type ZoneWhereInput struct {
 	IssuerURLEqualFold    *string  `json:"issuerURLEqualFold,omitempty"`
 	IssuerURLContainsFold *string  `json:"issuerURLContainsFold,omitempty"`
 
-	// "permission_url" field predicates.
-	PermissionURL             *string  `json:"permissionURL,omitempty"`
-	PermissionURLNEQ          *string  `json:"permissionURLNEQ,omitempty"`
-	PermissionURLIn           []string `json:"permissionURLIn,omitempty"`
-	PermissionURLNotIn        []string `json:"permissionURLNotIn,omitempty"`
-	PermissionURLGT           *string  `json:"permissionURLGT,omitempty"`
-	PermissionURLGTE          *string  `json:"permissionURLGTE,omitempty"`
-	PermissionURLLT           *string  `json:"permissionURLLT,omitempty"`
-	PermissionURLLTE          *string  `json:"permissionURLLTE,omitempty"`
-	PermissionURLContains     *string  `json:"permissionURLContains,omitempty"`
-	PermissionURLHasPrefix    *string  `json:"permissionURLHasPrefix,omitempty"`
-	PermissionURLHasSuffix    *string  `json:"permissionURLHasSuffix,omitempty"`
-	PermissionURLIsNil        bool     `json:"permissionURLIsNil,omitempty"`
-	PermissionURLNotNil       bool     `json:"permissionURLNotNil,omitempty"`
-	PermissionURLEqualFold    *string  `json:"permissionURLEqualFold,omitempty"`
-	PermissionURLContainsFold *string  `json:"permissionURLContainsFold,omitempty"`
+	// "permissions_url" field predicates.
+	PermissionsURL             *string  `json:"permissionsURL,omitempty"`
+	PermissionsURLNEQ          *string  `json:"permissionsURLNEQ,omitempty"`
+	PermissionsURLIn           []string `json:"permissionsURLIn,omitempty"`
+	PermissionsURLNotIn        []string `json:"permissionsURLNotIn,omitempty"`
+	PermissionsURLGT           *string  `json:"permissionsURLGT,omitempty"`
+	PermissionsURLGTE          *string  `json:"permissionsURLGTE,omitempty"`
+	PermissionsURLLT           *string  `json:"permissionsURLLT,omitempty"`
+	PermissionsURLLTE          *string  `json:"permissionsURLLTE,omitempty"`
+	PermissionsURLContains     *string  `json:"permissionsURLContains,omitempty"`
+	PermissionsURLHasPrefix    *string  `json:"permissionsURLHasPrefix,omitempty"`
+	PermissionsURLHasSuffix    *string  `json:"permissionsURLHasSuffix,omitempty"`
+	PermissionsURLIsNil        bool     `json:"permissionsURLIsNil,omitempty"`
+	PermissionsURLNotNil       bool     `json:"permissionsURLNotNil,omitempty"`
+	PermissionsURLEqualFold    *string  `json:"permissionsURLEqualFold,omitempty"`
+	PermissionsURLContainsFold *string  `json:"permissionsURLContainsFold,omitempty"`
 
 	// "visibility" field predicates.
 	Visibility      *zone.Visibility  `json:"visibility,omitempty"`
@@ -8437,50 +8437,50 @@ func (i *ZoneWhereInput) P() (predicate.Zone, error) {
 	if i.IssuerURLContainsFold != nil {
 		predicates = append(predicates, zone.IssuerURLContainsFold(*i.IssuerURLContainsFold))
 	}
-	if i.PermissionURL != nil {
-		predicates = append(predicates, zone.PermissionURLEQ(*i.PermissionURL))
+	if i.PermissionsURL != nil {
+		predicates = append(predicates, zone.PermissionsURLEQ(*i.PermissionsURL))
 	}
-	if i.PermissionURLNEQ != nil {
-		predicates = append(predicates, zone.PermissionURLNEQ(*i.PermissionURLNEQ))
+	if i.PermissionsURLNEQ != nil {
+		predicates = append(predicates, zone.PermissionsURLNEQ(*i.PermissionsURLNEQ))
 	}
-	if len(i.PermissionURLIn) > 0 {
-		predicates = append(predicates, zone.PermissionURLIn(i.PermissionURLIn...))
+	if len(i.PermissionsURLIn) > 0 {
+		predicates = append(predicates, zone.PermissionsURLIn(i.PermissionsURLIn...))
 	}
-	if len(i.PermissionURLNotIn) > 0 {
-		predicates = append(predicates, zone.PermissionURLNotIn(i.PermissionURLNotIn...))
+	if len(i.PermissionsURLNotIn) > 0 {
+		predicates = append(predicates, zone.PermissionsURLNotIn(i.PermissionsURLNotIn...))
 	}
-	if i.PermissionURLGT != nil {
-		predicates = append(predicates, zone.PermissionURLGT(*i.PermissionURLGT))
+	if i.PermissionsURLGT != nil {
+		predicates = append(predicates, zone.PermissionsURLGT(*i.PermissionsURLGT))
 	}
-	if i.PermissionURLGTE != nil {
-		predicates = append(predicates, zone.PermissionURLGTE(*i.PermissionURLGTE))
+	if i.PermissionsURLGTE != nil {
+		predicates = append(predicates, zone.PermissionsURLGTE(*i.PermissionsURLGTE))
 	}
-	if i.PermissionURLLT != nil {
-		predicates = append(predicates, zone.PermissionURLLT(*i.PermissionURLLT))
+	if i.PermissionsURLLT != nil {
+		predicates = append(predicates, zone.PermissionsURLLT(*i.PermissionsURLLT))
 	}
-	if i.PermissionURLLTE != nil {
-		predicates = append(predicates, zone.PermissionURLLTE(*i.PermissionURLLTE))
+	if i.PermissionsURLLTE != nil {
+		predicates = append(predicates, zone.PermissionsURLLTE(*i.PermissionsURLLTE))
 	}
-	if i.PermissionURLContains != nil {
-		predicates = append(predicates, zone.PermissionURLContains(*i.PermissionURLContains))
+	if i.PermissionsURLContains != nil {
+		predicates = append(predicates, zone.PermissionsURLContains(*i.PermissionsURLContains))
 	}
-	if i.PermissionURLHasPrefix != nil {
-		predicates = append(predicates, zone.PermissionURLHasPrefix(*i.PermissionURLHasPrefix))
+	if i.PermissionsURLHasPrefix != nil {
+		predicates = append(predicates, zone.PermissionsURLHasPrefix(*i.PermissionsURLHasPrefix))
 	}
-	if i.PermissionURLHasSuffix != nil {
-		predicates = append(predicates, zone.PermissionURLHasSuffix(*i.PermissionURLHasSuffix))
+	if i.PermissionsURLHasSuffix != nil {
+		predicates = append(predicates, zone.PermissionsURLHasSuffix(*i.PermissionsURLHasSuffix))
 	}
-	if i.PermissionURLIsNil {
-		predicates = append(predicates, zone.PermissionURLIsNil())
+	if i.PermissionsURLIsNil {
+		predicates = append(predicates, zone.PermissionsURLIsNil())
 	}
-	if i.PermissionURLNotNil {
-		predicates = append(predicates, zone.PermissionURLNotNil())
+	if i.PermissionsURLNotNil {
+		predicates = append(predicates, zone.PermissionsURLNotNil())
 	}
-	if i.PermissionURLEqualFold != nil {
-		predicates = append(predicates, zone.PermissionURLEqualFold(*i.PermissionURLEqualFold))
+	if i.PermissionsURLEqualFold != nil {
+		predicates = append(predicates, zone.PermissionsURLEqualFold(*i.PermissionsURLEqualFold))
 	}
-	if i.PermissionURLContainsFold != nil {
-		predicates = append(predicates, zone.PermissionURLContainsFold(*i.PermissionURLContainsFold))
+	if i.PermissionsURLContainsFold != nil {
+		predicates = append(predicates, zone.PermissionsURLContainsFold(*i.PermissionsURLContainsFold))
 	}
 	if i.Visibility != nil {
 		predicates = append(predicates, zone.VisibilityEQ(*i.Visibility))

--- a/controlplane-api/ent/gql_where_input.go
+++ b/controlplane-api/ent/gql_where_input.go
@@ -8140,6 +8140,23 @@ type ZoneWhereInput struct {
 	IssuerURLEqualFold    *string  `json:"issuerURLEqualFold,omitempty"`
 	IssuerURLContainsFold *string  `json:"issuerURLContainsFold,omitempty"`
 
+	// "permission_url" field predicates.
+	PermissionURL             *string  `json:"permissionURL,omitempty"`
+	PermissionURLNEQ          *string  `json:"permissionURLNEQ,omitempty"`
+	PermissionURLIn           []string `json:"permissionURLIn,omitempty"`
+	PermissionURLNotIn        []string `json:"permissionURLNotIn,omitempty"`
+	PermissionURLGT           *string  `json:"permissionURLGT,omitempty"`
+	PermissionURLGTE          *string  `json:"permissionURLGTE,omitempty"`
+	PermissionURLLT           *string  `json:"permissionURLLT,omitempty"`
+	PermissionURLLTE          *string  `json:"permissionURLLTE,omitempty"`
+	PermissionURLContains     *string  `json:"permissionURLContains,omitempty"`
+	PermissionURLHasPrefix    *string  `json:"permissionURLHasPrefix,omitempty"`
+	PermissionURLHasSuffix    *string  `json:"permissionURLHasSuffix,omitempty"`
+	PermissionURLIsNil        bool     `json:"permissionURLIsNil,omitempty"`
+	PermissionURLNotNil       bool     `json:"permissionURLNotNil,omitempty"`
+	PermissionURLEqualFold    *string  `json:"permissionURLEqualFold,omitempty"`
+	PermissionURLContainsFold *string  `json:"permissionURLContainsFold,omitempty"`
+
 	// "visibility" field predicates.
 	Visibility      *zone.Visibility  `json:"visibility,omitempty"`
 	VisibilityNEQ   *zone.Visibility  `json:"visibilityNEQ,omitempty"`
@@ -8419,6 +8436,51 @@ func (i *ZoneWhereInput) P() (predicate.Zone, error) {
 	}
 	if i.IssuerURLContainsFold != nil {
 		predicates = append(predicates, zone.IssuerURLContainsFold(*i.IssuerURLContainsFold))
+	}
+	if i.PermissionURL != nil {
+		predicates = append(predicates, zone.PermissionURLEQ(*i.PermissionURL))
+	}
+	if i.PermissionURLNEQ != nil {
+		predicates = append(predicates, zone.PermissionURLNEQ(*i.PermissionURLNEQ))
+	}
+	if len(i.PermissionURLIn) > 0 {
+		predicates = append(predicates, zone.PermissionURLIn(i.PermissionURLIn...))
+	}
+	if len(i.PermissionURLNotIn) > 0 {
+		predicates = append(predicates, zone.PermissionURLNotIn(i.PermissionURLNotIn...))
+	}
+	if i.PermissionURLGT != nil {
+		predicates = append(predicates, zone.PermissionURLGT(*i.PermissionURLGT))
+	}
+	if i.PermissionURLGTE != nil {
+		predicates = append(predicates, zone.PermissionURLGTE(*i.PermissionURLGTE))
+	}
+	if i.PermissionURLLT != nil {
+		predicates = append(predicates, zone.PermissionURLLT(*i.PermissionURLLT))
+	}
+	if i.PermissionURLLTE != nil {
+		predicates = append(predicates, zone.PermissionURLLTE(*i.PermissionURLLTE))
+	}
+	if i.PermissionURLContains != nil {
+		predicates = append(predicates, zone.PermissionURLContains(*i.PermissionURLContains))
+	}
+	if i.PermissionURLHasPrefix != nil {
+		predicates = append(predicates, zone.PermissionURLHasPrefix(*i.PermissionURLHasPrefix))
+	}
+	if i.PermissionURLHasSuffix != nil {
+		predicates = append(predicates, zone.PermissionURLHasSuffix(*i.PermissionURLHasSuffix))
+	}
+	if i.PermissionURLIsNil {
+		predicates = append(predicates, zone.PermissionURLIsNil())
+	}
+	if i.PermissionURLNotNil {
+		predicates = append(predicates, zone.PermissionURLNotNil())
+	}
+	if i.PermissionURLEqualFold != nil {
+		predicates = append(predicates, zone.PermissionURLEqualFold(*i.PermissionURLEqualFold))
+	}
+	if i.PermissionURLContainsFold != nil {
+		predicates = append(predicates, zone.PermissionURLContainsFold(*i.PermissionURLContainsFold))
 	}
 	if i.Visibility != nil {
 		predicates = append(predicates, zone.VisibilityEQ(*i.Visibility))

--- a/controlplane-api/ent/migrate/schema.go
+++ b/controlplane-api/ent/migrate/schema.go
@@ -540,7 +540,7 @@ var (
 		{Name: "name", Type: field.TypeString, Unique: true, Size: 2147483647},
 		{Name: "gateway_url", Type: field.TypeString, Nullable: true, Size: 2147483647},
 		{Name: "issuer_url", Type: field.TypeString, Nullable: true, Size: 2147483647},
-		{Name: "permission_url", Type: field.TypeString, Nullable: true, Size: 2147483647},
+		{Name: "permissions_url", Type: field.TypeString, Nullable: true, Size: 2147483647},
 		{Name: "visibility", Type: field.TypeEnum, Enums: []string{"WORLD", "ENTERPRISE"}, Default: "ENTERPRISE"},
 		{Name: "api_subscription_failover_zones", Type: field.TypeInt, Nullable: true},
 	}

--- a/controlplane-api/ent/migrate/schema.go
+++ b/controlplane-api/ent/migrate/schema.go
@@ -540,6 +540,7 @@ var (
 		{Name: "name", Type: field.TypeString, Unique: true, Size: 2147483647},
 		{Name: "gateway_url", Type: field.TypeString, Nullable: true, Size: 2147483647},
 		{Name: "issuer_url", Type: field.TypeString, Nullable: true, Size: 2147483647},
+		{Name: "permission_url", Type: field.TypeString, Nullable: true, Size: 2147483647},
 		{Name: "visibility", Type: field.TypeEnum, Enums: []string{"WORLD", "ENTERPRISE"}, Default: "ENTERPRISE"},
 		{Name: "api_subscription_failover_zones", Type: field.TypeInt, Nullable: true},
 	}
@@ -551,7 +552,7 @@ var (
 		ForeignKeys: []*schema.ForeignKey{
 			{
 				Symbol:     "zones_api_subscriptions_failover_zones",
-				Columns:    []*schema.Column{ZonesColumns[6]},
+				Columns:    []*schema.Column{ZonesColumns[7]},
 				RefColumns: []*schema.Column{APISubscriptionsColumns[0]},
 				OnDelete:   schema.SetNull,
 			},

--- a/controlplane-api/ent/mutation.go
+++ b/controlplane-api/ent/mutation.go
@@ -15999,6 +15999,7 @@ type ZoneMutation struct {
 	name                *string
 	gateway_url         *string
 	issuer_url          *string
+	permission_url      *string
 	visibility          *zone.Visibility
 	clearedFields       map[string]struct{}
 	applications        map[int]struct{}
@@ -16290,6 +16291,55 @@ func (m *ZoneMutation) ResetIssuerURL() {
 	delete(m.clearedFields, zone.FieldIssuerURL)
 }
 
+// SetPermissionURL sets the "permission_url" field.
+func (m *ZoneMutation) SetPermissionURL(s string) {
+	m.permission_url = &s
+}
+
+// PermissionURL returns the value of the "permission_url" field in the mutation.
+func (m *ZoneMutation) PermissionURL() (r string, exists bool) {
+	v := m.permission_url
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldPermissionURL returns the old "permission_url" field's value of the Zone entity.
+// If the Zone object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *ZoneMutation) OldPermissionURL(ctx context.Context) (v *string, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldPermissionURL is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldPermissionURL requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldPermissionURL: %w", err)
+	}
+	return oldValue.PermissionURL, nil
+}
+
+// ClearPermissionURL clears the value of the "permission_url" field.
+func (m *ZoneMutation) ClearPermissionURL() {
+	m.permission_url = nil
+	m.clearedFields[zone.FieldPermissionURL] = struct{}{}
+}
+
+// PermissionURLCleared returns if the "permission_url" field was cleared in this mutation.
+func (m *ZoneMutation) PermissionURLCleared() bool {
+	_, ok := m.clearedFields[zone.FieldPermissionURL]
+	return ok
+}
+
+// ResetPermissionURL resets all changes to the "permission_url" field.
+func (m *ZoneMutation) ResetPermissionURL() {
+	m.permission_url = nil
+	delete(m.clearedFields, zone.FieldPermissionURL)
+}
+
 // SetVisibility sets the "visibility" field.
 func (m *ZoneMutation) SetVisibility(z zone.Visibility) {
 	m.visibility = &z
@@ -16414,7 +16464,7 @@ func (m *ZoneMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *ZoneMutation) Fields() []string {
-	fields := make([]string, 0, 5)
+	fields := make([]string, 0, 6)
 	if m.environment != nil {
 		fields = append(fields, zone.FieldEnvironment)
 	}
@@ -16426,6 +16476,9 @@ func (m *ZoneMutation) Fields() []string {
 	}
 	if m.issuer_url != nil {
 		fields = append(fields, zone.FieldIssuerURL)
+	}
+	if m.permission_url != nil {
+		fields = append(fields, zone.FieldPermissionURL)
 	}
 	if m.visibility != nil {
 		fields = append(fields, zone.FieldVisibility)
@@ -16446,6 +16499,8 @@ func (m *ZoneMutation) Field(name string) (ent.Value, bool) {
 		return m.GatewayURL()
 	case zone.FieldIssuerURL:
 		return m.IssuerURL()
+	case zone.FieldPermissionURL:
+		return m.PermissionURL()
 	case zone.FieldVisibility:
 		return m.Visibility()
 	}
@@ -16465,6 +16520,8 @@ func (m *ZoneMutation) OldField(ctx context.Context, name string) (ent.Value, er
 		return m.OldGatewayURL(ctx)
 	case zone.FieldIssuerURL:
 		return m.OldIssuerURL(ctx)
+	case zone.FieldPermissionURL:
+		return m.OldPermissionURL(ctx)
 	case zone.FieldVisibility:
 		return m.OldVisibility(ctx)
 	}
@@ -16503,6 +16560,13 @@ func (m *ZoneMutation) SetField(name string, value ent.Value) error {
 			return fmt.Errorf("unexpected type %T for field %s", value, name)
 		}
 		m.SetIssuerURL(v)
+		return nil
+	case zone.FieldPermissionURL:
+		v, ok := value.(string)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetPermissionURL(v)
 		return nil
 	case zone.FieldVisibility:
 		v, ok := value.(zone.Visibility)
@@ -16550,6 +16614,9 @@ func (m *ZoneMutation) ClearedFields() []string {
 	if m.FieldCleared(zone.FieldIssuerURL) {
 		fields = append(fields, zone.FieldIssuerURL)
 	}
+	if m.FieldCleared(zone.FieldPermissionURL) {
+		fields = append(fields, zone.FieldPermissionURL)
+	}
 	return fields
 }
 
@@ -16573,6 +16640,9 @@ func (m *ZoneMutation) ClearField(name string) error {
 	case zone.FieldIssuerURL:
 		m.ClearIssuerURL()
 		return nil
+	case zone.FieldPermissionURL:
+		m.ClearPermissionURL()
+		return nil
 	}
 	return fmt.Errorf("unknown Zone nullable field %s", name)
 }
@@ -16592,6 +16662,9 @@ func (m *ZoneMutation) ResetField(name string) error {
 		return nil
 	case zone.FieldIssuerURL:
 		m.ResetIssuerURL()
+		return nil
+	case zone.FieldPermissionURL:
+		m.ResetPermissionURL()
 		return nil
 	case zone.FieldVisibility:
 		m.ResetVisibility()

--- a/controlplane-api/ent/mutation.go
+++ b/controlplane-api/ent/mutation.go
@@ -15999,7 +15999,7 @@ type ZoneMutation struct {
 	name                *string
 	gateway_url         *string
 	issuer_url          *string
-	permission_url      *string
+	permissions_url     *string
 	visibility          *zone.Visibility
 	clearedFields       map[string]struct{}
 	applications        map[int]struct{}
@@ -16291,53 +16291,53 @@ func (m *ZoneMutation) ResetIssuerURL() {
 	delete(m.clearedFields, zone.FieldIssuerURL)
 }
 
-// SetPermissionURL sets the "permission_url" field.
-func (m *ZoneMutation) SetPermissionURL(s string) {
-	m.permission_url = &s
+// SetPermissionsURL sets the "permissions_url" field.
+func (m *ZoneMutation) SetPermissionsURL(s string) {
+	m.permissions_url = &s
 }
 
-// PermissionURL returns the value of the "permission_url" field in the mutation.
-func (m *ZoneMutation) PermissionURL() (r string, exists bool) {
-	v := m.permission_url
+// PermissionsURL returns the value of the "permissions_url" field in the mutation.
+func (m *ZoneMutation) PermissionsURL() (r string, exists bool) {
+	v := m.permissions_url
 	if v == nil {
 		return
 	}
 	return *v, true
 }
 
-// OldPermissionURL returns the old "permission_url" field's value of the Zone entity.
+// OldPermissionsURL returns the old "permissions_url" field's value of the Zone entity.
 // If the Zone object wasn't provided to the builder, the object is fetched from the database.
 // An error is returned if the mutation operation is not UpdateOne, or the database query fails.
-func (m *ZoneMutation) OldPermissionURL(ctx context.Context) (v *string, err error) {
+func (m *ZoneMutation) OldPermissionsURL(ctx context.Context) (v *string, err error) {
 	if !m.op.Is(OpUpdateOne) {
-		return v, errors.New("OldPermissionURL is only allowed on UpdateOne operations")
+		return v, errors.New("OldPermissionsURL is only allowed on UpdateOne operations")
 	}
 	if m.id == nil || m.oldValue == nil {
-		return v, errors.New("OldPermissionURL requires an ID field in the mutation")
+		return v, errors.New("OldPermissionsURL requires an ID field in the mutation")
 	}
 	oldValue, err := m.oldValue(ctx)
 	if err != nil {
-		return v, fmt.Errorf("querying old value for OldPermissionURL: %w", err)
+		return v, fmt.Errorf("querying old value for OldPermissionsURL: %w", err)
 	}
-	return oldValue.PermissionURL, nil
+	return oldValue.PermissionsURL, nil
 }
 
-// ClearPermissionURL clears the value of the "permission_url" field.
-func (m *ZoneMutation) ClearPermissionURL() {
-	m.permission_url = nil
-	m.clearedFields[zone.FieldPermissionURL] = struct{}{}
+// ClearPermissionsURL clears the value of the "permissions_url" field.
+func (m *ZoneMutation) ClearPermissionsURL() {
+	m.permissions_url = nil
+	m.clearedFields[zone.FieldPermissionsURL] = struct{}{}
 }
 
-// PermissionURLCleared returns if the "permission_url" field was cleared in this mutation.
-func (m *ZoneMutation) PermissionURLCleared() bool {
-	_, ok := m.clearedFields[zone.FieldPermissionURL]
+// PermissionsURLCleared returns if the "permissions_url" field was cleared in this mutation.
+func (m *ZoneMutation) PermissionsURLCleared() bool {
+	_, ok := m.clearedFields[zone.FieldPermissionsURL]
 	return ok
 }
 
-// ResetPermissionURL resets all changes to the "permission_url" field.
-func (m *ZoneMutation) ResetPermissionURL() {
-	m.permission_url = nil
-	delete(m.clearedFields, zone.FieldPermissionURL)
+// ResetPermissionsURL resets all changes to the "permissions_url" field.
+func (m *ZoneMutation) ResetPermissionsURL() {
+	m.permissions_url = nil
+	delete(m.clearedFields, zone.FieldPermissionsURL)
 }
 
 // SetVisibility sets the "visibility" field.
@@ -16477,8 +16477,8 @@ func (m *ZoneMutation) Fields() []string {
 	if m.issuer_url != nil {
 		fields = append(fields, zone.FieldIssuerURL)
 	}
-	if m.permission_url != nil {
-		fields = append(fields, zone.FieldPermissionURL)
+	if m.permissions_url != nil {
+		fields = append(fields, zone.FieldPermissionsURL)
 	}
 	if m.visibility != nil {
 		fields = append(fields, zone.FieldVisibility)
@@ -16499,8 +16499,8 @@ func (m *ZoneMutation) Field(name string) (ent.Value, bool) {
 		return m.GatewayURL()
 	case zone.FieldIssuerURL:
 		return m.IssuerURL()
-	case zone.FieldPermissionURL:
-		return m.PermissionURL()
+	case zone.FieldPermissionsURL:
+		return m.PermissionsURL()
 	case zone.FieldVisibility:
 		return m.Visibility()
 	}
@@ -16520,8 +16520,8 @@ func (m *ZoneMutation) OldField(ctx context.Context, name string) (ent.Value, er
 		return m.OldGatewayURL(ctx)
 	case zone.FieldIssuerURL:
 		return m.OldIssuerURL(ctx)
-	case zone.FieldPermissionURL:
-		return m.OldPermissionURL(ctx)
+	case zone.FieldPermissionsURL:
+		return m.OldPermissionsURL(ctx)
 	case zone.FieldVisibility:
 		return m.OldVisibility(ctx)
 	}
@@ -16561,12 +16561,12 @@ func (m *ZoneMutation) SetField(name string, value ent.Value) error {
 		}
 		m.SetIssuerURL(v)
 		return nil
-	case zone.FieldPermissionURL:
+	case zone.FieldPermissionsURL:
 		v, ok := value.(string)
 		if !ok {
 			return fmt.Errorf("unexpected type %T for field %s", value, name)
 		}
-		m.SetPermissionURL(v)
+		m.SetPermissionsURL(v)
 		return nil
 	case zone.FieldVisibility:
 		v, ok := value.(zone.Visibility)
@@ -16614,8 +16614,8 @@ func (m *ZoneMutation) ClearedFields() []string {
 	if m.FieldCleared(zone.FieldIssuerURL) {
 		fields = append(fields, zone.FieldIssuerURL)
 	}
-	if m.FieldCleared(zone.FieldPermissionURL) {
-		fields = append(fields, zone.FieldPermissionURL)
+	if m.FieldCleared(zone.FieldPermissionsURL) {
+		fields = append(fields, zone.FieldPermissionsURL)
 	}
 	return fields
 }
@@ -16640,8 +16640,8 @@ func (m *ZoneMutation) ClearField(name string) error {
 	case zone.FieldIssuerURL:
 		m.ClearIssuerURL()
 		return nil
-	case zone.FieldPermissionURL:
-		m.ClearPermissionURL()
+	case zone.FieldPermissionsURL:
+		m.ClearPermissionsURL()
 		return nil
 	}
 	return fmt.Errorf("unknown Zone nullable field %s", name)
@@ -16663,8 +16663,8 @@ func (m *ZoneMutation) ResetField(name string) error {
 	case zone.FieldIssuerURL:
 		m.ResetIssuerURL()
 		return nil
-	case zone.FieldPermissionURL:
-		m.ResetPermissionURL()
+	case zone.FieldPermissionsURL:
+		m.ResetPermissionsURL()
 		return nil
 	case zone.FieldVisibility:
 		m.ResetVisibility()

--- a/controlplane-api/ent/schema/zone.go
+++ b/controlplane-api/ent/schema/zone.go
@@ -37,7 +37,7 @@ func (Zone) Fields() []ent.Field {
 		field.Text("issuer_url").
 			Optional().
 			Nillable(),
-		field.Text("permission_url").
+		field.Text("permissions_url").
 			Optional().
 			Nillable(),
 		field.Enum("visibility").

--- a/controlplane-api/ent/schema/zone.go
+++ b/controlplane-api/ent/schema/zone.go
@@ -37,6 +37,9 @@ func (Zone) Fields() []ent.Field {
 		field.Text("issuer_url").
 			Optional().
 			Nillable(),
+		field.Text("permission_url").
+			Optional().
+			Nillable(),
 		field.Enum("visibility").
 			NamedValues(
 				"World", "WORLD",

--- a/controlplane-api/ent/zone.go
+++ b/controlplane-api/ent/zone.go
@@ -27,8 +27,8 @@ type Zone struct {
 	GatewayURL *string `json:"gateway_url,omitempty"`
 	// IssuerURL holds the value of the "issuer_url" field.
 	IssuerURL *string `json:"issuer_url,omitempty"`
-	// PermissionURL holds the value of the "permission_url" field.
-	PermissionURL *string `json:"permission_url,omitempty"`
+	// PermissionsURL holds the value of the "permissions_url" field.
+	PermissionsURL *string `json:"permissions_url,omitempty"`
 	// Visibility holds the value of the "visibility" field.
 	Visibility zone.Visibility `json:"visibility,omitempty"`
 	// Edges holds the relations/edges for other nodes in the graph.
@@ -67,7 +67,7 @@ func (*Zone) scanValues(columns []string) ([]any, error) {
 		switch columns[i] {
 		case zone.FieldID:
 			values[i] = new(sql.NullInt64)
-		case zone.FieldEnvironment, zone.FieldName, zone.FieldGatewayURL, zone.FieldIssuerURL, zone.FieldPermissionURL, zone.FieldVisibility:
+		case zone.FieldEnvironment, zone.FieldName, zone.FieldGatewayURL, zone.FieldIssuerURL, zone.FieldPermissionsURL, zone.FieldVisibility:
 			values[i] = new(sql.NullString)
 		case zone.ForeignKeys[0]: // api_subscription_failover_zones
 			values[i] = new(sql.NullInt64)
@@ -119,12 +119,12 @@ func (_m *Zone) assignValues(columns []string, values []any) error {
 				_m.IssuerURL = new(string)
 				*_m.IssuerURL = value.String
 			}
-		case zone.FieldPermissionURL:
+		case zone.FieldPermissionsURL:
 			if value, ok := values[i].(*sql.NullString); !ok {
-				return fmt.Errorf("unexpected type %T for field permission_url", values[i])
+				return fmt.Errorf("unexpected type %T for field permissions_url", values[i])
 			} else if value.Valid {
-				_m.PermissionURL = new(string)
-				*_m.PermissionURL = value.String
+				_m.PermissionsURL = new(string)
+				*_m.PermissionsURL = value.String
 			}
 		case zone.FieldVisibility:
 			if value, ok := values[i].(*sql.NullString); !ok {
@@ -198,8 +198,8 @@ func (_m *Zone) String() string {
 		builder.WriteString(*v)
 	}
 	builder.WriteString(", ")
-	if v := _m.PermissionURL; v != nil {
-		builder.WriteString("permission_url=")
+	if v := _m.PermissionsURL; v != nil {
+		builder.WriteString("permissions_url=")
 		builder.WriteString(*v)
 	}
 	builder.WriteString(", ")

--- a/controlplane-api/ent/zone.go
+++ b/controlplane-api/ent/zone.go
@@ -27,6 +27,8 @@ type Zone struct {
 	GatewayURL *string `json:"gateway_url,omitempty"`
 	// IssuerURL holds the value of the "issuer_url" field.
 	IssuerURL *string `json:"issuer_url,omitempty"`
+	// PermissionURL holds the value of the "permission_url" field.
+	PermissionURL *string `json:"permission_url,omitempty"`
 	// Visibility holds the value of the "visibility" field.
 	Visibility zone.Visibility `json:"visibility,omitempty"`
 	// Edges holds the relations/edges for other nodes in the graph.
@@ -65,7 +67,7 @@ func (*Zone) scanValues(columns []string) ([]any, error) {
 		switch columns[i] {
 		case zone.FieldID:
 			values[i] = new(sql.NullInt64)
-		case zone.FieldEnvironment, zone.FieldName, zone.FieldGatewayURL, zone.FieldIssuerURL, zone.FieldVisibility:
+		case zone.FieldEnvironment, zone.FieldName, zone.FieldGatewayURL, zone.FieldIssuerURL, zone.FieldPermissionURL, zone.FieldVisibility:
 			values[i] = new(sql.NullString)
 		case zone.ForeignKeys[0]: // api_subscription_failover_zones
 			values[i] = new(sql.NullInt64)
@@ -116,6 +118,13 @@ func (_m *Zone) assignValues(columns []string, values []any) error {
 			} else if value.Valid {
 				_m.IssuerURL = new(string)
 				*_m.IssuerURL = value.String
+			}
+		case zone.FieldPermissionURL:
+			if value, ok := values[i].(*sql.NullString); !ok {
+				return fmt.Errorf("unexpected type %T for field permission_url", values[i])
+			} else if value.Valid {
+				_m.PermissionURL = new(string)
+				*_m.PermissionURL = value.String
 			}
 		case zone.FieldVisibility:
 			if value, ok := values[i].(*sql.NullString); !ok {
@@ -186,6 +195,11 @@ func (_m *Zone) String() string {
 	builder.WriteString(", ")
 	if v := _m.IssuerURL; v != nil {
 		builder.WriteString("issuer_url=")
+		builder.WriteString(*v)
+	}
+	builder.WriteString(", ")
+	if v := _m.PermissionURL; v != nil {
+		builder.WriteString("permission_url=")
 		builder.WriteString(*v)
 	}
 	builder.WriteString(", ")

--- a/controlplane-api/ent/zone/where.go
+++ b/controlplane-api/ent/zone/where.go
@@ -76,9 +76,9 @@ func IssuerURL(v string) predicate.Zone {
 	return predicate.Zone(sql.FieldEQ(FieldIssuerURL, v))
 }
 
-// PermissionURL applies equality check predicate on the "permission_url" field. It's identical to PermissionURLEQ.
-func PermissionURL(v string) predicate.Zone {
-	return predicate.Zone(sql.FieldEQ(FieldPermissionURL, v))
+// PermissionsURL applies equality check predicate on the "permissions_url" field. It's identical to PermissionsURLEQ.
+func PermissionsURL(v string) predicate.Zone {
+	return predicate.Zone(sql.FieldEQ(FieldPermissionsURL, v))
 }
 
 // EnvironmentEQ applies the EQ predicate on the "environment" field.
@@ -371,79 +371,79 @@ func IssuerURLContainsFold(v string) predicate.Zone {
 	return predicate.Zone(sql.FieldContainsFold(FieldIssuerURL, v))
 }
 
-// PermissionURLEQ applies the EQ predicate on the "permission_url" field.
-func PermissionURLEQ(v string) predicate.Zone {
-	return predicate.Zone(sql.FieldEQ(FieldPermissionURL, v))
+// PermissionsURLEQ applies the EQ predicate on the "permissions_url" field.
+func PermissionsURLEQ(v string) predicate.Zone {
+	return predicate.Zone(sql.FieldEQ(FieldPermissionsURL, v))
 }
 
-// PermissionURLNEQ applies the NEQ predicate on the "permission_url" field.
-func PermissionURLNEQ(v string) predicate.Zone {
-	return predicate.Zone(sql.FieldNEQ(FieldPermissionURL, v))
+// PermissionsURLNEQ applies the NEQ predicate on the "permissions_url" field.
+func PermissionsURLNEQ(v string) predicate.Zone {
+	return predicate.Zone(sql.FieldNEQ(FieldPermissionsURL, v))
 }
 
-// PermissionURLIn applies the In predicate on the "permission_url" field.
-func PermissionURLIn(vs ...string) predicate.Zone {
-	return predicate.Zone(sql.FieldIn(FieldPermissionURL, vs...))
+// PermissionsURLIn applies the In predicate on the "permissions_url" field.
+func PermissionsURLIn(vs ...string) predicate.Zone {
+	return predicate.Zone(sql.FieldIn(FieldPermissionsURL, vs...))
 }
 
-// PermissionURLNotIn applies the NotIn predicate on the "permission_url" field.
-func PermissionURLNotIn(vs ...string) predicate.Zone {
-	return predicate.Zone(sql.FieldNotIn(FieldPermissionURL, vs...))
+// PermissionsURLNotIn applies the NotIn predicate on the "permissions_url" field.
+func PermissionsURLNotIn(vs ...string) predicate.Zone {
+	return predicate.Zone(sql.FieldNotIn(FieldPermissionsURL, vs...))
 }
 
-// PermissionURLGT applies the GT predicate on the "permission_url" field.
-func PermissionURLGT(v string) predicate.Zone {
-	return predicate.Zone(sql.FieldGT(FieldPermissionURL, v))
+// PermissionsURLGT applies the GT predicate on the "permissions_url" field.
+func PermissionsURLGT(v string) predicate.Zone {
+	return predicate.Zone(sql.FieldGT(FieldPermissionsURL, v))
 }
 
-// PermissionURLGTE applies the GTE predicate on the "permission_url" field.
-func PermissionURLGTE(v string) predicate.Zone {
-	return predicate.Zone(sql.FieldGTE(FieldPermissionURL, v))
+// PermissionsURLGTE applies the GTE predicate on the "permissions_url" field.
+func PermissionsURLGTE(v string) predicate.Zone {
+	return predicate.Zone(sql.FieldGTE(FieldPermissionsURL, v))
 }
 
-// PermissionURLLT applies the LT predicate on the "permission_url" field.
-func PermissionURLLT(v string) predicate.Zone {
-	return predicate.Zone(sql.FieldLT(FieldPermissionURL, v))
+// PermissionsURLLT applies the LT predicate on the "permissions_url" field.
+func PermissionsURLLT(v string) predicate.Zone {
+	return predicate.Zone(sql.FieldLT(FieldPermissionsURL, v))
 }
 
-// PermissionURLLTE applies the LTE predicate on the "permission_url" field.
-func PermissionURLLTE(v string) predicate.Zone {
-	return predicate.Zone(sql.FieldLTE(FieldPermissionURL, v))
+// PermissionsURLLTE applies the LTE predicate on the "permissions_url" field.
+func PermissionsURLLTE(v string) predicate.Zone {
+	return predicate.Zone(sql.FieldLTE(FieldPermissionsURL, v))
 }
 
-// PermissionURLContains applies the Contains predicate on the "permission_url" field.
-func PermissionURLContains(v string) predicate.Zone {
-	return predicate.Zone(sql.FieldContains(FieldPermissionURL, v))
+// PermissionsURLContains applies the Contains predicate on the "permissions_url" field.
+func PermissionsURLContains(v string) predicate.Zone {
+	return predicate.Zone(sql.FieldContains(FieldPermissionsURL, v))
 }
 
-// PermissionURLHasPrefix applies the HasPrefix predicate on the "permission_url" field.
-func PermissionURLHasPrefix(v string) predicate.Zone {
-	return predicate.Zone(sql.FieldHasPrefix(FieldPermissionURL, v))
+// PermissionsURLHasPrefix applies the HasPrefix predicate on the "permissions_url" field.
+func PermissionsURLHasPrefix(v string) predicate.Zone {
+	return predicate.Zone(sql.FieldHasPrefix(FieldPermissionsURL, v))
 }
 
-// PermissionURLHasSuffix applies the HasSuffix predicate on the "permission_url" field.
-func PermissionURLHasSuffix(v string) predicate.Zone {
-	return predicate.Zone(sql.FieldHasSuffix(FieldPermissionURL, v))
+// PermissionsURLHasSuffix applies the HasSuffix predicate on the "permissions_url" field.
+func PermissionsURLHasSuffix(v string) predicate.Zone {
+	return predicate.Zone(sql.FieldHasSuffix(FieldPermissionsURL, v))
 }
 
-// PermissionURLIsNil applies the IsNil predicate on the "permission_url" field.
-func PermissionURLIsNil() predicate.Zone {
-	return predicate.Zone(sql.FieldIsNull(FieldPermissionURL))
+// PermissionsURLIsNil applies the IsNil predicate on the "permissions_url" field.
+func PermissionsURLIsNil() predicate.Zone {
+	return predicate.Zone(sql.FieldIsNull(FieldPermissionsURL))
 }
 
-// PermissionURLNotNil applies the NotNil predicate on the "permission_url" field.
-func PermissionURLNotNil() predicate.Zone {
-	return predicate.Zone(sql.FieldNotNull(FieldPermissionURL))
+// PermissionsURLNotNil applies the NotNil predicate on the "permissions_url" field.
+func PermissionsURLNotNil() predicate.Zone {
+	return predicate.Zone(sql.FieldNotNull(FieldPermissionsURL))
 }
 
-// PermissionURLEqualFold applies the EqualFold predicate on the "permission_url" field.
-func PermissionURLEqualFold(v string) predicate.Zone {
-	return predicate.Zone(sql.FieldEqualFold(FieldPermissionURL, v))
+// PermissionsURLEqualFold applies the EqualFold predicate on the "permissions_url" field.
+func PermissionsURLEqualFold(v string) predicate.Zone {
+	return predicate.Zone(sql.FieldEqualFold(FieldPermissionsURL, v))
 }
 
-// PermissionURLContainsFold applies the ContainsFold predicate on the "permission_url" field.
-func PermissionURLContainsFold(v string) predicate.Zone {
-	return predicate.Zone(sql.FieldContainsFold(FieldPermissionURL, v))
+// PermissionsURLContainsFold applies the ContainsFold predicate on the "permissions_url" field.
+func PermissionsURLContainsFold(v string) predicate.Zone {
+	return predicate.Zone(sql.FieldContainsFold(FieldPermissionsURL, v))
 }
 
 // VisibilityEQ applies the EQ predicate on the "visibility" field.

--- a/controlplane-api/ent/zone/where.go
+++ b/controlplane-api/ent/zone/where.go
@@ -76,6 +76,11 @@ func IssuerURL(v string) predicate.Zone {
 	return predicate.Zone(sql.FieldEQ(FieldIssuerURL, v))
 }
 
+// PermissionURL applies equality check predicate on the "permission_url" field. It's identical to PermissionURLEQ.
+func PermissionURL(v string) predicate.Zone {
+	return predicate.Zone(sql.FieldEQ(FieldPermissionURL, v))
+}
+
 // EnvironmentEQ applies the EQ predicate on the "environment" field.
 func EnvironmentEQ(v string) predicate.Zone {
 	return predicate.Zone(sql.FieldEQ(FieldEnvironment, v))
@@ -364,6 +369,81 @@ func IssuerURLEqualFold(v string) predicate.Zone {
 // IssuerURLContainsFold applies the ContainsFold predicate on the "issuer_url" field.
 func IssuerURLContainsFold(v string) predicate.Zone {
 	return predicate.Zone(sql.FieldContainsFold(FieldIssuerURL, v))
+}
+
+// PermissionURLEQ applies the EQ predicate on the "permission_url" field.
+func PermissionURLEQ(v string) predicate.Zone {
+	return predicate.Zone(sql.FieldEQ(FieldPermissionURL, v))
+}
+
+// PermissionURLNEQ applies the NEQ predicate on the "permission_url" field.
+func PermissionURLNEQ(v string) predicate.Zone {
+	return predicate.Zone(sql.FieldNEQ(FieldPermissionURL, v))
+}
+
+// PermissionURLIn applies the In predicate on the "permission_url" field.
+func PermissionURLIn(vs ...string) predicate.Zone {
+	return predicate.Zone(sql.FieldIn(FieldPermissionURL, vs...))
+}
+
+// PermissionURLNotIn applies the NotIn predicate on the "permission_url" field.
+func PermissionURLNotIn(vs ...string) predicate.Zone {
+	return predicate.Zone(sql.FieldNotIn(FieldPermissionURL, vs...))
+}
+
+// PermissionURLGT applies the GT predicate on the "permission_url" field.
+func PermissionURLGT(v string) predicate.Zone {
+	return predicate.Zone(sql.FieldGT(FieldPermissionURL, v))
+}
+
+// PermissionURLGTE applies the GTE predicate on the "permission_url" field.
+func PermissionURLGTE(v string) predicate.Zone {
+	return predicate.Zone(sql.FieldGTE(FieldPermissionURL, v))
+}
+
+// PermissionURLLT applies the LT predicate on the "permission_url" field.
+func PermissionURLLT(v string) predicate.Zone {
+	return predicate.Zone(sql.FieldLT(FieldPermissionURL, v))
+}
+
+// PermissionURLLTE applies the LTE predicate on the "permission_url" field.
+func PermissionURLLTE(v string) predicate.Zone {
+	return predicate.Zone(sql.FieldLTE(FieldPermissionURL, v))
+}
+
+// PermissionURLContains applies the Contains predicate on the "permission_url" field.
+func PermissionURLContains(v string) predicate.Zone {
+	return predicate.Zone(sql.FieldContains(FieldPermissionURL, v))
+}
+
+// PermissionURLHasPrefix applies the HasPrefix predicate on the "permission_url" field.
+func PermissionURLHasPrefix(v string) predicate.Zone {
+	return predicate.Zone(sql.FieldHasPrefix(FieldPermissionURL, v))
+}
+
+// PermissionURLHasSuffix applies the HasSuffix predicate on the "permission_url" field.
+func PermissionURLHasSuffix(v string) predicate.Zone {
+	return predicate.Zone(sql.FieldHasSuffix(FieldPermissionURL, v))
+}
+
+// PermissionURLIsNil applies the IsNil predicate on the "permission_url" field.
+func PermissionURLIsNil() predicate.Zone {
+	return predicate.Zone(sql.FieldIsNull(FieldPermissionURL))
+}
+
+// PermissionURLNotNil applies the NotNil predicate on the "permission_url" field.
+func PermissionURLNotNil() predicate.Zone {
+	return predicate.Zone(sql.FieldNotNull(FieldPermissionURL))
+}
+
+// PermissionURLEqualFold applies the EqualFold predicate on the "permission_url" field.
+func PermissionURLEqualFold(v string) predicate.Zone {
+	return predicate.Zone(sql.FieldEqualFold(FieldPermissionURL, v))
+}
+
+// PermissionURLContainsFold applies the ContainsFold predicate on the "permission_url" field.
+func PermissionURLContainsFold(v string) predicate.Zone {
+	return predicate.Zone(sql.FieldContainsFold(FieldPermissionURL, v))
 }
 
 // VisibilityEQ applies the EQ predicate on the "visibility" field.

--- a/controlplane-api/ent/zone/zone.go
+++ b/controlplane-api/ent/zone/zone.go
@@ -28,6 +28,8 @@ const (
 	FieldGatewayURL = "gateway_url"
 	// FieldIssuerURL holds the string denoting the issuer_url field in the database.
 	FieldIssuerURL = "issuer_url"
+	// FieldPermissionURL holds the string denoting the permission_url field in the database.
+	FieldPermissionURL = "permission_url"
 	// FieldVisibility holds the string denoting the visibility field in the database.
 	FieldVisibility = "visibility"
 	// EdgeApplications holds the string denoting the applications edge name in mutations.
@@ -50,6 +52,7 @@ var Columns = []string{
 	FieldName,
 	FieldGatewayURL,
 	FieldIssuerURL,
+	FieldPermissionURL,
 	FieldVisibility,
 }
 
@@ -138,6 +141,11 @@ func ByGatewayURL(opts ...sql.OrderTermOption) OrderOption {
 // ByIssuerURL orders the results by the issuer_url field.
 func ByIssuerURL(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldIssuerURL, opts...).ToFunc()
+}
+
+// ByPermissionURL orders the results by the permission_url field.
+func ByPermissionURL(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldPermissionURL, opts...).ToFunc()
 }
 
 // ByVisibility orders the results by the visibility field.

--- a/controlplane-api/ent/zone/zone.go
+++ b/controlplane-api/ent/zone/zone.go
@@ -28,8 +28,8 @@ const (
 	FieldGatewayURL = "gateway_url"
 	// FieldIssuerURL holds the string denoting the issuer_url field in the database.
 	FieldIssuerURL = "issuer_url"
-	// FieldPermissionURL holds the string denoting the permission_url field in the database.
-	FieldPermissionURL = "permission_url"
+	// FieldPermissionsURL holds the string denoting the permissions_url field in the database.
+	FieldPermissionsURL = "permissions_url"
 	// FieldVisibility holds the string denoting the visibility field in the database.
 	FieldVisibility = "visibility"
 	// EdgeApplications holds the string denoting the applications edge name in mutations.
@@ -52,7 +52,7 @@ var Columns = []string{
 	FieldName,
 	FieldGatewayURL,
 	FieldIssuerURL,
-	FieldPermissionURL,
+	FieldPermissionsURL,
 	FieldVisibility,
 }
 
@@ -143,9 +143,9 @@ func ByIssuerURL(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldIssuerURL, opts...).ToFunc()
 }
 
-// ByPermissionURL orders the results by the permission_url field.
-func ByPermissionURL(opts ...sql.OrderTermOption) OrderOption {
-	return sql.OrderByField(FieldPermissionURL, opts...).ToFunc()
+// ByPermissionsURL orders the results by the permissions_url field.
+func ByPermissionsURL(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldPermissionsURL, opts...).ToFunc()
 }
 
 // ByVisibility orders the results by the visibility field.

--- a/controlplane-api/ent/zone_create.go
+++ b/controlplane-api/ent/zone_create.go
@@ -73,16 +73,16 @@ func (_c *ZoneCreate) SetNillableIssuerURL(v *string) *ZoneCreate {
 	return _c
 }
 
-// SetPermissionURL sets the "permission_url" field.
-func (_c *ZoneCreate) SetPermissionURL(v string) *ZoneCreate {
-	_c.mutation.SetPermissionURL(v)
+// SetPermissionsURL sets the "permissions_url" field.
+func (_c *ZoneCreate) SetPermissionsURL(v string) *ZoneCreate {
+	_c.mutation.SetPermissionsURL(v)
 	return _c
 }
 
-// SetNillablePermissionURL sets the "permission_url" field if the given value is not nil.
-func (_c *ZoneCreate) SetNillablePermissionURL(v *string) *ZoneCreate {
+// SetNillablePermissionsURL sets the "permissions_url" field if the given value is not nil.
+func (_c *ZoneCreate) SetNillablePermissionsURL(v *string) *ZoneCreate {
 	if v != nil {
-		_c.SetPermissionURL(*v)
+		_c.SetPermissionsURL(*v)
 	}
 	return _c
 }
@@ -221,9 +221,9 @@ func (_c *ZoneCreate) createSpec() (*Zone, *sqlgraph.CreateSpec) {
 		_spec.SetField(zone.FieldIssuerURL, field.TypeString, value)
 		_node.IssuerURL = &value
 	}
-	if value, ok := _c.mutation.PermissionURL(); ok {
-		_spec.SetField(zone.FieldPermissionURL, field.TypeString, value)
-		_node.PermissionURL = &value
+	if value, ok := _c.mutation.PermissionsURL(); ok {
+		_spec.SetField(zone.FieldPermissionsURL, field.TypeString, value)
+		_node.PermissionsURL = &value
 	}
 	if value, ok := _c.mutation.Visibility(); ok {
 		_spec.SetField(zone.FieldVisibility, field.TypeEnum, value)
@@ -363,21 +363,21 @@ func (u *ZoneUpsert) ClearIssuerURL() *ZoneUpsert {
 	return u
 }
 
-// SetPermissionURL sets the "permission_url" field.
-func (u *ZoneUpsert) SetPermissionURL(v string) *ZoneUpsert {
-	u.Set(zone.FieldPermissionURL, v)
+// SetPermissionsURL sets the "permissions_url" field.
+func (u *ZoneUpsert) SetPermissionsURL(v string) *ZoneUpsert {
+	u.Set(zone.FieldPermissionsURL, v)
 	return u
 }
 
-// UpdatePermissionURL sets the "permission_url" field to the value that was provided on create.
-func (u *ZoneUpsert) UpdatePermissionURL() *ZoneUpsert {
-	u.SetExcluded(zone.FieldPermissionURL)
+// UpdatePermissionsURL sets the "permissions_url" field to the value that was provided on create.
+func (u *ZoneUpsert) UpdatePermissionsURL() *ZoneUpsert {
+	u.SetExcluded(zone.FieldPermissionsURL)
 	return u
 }
 
-// ClearPermissionURL clears the value of the "permission_url" field.
-func (u *ZoneUpsert) ClearPermissionURL() *ZoneUpsert {
-	u.SetNull(zone.FieldPermissionURL)
+// ClearPermissionsURL clears the value of the "permissions_url" field.
+func (u *ZoneUpsert) ClearPermissionsURL() *ZoneUpsert {
+	u.SetNull(zone.FieldPermissionsURL)
 	return u
 }
 
@@ -510,24 +510,24 @@ func (u *ZoneUpsertOne) ClearIssuerURL() *ZoneUpsertOne {
 	})
 }
 
-// SetPermissionURL sets the "permission_url" field.
-func (u *ZoneUpsertOne) SetPermissionURL(v string) *ZoneUpsertOne {
+// SetPermissionsURL sets the "permissions_url" field.
+func (u *ZoneUpsertOne) SetPermissionsURL(v string) *ZoneUpsertOne {
 	return u.Update(func(s *ZoneUpsert) {
-		s.SetPermissionURL(v)
+		s.SetPermissionsURL(v)
 	})
 }
 
-// UpdatePermissionURL sets the "permission_url" field to the value that was provided on create.
-func (u *ZoneUpsertOne) UpdatePermissionURL() *ZoneUpsertOne {
+// UpdatePermissionsURL sets the "permissions_url" field to the value that was provided on create.
+func (u *ZoneUpsertOne) UpdatePermissionsURL() *ZoneUpsertOne {
 	return u.Update(func(s *ZoneUpsert) {
-		s.UpdatePermissionURL()
+		s.UpdatePermissionsURL()
 	})
 }
 
-// ClearPermissionURL clears the value of the "permission_url" field.
-func (u *ZoneUpsertOne) ClearPermissionURL() *ZoneUpsertOne {
+// ClearPermissionsURL clears the value of the "permissions_url" field.
+func (u *ZoneUpsertOne) ClearPermissionsURL() *ZoneUpsertOne {
 	return u.Update(func(s *ZoneUpsert) {
-		s.ClearPermissionURL()
+		s.ClearPermissionsURL()
 	})
 }
 
@@ -826,24 +826,24 @@ func (u *ZoneUpsertBulk) ClearIssuerURL() *ZoneUpsertBulk {
 	})
 }
 
-// SetPermissionURL sets the "permission_url" field.
-func (u *ZoneUpsertBulk) SetPermissionURL(v string) *ZoneUpsertBulk {
+// SetPermissionsURL sets the "permissions_url" field.
+func (u *ZoneUpsertBulk) SetPermissionsURL(v string) *ZoneUpsertBulk {
 	return u.Update(func(s *ZoneUpsert) {
-		s.SetPermissionURL(v)
+		s.SetPermissionsURL(v)
 	})
 }
 
-// UpdatePermissionURL sets the "permission_url" field to the value that was provided on create.
-func (u *ZoneUpsertBulk) UpdatePermissionURL() *ZoneUpsertBulk {
+// UpdatePermissionsURL sets the "permissions_url" field to the value that was provided on create.
+func (u *ZoneUpsertBulk) UpdatePermissionsURL() *ZoneUpsertBulk {
 	return u.Update(func(s *ZoneUpsert) {
-		s.UpdatePermissionURL()
+		s.UpdatePermissionsURL()
 	})
 }
 
-// ClearPermissionURL clears the value of the "permission_url" field.
-func (u *ZoneUpsertBulk) ClearPermissionURL() *ZoneUpsertBulk {
+// ClearPermissionsURL clears the value of the "permissions_url" field.
+func (u *ZoneUpsertBulk) ClearPermissionsURL() *ZoneUpsertBulk {
 	return u.Update(func(s *ZoneUpsert) {
-		s.ClearPermissionURL()
+		s.ClearPermissionsURL()
 	})
 }
 

--- a/controlplane-api/ent/zone_create.go
+++ b/controlplane-api/ent/zone_create.go
@@ -73,6 +73,20 @@ func (_c *ZoneCreate) SetNillableIssuerURL(v *string) *ZoneCreate {
 	return _c
 }
 
+// SetPermissionURL sets the "permission_url" field.
+func (_c *ZoneCreate) SetPermissionURL(v string) *ZoneCreate {
+	_c.mutation.SetPermissionURL(v)
+	return _c
+}
+
+// SetNillablePermissionURL sets the "permission_url" field if the given value is not nil.
+func (_c *ZoneCreate) SetNillablePermissionURL(v *string) *ZoneCreate {
+	if v != nil {
+		_c.SetPermissionURL(*v)
+	}
+	return _c
+}
+
 // SetVisibility sets the "visibility" field.
 func (_c *ZoneCreate) SetVisibility(v zone.Visibility) *ZoneCreate {
 	_c.mutation.SetVisibility(v)
@@ -206,6 +220,10 @@ func (_c *ZoneCreate) createSpec() (*Zone, *sqlgraph.CreateSpec) {
 	if value, ok := _c.mutation.IssuerURL(); ok {
 		_spec.SetField(zone.FieldIssuerURL, field.TypeString, value)
 		_node.IssuerURL = &value
+	}
+	if value, ok := _c.mutation.PermissionURL(); ok {
+		_spec.SetField(zone.FieldPermissionURL, field.TypeString, value)
+		_node.PermissionURL = &value
 	}
 	if value, ok := _c.mutation.Visibility(); ok {
 		_spec.SetField(zone.FieldVisibility, field.TypeEnum, value)
@@ -345,6 +363,24 @@ func (u *ZoneUpsert) ClearIssuerURL() *ZoneUpsert {
 	return u
 }
 
+// SetPermissionURL sets the "permission_url" field.
+func (u *ZoneUpsert) SetPermissionURL(v string) *ZoneUpsert {
+	u.Set(zone.FieldPermissionURL, v)
+	return u
+}
+
+// UpdatePermissionURL sets the "permission_url" field to the value that was provided on create.
+func (u *ZoneUpsert) UpdatePermissionURL() *ZoneUpsert {
+	u.SetExcluded(zone.FieldPermissionURL)
+	return u
+}
+
+// ClearPermissionURL clears the value of the "permission_url" field.
+func (u *ZoneUpsert) ClearPermissionURL() *ZoneUpsert {
+	u.SetNull(zone.FieldPermissionURL)
+	return u
+}
+
 // SetVisibility sets the "visibility" field.
 func (u *ZoneUpsert) SetVisibility(v zone.Visibility) *ZoneUpsert {
 	u.Set(zone.FieldVisibility, v)
@@ -471,6 +507,27 @@ func (u *ZoneUpsertOne) UpdateIssuerURL() *ZoneUpsertOne {
 func (u *ZoneUpsertOne) ClearIssuerURL() *ZoneUpsertOne {
 	return u.Update(func(s *ZoneUpsert) {
 		s.ClearIssuerURL()
+	})
+}
+
+// SetPermissionURL sets the "permission_url" field.
+func (u *ZoneUpsertOne) SetPermissionURL(v string) *ZoneUpsertOne {
+	return u.Update(func(s *ZoneUpsert) {
+		s.SetPermissionURL(v)
+	})
+}
+
+// UpdatePermissionURL sets the "permission_url" field to the value that was provided on create.
+func (u *ZoneUpsertOne) UpdatePermissionURL() *ZoneUpsertOne {
+	return u.Update(func(s *ZoneUpsert) {
+		s.UpdatePermissionURL()
+	})
+}
+
+// ClearPermissionURL clears the value of the "permission_url" field.
+func (u *ZoneUpsertOne) ClearPermissionURL() *ZoneUpsertOne {
+	return u.Update(func(s *ZoneUpsert) {
+		s.ClearPermissionURL()
 	})
 }
 
@@ -766,6 +823,27 @@ func (u *ZoneUpsertBulk) UpdateIssuerURL() *ZoneUpsertBulk {
 func (u *ZoneUpsertBulk) ClearIssuerURL() *ZoneUpsertBulk {
 	return u.Update(func(s *ZoneUpsert) {
 		s.ClearIssuerURL()
+	})
+}
+
+// SetPermissionURL sets the "permission_url" field.
+func (u *ZoneUpsertBulk) SetPermissionURL(v string) *ZoneUpsertBulk {
+	return u.Update(func(s *ZoneUpsert) {
+		s.SetPermissionURL(v)
+	})
+}
+
+// UpdatePermissionURL sets the "permission_url" field to the value that was provided on create.
+func (u *ZoneUpsertBulk) UpdatePermissionURL() *ZoneUpsertBulk {
+	return u.Update(func(s *ZoneUpsert) {
+		s.UpdatePermissionURL()
+	})
+}
+
+// ClearPermissionURL clears the value of the "permission_url" field.
+func (u *ZoneUpsertBulk) ClearPermissionURL() *ZoneUpsertBulk {
+	return u.Update(func(s *ZoneUpsert) {
+		s.ClearPermissionURL()
 	})
 }
 

--- a/controlplane-api/ent/zone_update.go
+++ b/controlplane-api/ent/zone_update.go
@@ -105,6 +105,26 @@ func (_u *ZoneUpdate) ClearIssuerURL() *ZoneUpdate {
 	return _u
 }
 
+// SetPermissionURL sets the "permission_url" field.
+func (_u *ZoneUpdate) SetPermissionURL(v string) *ZoneUpdate {
+	_u.mutation.SetPermissionURL(v)
+	return _u
+}
+
+// SetNillablePermissionURL sets the "permission_url" field if the given value is not nil.
+func (_u *ZoneUpdate) SetNillablePermissionURL(v *string) *ZoneUpdate {
+	if v != nil {
+		_u.SetPermissionURL(*v)
+	}
+	return _u
+}
+
+// ClearPermissionURL clears the value of the "permission_url" field.
+func (_u *ZoneUpdate) ClearPermissionURL() *ZoneUpdate {
+	_u.mutation.ClearPermissionURL()
+	return _u
+}
+
 // SetVisibility sets the "visibility" field.
 func (_u *ZoneUpdate) SetVisibility(v zone.Visibility) *ZoneUpdate {
 	_u.mutation.SetVisibility(v)
@@ -234,6 +254,12 @@ func (_u *ZoneUpdate) sqlSave(ctx context.Context) (_node int, err error) {
 	}
 	if _u.mutation.IssuerURLCleared() {
 		_spec.ClearField(zone.FieldIssuerURL, field.TypeString)
+	}
+	if value, ok := _u.mutation.PermissionURL(); ok {
+		_spec.SetField(zone.FieldPermissionURL, field.TypeString, value)
+	}
+	if _u.mutation.PermissionURLCleared() {
+		_spec.ClearField(zone.FieldPermissionURL, field.TypeString)
 	}
 	if value, ok := _u.mutation.Visibility(); ok {
 		_spec.SetField(zone.FieldVisibility, field.TypeEnum, value)
@@ -374,6 +400,26 @@ func (_u *ZoneUpdateOne) SetNillableIssuerURL(v *string) *ZoneUpdateOne {
 // ClearIssuerURL clears the value of the "issuer_url" field.
 func (_u *ZoneUpdateOne) ClearIssuerURL() *ZoneUpdateOne {
 	_u.mutation.ClearIssuerURL()
+	return _u
+}
+
+// SetPermissionURL sets the "permission_url" field.
+func (_u *ZoneUpdateOne) SetPermissionURL(v string) *ZoneUpdateOne {
+	_u.mutation.SetPermissionURL(v)
+	return _u
+}
+
+// SetNillablePermissionURL sets the "permission_url" field if the given value is not nil.
+func (_u *ZoneUpdateOne) SetNillablePermissionURL(v *string) *ZoneUpdateOne {
+	if v != nil {
+		_u.SetPermissionURL(*v)
+	}
+	return _u
+}
+
+// ClearPermissionURL clears the value of the "permission_url" field.
+func (_u *ZoneUpdateOne) ClearPermissionURL() *ZoneUpdateOne {
+	_u.mutation.ClearPermissionURL()
 	return _u
 }
 
@@ -536,6 +582,12 @@ func (_u *ZoneUpdateOne) sqlSave(ctx context.Context) (_node *Zone, err error) {
 	}
 	if _u.mutation.IssuerURLCleared() {
 		_spec.ClearField(zone.FieldIssuerURL, field.TypeString)
+	}
+	if value, ok := _u.mutation.PermissionURL(); ok {
+		_spec.SetField(zone.FieldPermissionURL, field.TypeString, value)
+	}
+	if _u.mutation.PermissionURLCleared() {
+		_spec.ClearField(zone.FieldPermissionURL, field.TypeString)
 	}
 	if value, ok := _u.mutation.Visibility(); ok {
 		_spec.SetField(zone.FieldVisibility, field.TypeEnum, value)

--- a/controlplane-api/ent/zone_update.go
+++ b/controlplane-api/ent/zone_update.go
@@ -105,23 +105,23 @@ func (_u *ZoneUpdate) ClearIssuerURL() *ZoneUpdate {
 	return _u
 }
 
-// SetPermissionURL sets the "permission_url" field.
-func (_u *ZoneUpdate) SetPermissionURL(v string) *ZoneUpdate {
-	_u.mutation.SetPermissionURL(v)
+// SetPermissionsURL sets the "permissions_url" field.
+func (_u *ZoneUpdate) SetPermissionsURL(v string) *ZoneUpdate {
+	_u.mutation.SetPermissionsURL(v)
 	return _u
 }
 
-// SetNillablePermissionURL sets the "permission_url" field if the given value is not nil.
-func (_u *ZoneUpdate) SetNillablePermissionURL(v *string) *ZoneUpdate {
+// SetNillablePermissionsURL sets the "permissions_url" field if the given value is not nil.
+func (_u *ZoneUpdate) SetNillablePermissionsURL(v *string) *ZoneUpdate {
 	if v != nil {
-		_u.SetPermissionURL(*v)
+		_u.SetPermissionsURL(*v)
 	}
 	return _u
 }
 
-// ClearPermissionURL clears the value of the "permission_url" field.
-func (_u *ZoneUpdate) ClearPermissionURL() *ZoneUpdate {
-	_u.mutation.ClearPermissionURL()
+// ClearPermissionsURL clears the value of the "permissions_url" field.
+func (_u *ZoneUpdate) ClearPermissionsURL() *ZoneUpdate {
+	_u.mutation.ClearPermissionsURL()
 	return _u
 }
 
@@ -255,11 +255,11 @@ func (_u *ZoneUpdate) sqlSave(ctx context.Context) (_node int, err error) {
 	if _u.mutation.IssuerURLCleared() {
 		_spec.ClearField(zone.FieldIssuerURL, field.TypeString)
 	}
-	if value, ok := _u.mutation.PermissionURL(); ok {
-		_spec.SetField(zone.FieldPermissionURL, field.TypeString, value)
+	if value, ok := _u.mutation.PermissionsURL(); ok {
+		_spec.SetField(zone.FieldPermissionsURL, field.TypeString, value)
 	}
-	if _u.mutation.PermissionURLCleared() {
-		_spec.ClearField(zone.FieldPermissionURL, field.TypeString)
+	if _u.mutation.PermissionsURLCleared() {
+		_spec.ClearField(zone.FieldPermissionsURL, field.TypeString)
 	}
 	if value, ok := _u.mutation.Visibility(); ok {
 		_spec.SetField(zone.FieldVisibility, field.TypeEnum, value)
@@ -403,23 +403,23 @@ func (_u *ZoneUpdateOne) ClearIssuerURL() *ZoneUpdateOne {
 	return _u
 }
 
-// SetPermissionURL sets the "permission_url" field.
-func (_u *ZoneUpdateOne) SetPermissionURL(v string) *ZoneUpdateOne {
-	_u.mutation.SetPermissionURL(v)
+// SetPermissionsURL sets the "permissions_url" field.
+func (_u *ZoneUpdateOne) SetPermissionsURL(v string) *ZoneUpdateOne {
+	_u.mutation.SetPermissionsURL(v)
 	return _u
 }
 
-// SetNillablePermissionURL sets the "permission_url" field if the given value is not nil.
-func (_u *ZoneUpdateOne) SetNillablePermissionURL(v *string) *ZoneUpdateOne {
+// SetNillablePermissionsURL sets the "permissions_url" field if the given value is not nil.
+func (_u *ZoneUpdateOne) SetNillablePermissionsURL(v *string) *ZoneUpdateOne {
 	if v != nil {
-		_u.SetPermissionURL(*v)
+		_u.SetPermissionsURL(*v)
 	}
 	return _u
 }
 
-// ClearPermissionURL clears the value of the "permission_url" field.
-func (_u *ZoneUpdateOne) ClearPermissionURL() *ZoneUpdateOne {
-	_u.mutation.ClearPermissionURL()
+// ClearPermissionsURL clears the value of the "permissions_url" field.
+func (_u *ZoneUpdateOne) ClearPermissionsURL() *ZoneUpdateOne {
+	_u.mutation.ClearPermissionsURL()
 	return _u
 }
 
@@ -583,11 +583,11 @@ func (_u *ZoneUpdateOne) sqlSave(ctx context.Context) (_node *Zone, err error) {
 	if _u.mutation.IssuerURLCleared() {
 		_spec.ClearField(zone.FieldIssuerURL, field.TypeString)
 	}
-	if value, ok := _u.mutation.PermissionURL(); ok {
-		_spec.SetField(zone.FieldPermissionURL, field.TypeString, value)
+	if value, ok := _u.mutation.PermissionsURL(); ok {
+		_spec.SetField(zone.FieldPermissionsURL, field.TypeString, value)
 	}
-	if _u.mutation.PermissionURLCleared() {
-		_spec.ClearField(zone.FieldPermissionURL, field.TypeString)
+	if _u.mutation.PermissionsURLCleared() {
+		_spec.ClearField(zone.FieldPermissionsURL, field.TypeString)
 	}
 	if value, ok := _u.mutation.Visibility(); ok {
 		_spec.SetField(zone.FieldVisibility, field.TypeEnum, value)

--- a/controlplane-api/internal/resolvers/ent.generated.go
+++ b/controlplane-api/internal/resolvers/ent.generated.go
@@ -55,6 +55,7 @@ type ApplicationResolver interface {
 	RotatedClientSecret(ctx context.Context, obj *ent.Application) (*string, error)
 
 	OwnerTeam(ctx context.Context, obj *ent.Application) (*model.TeamInfo, error)
+	PermissionsURL(ctx context.Context, obj *ent.Application) (*string, error)
 }
 type ApprovalResolver interface {
 	Subscription(ctx context.Context, obj *ent.Approval) (model1.SubscriptionInfo, error)
@@ -3548,6 +3549,29 @@ func (ec *executionContext) fieldContext_Application_ownerTeam(_ context.Context
 		},
 	}
 	return fc, nil
+}
+
+func (ec *executionContext) _Application_permissionsURL(ctx context.Context, field graphql.CollectedField, obj *ent.Application) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.fieldContext_Application_permissionsURL(ctx, field)
+		},
+		func(ctx context.Context) (any, error) {
+			return ec.Resolvers.Application().PermissionsURL(ctx, obj)
+		},
+		nil,
+		func(ctx context.Context, selections ast.SelectionSet, v *string) graphql.Marshaler {
+			return ec.marshalOString2ᚖstring(ctx, selections, v)
+		},
+		true,
+		false,
+	)
+}
+func (ec *executionContext) fieldContext_Application_permissionsURL(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	return graphql.NewScalarFieldContext("Application", field, true, true, errors.New("field of type String does not have child fields"))
 }
 
 func (ec *executionContext) _ApplicationConnection_edges(ctx context.Context, field graphql.CollectedField, obj *ent.ApplicationConnection) (ret graphql.Marshaler) {
@@ -8807,16 +8831,16 @@ func (ec *executionContext) fieldContext_Zone_issuerURL(_ context.Context, field
 	return graphql.NewScalarFieldContext("Zone", field, false, false, errors.New("field of type String does not have child fields"))
 }
 
-func (ec *executionContext) _Zone_permissionURL(ctx context.Context, field graphql.CollectedField, obj *ent.Zone) (ret graphql.Marshaler) {
+func (ec *executionContext) _Zone_permissionsURL(ctx context.Context, field graphql.CollectedField, obj *ent.Zone) (ret graphql.Marshaler) {
 	return graphql.ResolveField(
 		ctx,
 		ec.OperationContext,
 		field,
 		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return ec.fieldContext_Zone_permissionURL(ctx, field)
+			return ec.fieldContext_Zone_permissionsURL(ctx, field)
 		},
 		func(ctx context.Context) (any, error) {
-			return obj.PermissionURL, nil
+			return obj.PermissionsURL, nil
 		},
 		nil,
 		func(ctx context.Context, selections ast.SelectionSet, v *string) graphql.Marshaler {
@@ -8826,7 +8850,7 @@ func (ec *executionContext) _Zone_permissionURL(ctx context.Context, field graph
 		false,
 	)
 }
-func (ec *executionContext) fieldContext_Zone_permissionURL(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+func (ec *executionContext) fieldContext_Zone_permissionsURL(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	return graphql.NewScalarFieldContext("Zone", field, false, false, errors.New("field of type String does not have child fields"))
 }
 
@@ -20544,7 +20568,7 @@ func (ec *executionContext) unmarshalInputZoneWhereInput(ctx context.Context, ob
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"not", "and", "or", "id", "idNEQ", "idIn", "idNotIn", "idGT", "idGTE", "idLT", "idLTE", "environment", "environmentNEQ", "environmentIn", "environmentNotIn", "environmentGT", "environmentGTE", "environmentLT", "environmentLTE", "environmentContains", "environmentHasPrefix", "environmentHasSuffix", "environmentIsNil", "environmentNotNil", "environmentEqualFold", "environmentContainsFold", "name", "nameNEQ", "nameIn", "nameNotIn", "nameGT", "nameGTE", "nameLT", "nameLTE", "nameContains", "nameHasPrefix", "nameHasSuffix", "nameEqualFold", "nameContainsFold", "gatewayURL", "gatewayURLNEQ", "gatewayURLIn", "gatewayURLNotIn", "gatewayURLGT", "gatewayURLGTE", "gatewayURLLT", "gatewayURLLTE", "gatewayURLContains", "gatewayURLHasPrefix", "gatewayURLHasSuffix", "gatewayURLIsNil", "gatewayURLNotNil", "gatewayURLEqualFold", "gatewayURLContainsFold", "issuerURL", "issuerURLNEQ", "issuerURLIn", "issuerURLNotIn", "issuerURLGT", "issuerURLGTE", "issuerURLLT", "issuerURLLTE", "issuerURLContains", "issuerURLHasPrefix", "issuerURLHasSuffix", "issuerURLIsNil", "issuerURLNotNil", "issuerURLEqualFold", "issuerURLContainsFold", "permissionURL", "permissionURLNEQ", "permissionURLIn", "permissionURLNotIn", "permissionURLGT", "permissionURLGTE", "permissionURLLT", "permissionURLLTE", "permissionURLContains", "permissionURLHasPrefix", "permissionURLHasSuffix", "permissionURLIsNil", "permissionURLNotNil", "permissionURLEqualFold", "permissionURLContainsFold", "visibility", "visibilityNEQ", "visibilityIn", "visibilityNotIn", "hasApplications", "hasApplicationsWith"}
+	fieldsInOrder := [...]string{"not", "and", "or", "id", "idNEQ", "idIn", "idNotIn", "idGT", "idGTE", "idLT", "idLTE", "environment", "environmentNEQ", "environmentIn", "environmentNotIn", "environmentGT", "environmentGTE", "environmentLT", "environmentLTE", "environmentContains", "environmentHasPrefix", "environmentHasSuffix", "environmentIsNil", "environmentNotNil", "environmentEqualFold", "environmentContainsFold", "name", "nameNEQ", "nameIn", "nameNotIn", "nameGT", "nameGTE", "nameLT", "nameLTE", "nameContains", "nameHasPrefix", "nameHasSuffix", "nameEqualFold", "nameContainsFold", "gatewayURL", "gatewayURLNEQ", "gatewayURLIn", "gatewayURLNotIn", "gatewayURLGT", "gatewayURLGTE", "gatewayURLLT", "gatewayURLLTE", "gatewayURLContains", "gatewayURLHasPrefix", "gatewayURLHasSuffix", "gatewayURLIsNil", "gatewayURLNotNil", "gatewayURLEqualFold", "gatewayURLContainsFold", "issuerURL", "issuerURLNEQ", "issuerURLIn", "issuerURLNotIn", "issuerURLGT", "issuerURLGTE", "issuerURLLT", "issuerURLLTE", "issuerURLContains", "issuerURLHasPrefix", "issuerURLHasSuffix", "issuerURLIsNil", "issuerURLNotNil", "issuerURLEqualFold", "issuerURLContainsFold", "permissionsURL", "permissionsURLNEQ", "permissionsURLIn", "permissionsURLNotIn", "permissionsURLGT", "permissionsURLGTE", "permissionsURLLT", "permissionsURLLTE", "permissionsURLContains", "permissionsURLHasPrefix", "permissionsURLHasSuffix", "permissionsURLIsNil", "permissionsURLNotNil", "permissionsURLEqualFold", "permissionsURLContainsFold", "visibility", "visibilityNEQ", "visibilityIn", "visibilityNotIn", "hasApplications", "hasApplicationsWith"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -21034,111 +21058,111 @@ func (ec *executionContext) unmarshalInputZoneWhereInput(ctx context.Context, ob
 				return it, err
 			}
 			it.IssuerURLContainsFold = data
-		case "permissionURL":
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("permissionURL"))
+		case "permissionsURL":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("permissionsURL"))
 			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
 			if err != nil {
 				return it, err
 			}
-			it.PermissionURL = data
-		case "permissionURLNEQ":
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("permissionURLNEQ"))
+			it.PermissionsURL = data
+		case "permissionsURLNEQ":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("permissionsURLNEQ"))
 			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
 			if err != nil {
 				return it, err
 			}
-			it.PermissionURLNEQ = data
-		case "permissionURLIn":
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("permissionURLIn"))
+			it.PermissionsURLNEQ = data
+		case "permissionsURLIn":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("permissionsURLIn"))
 			data, err := ec.unmarshalOString2ᚕstringᚄ(ctx, v)
 			if err != nil {
 				return it, err
 			}
-			it.PermissionURLIn = data
-		case "permissionURLNotIn":
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("permissionURLNotIn"))
+			it.PermissionsURLIn = data
+		case "permissionsURLNotIn":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("permissionsURLNotIn"))
 			data, err := ec.unmarshalOString2ᚕstringᚄ(ctx, v)
 			if err != nil {
 				return it, err
 			}
-			it.PermissionURLNotIn = data
-		case "permissionURLGT":
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("permissionURLGT"))
+			it.PermissionsURLNotIn = data
+		case "permissionsURLGT":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("permissionsURLGT"))
 			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
 			if err != nil {
 				return it, err
 			}
-			it.PermissionURLGT = data
-		case "permissionURLGTE":
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("permissionURLGTE"))
+			it.PermissionsURLGT = data
+		case "permissionsURLGTE":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("permissionsURLGTE"))
 			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
 			if err != nil {
 				return it, err
 			}
-			it.PermissionURLGTE = data
-		case "permissionURLLT":
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("permissionURLLT"))
+			it.PermissionsURLGTE = data
+		case "permissionsURLLT":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("permissionsURLLT"))
 			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
 			if err != nil {
 				return it, err
 			}
-			it.PermissionURLLT = data
-		case "permissionURLLTE":
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("permissionURLLTE"))
+			it.PermissionsURLLT = data
+		case "permissionsURLLTE":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("permissionsURLLTE"))
 			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
 			if err != nil {
 				return it, err
 			}
-			it.PermissionURLLTE = data
-		case "permissionURLContains":
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("permissionURLContains"))
+			it.PermissionsURLLTE = data
+		case "permissionsURLContains":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("permissionsURLContains"))
 			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
 			if err != nil {
 				return it, err
 			}
-			it.PermissionURLContains = data
-		case "permissionURLHasPrefix":
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("permissionURLHasPrefix"))
+			it.PermissionsURLContains = data
+		case "permissionsURLHasPrefix":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("permissionsURLHasPrefix"))
 			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
 			if err != nil {
 				return it, err
 			}
-			it.PermissionURLHasPrefix = data
-		case "permissionURLHasSuffix":
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("permissionURLHasSuffix"))
+			it.PermissionsURLHasPrefix = data
+		case "permissionsURLHasSuffix":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("permissionsURLHasSuffix"))
 			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
 			if err != nil {
 				return it, err
 			}
-			it.PermissionURLHasSuffix = data
-		case "permissionURLIsNil":
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("permissionURLIsNil"))
+			it.PermissionsURLHasSuffix = data
+		case "permissionsURLIsNil":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("permissionsURLIsNil"))
 			data, err := ec.unmarshalOBoolean2bool(ctx, v)
 			if err != nil {
 				return it, err
 			}
-			it.PermissionURLIsNil = data
-		case "permissionURLNotNil":
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("permissionURLNotNil"))
+			it.PermissionsURLIsNil = data
+		case "permissionsURLNotNil":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("permissionsURLNotNil"))
 			data, err := ec.unmarshalOBoolean2bool(ctx, v)
 			if err != nil {
 				return it, err
 			}
-			it.PermissionURLNotNil = data
-		case "permissionURLEqualFold":
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("permissionURLEqualFold"))
+			it.PermissionsURLNotNil = data
+		case "permissionsURLEqualFold":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("permissionsURLEqualFold"))
 			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
 			if err != nil {
 				return it, err
 			}
-			it.PermissionURLEqualFold = data
-		case "permissionURLContainsFold":
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("permissionURLContainsFold"))
+			it.PermissionsURLEqualFold = data
+		case "permissionsURLContainsFold":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("permissionsURLContainsFold"))
 			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
 			if err != nil {
 				return it, err
 			}
-			it.PermissionURLContainsFold = data
+			it.PermissionsURLContainsFold = data
 		case "visibility":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("visibility"))
 			data, err := ec.unmarshalOZoneVisibility2ᚖgithubᚗcomᚋtelekomᚋcontrolplaneᚋcontrolplaneᚑapiᚋentᚋzoneᚐVisibility(ctx, v)
@@ -22702,6 +22726,44 @@ func (ec *executionContext) _Application(ctx context.Context, sel ast.SelectionS
 				}()
 				res = ec._Application_ownerTeam(ctx, field, obj)
 				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			if field.IsDeferred() {
+				deferredFieldSet.AddField(field)
+				fieldIndex := len(deferredFieldSet.Values) - 1
+				deferredFieldSet.Concurrently(fieldIndex, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, deferredFieldSet)
+				})
+
+				for _, deferrable := range field.Deferrables {
+					view, ok := deferLabelToView[deferrable.Label]
+					if !ok {
+						view = deferredFieldSet.NewView()
+						deferLabelToView[deferrable.Label] = view
+					}
+					view.AddIndices(fieldIndex)
+				}
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		case "permissionsURL":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Application_permissionsURL(ctx, field, obj)
+				if res == graphql.RequiredNull {
 					atomic.AddUint32(&fs.Invalids, 1)
 				}
 				return res
@@ -25585,8 +25647,8 @@ func (ec *executionContext) _Zone(ctx context.Context, sel ast.SelectionSet, obj
 			if out.Values[i] == graphql.RequiredNull {
 				atomic.AddUint32(&out.Invalids, 1)
 			}
-		case "permissionURL":
-			out.Values[i] = ec._Zone_permissionURL(ctx, field, obj)
+		case "permissionsURL":
+			out.Values[i] = ec._Zone_permissionsURL(ctx, field, obj)
 			if out.Values[i] == graphql.RequiredNull {
 				atomic.AddUint32(&out.Invalids, 1)
 			}

--- a/controlplane-api/internal/resolvers/ent.generated.go
+++ b/controlplane-api/internal/resolvers/ent.generated.go
@@ -8807,6 +8807,29 @@ func (ec *executionContext) fieldContext_Zone_issuerURL(_ context.Context, field
 	return graphql.NewScalarFieldContext("Zone", field, false, false, errors.New("field of type String does not have child fields"))
 }
 
+func (ec *executionContext) _Zone_permissionURL(ctx context.Context, field graphql.CollectedField, obj *ent.Zone) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.fieldContext_Zone_permissionURL(ctx, field)
+		},
+		func(ctx context.Context) (any, error) {
+			return obj.PermissionURL, nil
+		},
+		nil,
+		func(ctx context.Context, selections ast.SelectionSet, v *string) graphql.Marshaler {
+			return ec.marshalOString2ᚖstring(ctx, selections, v)
+		},
+		true,
+		false,
+	)
+}
+func (ec *executionContext) fieldContext_Zone_permissionURL(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	return graphql.NewScalarFieldContext("Zone", field, false, false, errors.New("field of type String does not have child fields"))
+}
+
 func (ec *executionContext) _Zone_visibility(ctx context.Context, field graphql.CollectedField, obj *ent.Zone) (ret graphql.Marshaler) {
 	return graphql.ResolveField(
 		ctx,
@@ -20521,7 +20544,7 @@ func (ec *executionContext) unmarshalInputZoneWhereInput(ctx context.Context, ob
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"not", "and", "or", "id", "idNEQ", "idIn", "idNotIn", "idGT", "idGTE", "idLT", "idLTE", "environment", "environmentNEQ", "environmentIn", "environmentNotIn", "environmentGT", "environmentGTE", "environmentLT", "environmentLTE", "environmentContains", "environmentHasPrefix", "environmentHasSuffix", "environmentIsNil", "environmentNotNil", "environmentEqualFold", "environmentContainsFold", "name", "nameNEQ", "nameIn", "nameNotIn", "nameGT", "nameGTE", "nameLT", "nameLTE", "nameContains", "nameHasPrefix", "nameHasSuffix", "nameEqualFold", "nameContainsFold", "gatewayURL", "gatewayURLNEQ", "gatewayURLIn", "gatewayURLNotIn", "gatewayURLGT", "gatewayURLGTE", "gatewayURLLT", "gatewayURLLTE", "gatewayURLContains", "gatewayURLHasPrefix", "gatewayURLHasSuffix", "gatewayURLIsNil", "gatewayURLNotNil", "gatewayURLEqualFold", "gatewayURLContainsFold", "issuerURL", "issuerURLNEQ", "issuerURLIn", "issuerURLNotIn", "issuerURLGT", "issuerURLGTE", "issuerURLLT", "issuerURLLTE", "issuerURLContains", "issuerURLHasPrefix", "issuerURLHasSuffix", "issuerURLIsNil", "issuerURLNotNil", "issuerURLEqualFold", "issuerURLContainsFold", "visibility", "visibilityNEQ", "visibilityIn", "visibilityNotIn", "hasApplications", "hasApplicationsWith"}
+	fieldsInOrder := [...]string{"not", "and", "or", "id", "idNEQ", "idIn", "idNotIn", "idGT", "idGTE", "idLT", "idLTE", "environment", "environmentNEQ", "environmentIn", "environmentNotIn", "environmentGT", "environmentGTE", "environmentLT", "environmentLTE", "environmentContains", "environmentHasPrefix", "environmentHasSuffix", "environmentIsNil", "environmentNotNil", "environmentEqualFold", "environmentContainsFold", "name", "nameNEQ", "nameIn", "nameNotIn", "nameGT", "nameGTE", "nameLT", "nameLTE", "nameContains", "nameHasPrefix", "nameHasSuffix", "nameEqualFold", "nameContainsFold", "gatewayURL", "gatewayURLNEQ", "gatewayURLIn", "gatewayURLNotIn", "gatewayURLGT", "gatewayURLGTE", "gatewayURLLT", "gatewayURLLTE", "gatewayURLContains", "gatewayURLHasPrefix", "gatewayURLHasSuffix", "gatewayURLIsNil", "gatewayURLNotNil", "gatewayURLEqualFold", "gatewayURLContainsFold", "issuerURL", "issuerURLNEQ", "issuerURLIn", "issuerURLNotIn", "issuerURLGT", "issuerURLGTE", "issuerURLLT", "issuerURLLTE", "issuerURLContains", "issuerURLHasPrefix", "issuerURLHasSuffix", "issuerURLIsNil", "issuerURLNotNil", "issuerURLEqualFold", "issuerURLContainsFold", "permissionURL", "permissionURLNEQ", "permissionURLIn", "permissionURLNotIn", "permissionURLGT", "permissionURLGTE", "permissionURLLT", "permissionURLLTE", "permissionURLContains", "permissionURLHasPrefix", "permissionURLHasSuffix", "permissionURLIsNil", "permissionURLNotNil", "permissionURLEqualFold", "permissionURLContainsFold", "visibility", "visibilityNEQ", "visibilityIn", "visibilityNotIn", "hasApplications", "hasApplicationsWith"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -21011,6 +21034,111 @@ func (ec *executionContext) unmarshalInputZoneWhereInput(ctx context.Context, ob
 				return it, err
 			}
 			it.IssuerURLContainsFold = data
+		case "permissionURL":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("permissionURL"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.PermissionURL = data
+		case "permissionURLNEQ":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("permissionURLNEQ"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.PermissionURLNEQ = data
+		case "permissionURLIn":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("permissionURLIn"))
+			data, err := ec.unmarshalOString2ᚕstringᚄ(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.PermissionURLIn = data
+		case "permissionURLNotIn":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("permissionURLNotIn"))
+			data, err := ec.unmarshalOString2ᚕstringᚄ(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.PermissionURLNotIn = data
+		case "permissionURLGT":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("permissionURLGT"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.PermissionURLGT = data
+		case "permissionURLGTE":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("permissionURLGTE"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.PermissionURLGTE = data
+		case "permissionURLLT":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("permissionURLLT"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.PermissionURLLT = data
+		case "permissionURLLTE":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("permissionURLLTE"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.PermissionURLLTE = data
+		case "permissionURLContains":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("permissionURLContains"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.PermissionURLContains = data
+		case "permissionURLHasPrefix":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("permissionURLHasPrefix"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.PermissionURLHasPrefix = data
+		case "permissionURLHasSuffix":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("permissionURLHasSuffix"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.PermissionURLHasSuffix = data
+		case "permissionURLIsNil":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("permissionURLIsNil"))
+			data, err := ec.unmarshalOBoolean2bool(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.PermissionURLIsNil = data
+		case "permissionURLNotNil":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("permissionURLNotNil"))
+			data, err := ec.unmarshalOBoolean2bool(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.PermissionURLNotNil = data
+		case "permissionURLEqualFold":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("permissionURLEqualFold"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.PermissionURLEqualFold = data
+		case "permissionURLContainsFold":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("permissionURLContainsFold"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.PermissionURLContainsFold = data
 		case "visibility":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("visibility"))
 			data, err := ec.unmarshalOZoneVisibility2ᚖgithubᚗcomᚋtelekomᚋcontrolplaneᚋcontrolplaneᚑapiᚋentᚋzoneᚐVisibility(ctx, v)
@@ -25454,6 +25582,11 @@ func (ec *executionContext) _Zone(ctx context.Context, sel ast.SelectionSet, obj
 			}
 		case "issuerURL":
 			out.Values[i] = ec._Zone_issuerURL(ctx, field, obj)
+			if out.Values[i] == graphql.RequiredNull {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
+		case "permissionURL":
+			out.Values[i] = ec._Zone_permissionURL(ctx, field, obj)
 			if out.Values[i] == graphql.RequiredNull {
 				atomic.AddUint32(&out.Invalids, 1)
 			}

--- a/controlplane-api/internal/resolvers/root_.generated.go
+++ b/controlplane-api/internal/resolvers/root_.generated.go
@@ -748,14 +748,15 @@ type ComplexityRoot struct {
 	}
 
 	Zone struct {
-		Applications func(childComplexity int) int
-		Environment  func(childComplexity int) int
-		GatewayURL   func(childComplexity int) int
-		ID           func(childComplexity int) int
-		IssuerURL    func(childComplexity int) int
-		Name         func(childComplexity int) int
-		TokenURL     func(childComplexity int) int
-		Visibility   func(childComplexity int) int
+		Applications  func(childComplexity int) int
+		Environment   func(childComplexity int) int
+		GatewayURL    func(childComplexity int) int
+		ID            func(childComplexity int) int
+		IssuerURL     func(childComplexity int) int
+		Name          func(childComplexity int) int
+		PermissionURL func(childComplexity int) int
+		TokenURL      func(childComplexity int) int
+		Visibility    func(childComplexity int) int
 	}
 }
 
@@ -3635,6 +3636,12 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.ComplexityRoot.Zone.Name(childComplexity), true
+	case "Zone.permissionURL":
+		if e.ComplexityRoot.Zone.PermissionURL == nil {
+			break
+		}
+
+		return e.ComplexityRoot.Zone.PermissionURL(childComplexity), true
 	case "Zone.tokenURL":
 		if e.ComplexityRoot.Zone.TokenURL == nil {
 			break
@@ -7504,6 +7511,7 @@ type Zone implements Node {
   name: String!
   gatewayURL: String
   issuerURL: String
+  permissionURL: String
   visibility: ZoneVisibility!
   applications: [Application!]
 }
@@ -7603,6 +7611,24 @@ input ZoneWhereInput {
   issuerURLNotNil: Boolean
   issuerURLEqualFold: String
   issuerURLContainsFold: String
+  """
+  permission_url field predicates
+  """
+  permissionURL: String
+  permissionURLNEQ: String
+  permissionURLIn: [String!]
+  permissionURLNotIn: [String!]
+  permissionURLGT: String
+  permissionURLGTE: String
+  permissionURLLT: String
+  permissionURLLTE: String
+  permissionURLContains: String
+  permissionURLHasPrefix: String
+  permissionURLHasSuffix: String
+  permissionURLIsNil: Boolean
+  permissionURLNotNil: Boolean
+  permissionURLEqualFold: String
+  permissionURLContainsFold: String
   """
   visibility field predicates
   """
@@ -9497,6 +9523,8 @@ func (ec *executionContext) childFields_Zone(ctx context.Context, field graphql.
 		return ec.fieldContext_Zone_gatewayURL(ctx, field)
 	case "issuerURL":
 		return ec.fieldContext_Zone_issuerURL(ctx, field)
+	case "permissionURL":
+		return ec.fieldContext_Zone_permissionURL(ctx, field)
 	case "visibility":
 		return ec.fieldContext_Zone_visibility(ctx, field)
 	case "applications":

--- a/controlplane-api/internal/resolvers/root_.generated.go
+++ b/controlplane-api/internal/resolvers/root_.generated.go
@@ -208,6 +208,7 @@ type ComplexityRoot struct {
 		Namespace             func(childComplexity int) int
 		OwnerTeam             func(childComplexity int) int
 		PermissionSet         func(childComplexity int) int
+		PermissionsURL        func(childComplexity int) int
 		RotatedClientSecret   func(childComplexity int) int
 		RotatedExpiresAt      func(childComplexity int) int
 		SecretRotationMessage func(childComplexity int) int
@@ -748,15 +749,15 @@ type ComplexityRoot struct {
 	}
 
 	Zone struct {
-		Applications  func(childComplexity int) int
-		Environment   func(childComplexity int) int
-		GatewayURL    func(childComplexity int) int
-		ID            func(childComplexity int) int
-		IssuerURL     func(childComplexity int) int
-		Name          func(childComplexity int) int
-		PermissionURL func(childComplexity int) int
-		TokenURL      func(childComplexity int) int
-		Visibility    func(childComplexity int) int
+		Applications   func(childComplexity int) int
+		Environment    func(childComplexity int) int
+		GatewayURL     func(childComplexity int) int
+		ID             func(childComplexity int) int
+		IssuerURL      func(childComplexity int) int
+		Name           func(childComplexity int) int
+		PermissionsURL func(childComplexity int) int
+		TokenURL       func(childComplexity int) int
+		Visibility     func(childComplexity int) int
 	}
 }
 
@@ -1411,6 +1412,12 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.ComplexityRoot.Application.PermissionSet(childComplexity), true
+	case "Application.permissionsURL":
+		if e.ComplexityRoot.Application.PermissionsURL == nil {
+			break
+		}
+
+		return e.ComplexityRoot.Application.PermissionsURL(childComplexity), true
 	case "Application.rotatedClientSecret":
 		if e.ComplexityRoot.Application.RotatedClientSecret == nil {
 			break
@@ -3636,12 +3643,12 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.ComplexityRoot.Zone.Name(childComplexity), true
-	case "Zone.permissionURL":
-		if e.ComplexityRoot.Zone.PermissionURL == nil {
+	case "Zone.permissionsURL":
+		if e.ComplexityRoot.Zone.PermissionsURL == nil {
 			break
 		}
 
-		return e.ComplexityRoot.Zone.PermissionURL(childComplexity), true
+		return e.ComplexityRoot.Zone.PermissionsURL(childComplexity), true
 	case "Zone.tokenURL":
 		if e.ComplexityRoot.Zone.TokenURL == nil {
 			break
@@ -7511,7 +7518,7 @@ type Zone implements Node {
   name: String!
   gatewayURL: String
   issuerURL: String
-  permissionURL: String
+  permissionsURL: String
   visibility: ZoneVisibility!
   applications: [Application!]
 }
@@ -7612,23 +7619,23 @@ input ZoneWhereInput {
   issuerURLEqualFold: String
   issuerURLContainsFold: String
   """
-  permission_url field predicates
+  permissions_url field predicates
   """
-  permissionURL: String
-  permissionURLNEQ: String
-  permissionURLIn: [String!]
-  permissionURLNotIn: [String!]
-  permissionURLGT: String
-  permissionURLGTE: String
-  permissionURLLT: String
-  permissionURLLTE: String
-  permissionURLContains: String
-  permissionURLHasPrefix: String
-  permissionURLHasSuffix: String
-  permissionURLIsNil: Boolean
-  permissionURLNotNil: Boolean
-  permissionURLEqualFold: String
-  permissionURLContainsFold: String
+  permissionsURL: String
+  permissionsURLNEQ: String
+  permissionsURLIn: [String!]
+  permissionsURLNotIn: [String!]
+  permissionsURLGT: String
+  permissionsURLGTE: String
+  permissionsURLLT: String
+  permissionsURLLTE: String
+  permissionsURLContains: String
+  permissionsURLHasPrefix: String
+  permissionsURLHasSuffix: String
+  permissionsURLIsNil: Boolean
+  permissionsURLNotNil: Boolean
+  permissionsURLEqualFold: String
+  permissionsURLContainsFold: String
   """
   visibility field predicates
   """
@@ -8121,6 +8128,8 @@ type EventExposureInfo {
 extend type Application {
   "Owning team (reduced view for cross-tenant safety)"
   ownerTeam: TeamInfo!
+  "PermissionsUrl for permission queries (dynamically built from gateway URL) with ?application=<clientId> appended when querying"
+  permissionsURL: String @goField(forceResolver: true)
 }
 
 extend type Zone {
@@ -8519,6 +8528,8 @@ func (ec *executionContext) childFields_Application(ctx context.Context, field g
 		return ec.fieldContext_Application_permissionSet(ctx, field)
 	case "ownerTeam":
 		return ec.fieldContext_Application_ownerTeam(ctx, field)
+	case "permissionsURL":
+		return ec.fieldContext_Application_permissionsURL(ctx, field)
 	}
 	return nil, fmt.Errorf("no field named %q was found under type Application", field.Name)
 }
@@ -9523,8 +9534,8 @@ func (ec *executionContext) childFields_Zone(ctx context.Context, field graphql.
 		return ec.fieldContext_Zone_gatewayURL(ctx, field)
 	case "issuerURL":
 		return ec.fieldContext_Zone_issuerURL(ctx, field)
-	case "permissionURL":
-		return ec.fieldContext_Zone_permissionURL(ctx, field)
+	case "permissionsURL":
+		return ec.fieldContext_Zone_permissionsURL(ctx, field)
 	case "visibility":
 		return ec.fieldContext_Zone_visibility(ctx, field)
 	case "applications":

--- a/controlplane-api/internal/resolvers/schema.resolvers.go
+++ b/controlplane-api/internal/resolvers/schema.resolvers.go
@@ -11,6 +11,7 @@ package resolvers
 import (
 	"context"
 	"fmt"
+	"net/url"
 	"sort"
 
 	"github.com/go-logr/logr"
@@ -194,6 +195,21 @@ func (r *applicationResolver) OwnerTeam(ctx context.Context, obj *ent.Applicatio
 	}
 
 	return mapTeamInfo(team, group), nil
+}
+
+// PermissionsURL is the resolver for the permissionsURL field.
+func (r *applicationResolver) PermissionsURL(ctx context.Context, obj *ent.Application) (*string, error) {
+	zone, err := obj.QueryZone().Only(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("unable to load zone for application %d: %w", obj.ID, err)
+	}
+
+	if zone.PermissionsURL == nil || obj.ClientID == nil || *zone.PermissionsURL == "" || *obj.ClientID == "" {
+		return nil, nil
+	}
+
+	url := *zone.PermissionsURL + "?" + url.Values{"application": {*obj.ClientID}}.Encode()
+	return &url, nil
 }
 
 // Subscription is the resolver for the subscription field.

--- a/controlplane-api/internal/resolvers/schema_resolvers_application_test.go
+++ b/controlplane-api/internal/resolvers/schema_resolvers_application_test.go
@@ -6,7 +6,10 @@ package resolvers_test
 
 import (
 	"github.com/telekom/controlplane/controlplane-api/ent"
+	"github.com/telekom/controlplane/controlplane-api/internal/resolvers"
+	"github.com/telekom/controlplane/controlplane-api/internal/service"
 	"github.com/telekom/controlplane/controlplane-api/internal/testutil"
+	"github.com/telekom/controlplane/controlplane-api/internal/viewer"
 	"github.com/telekom/controlplane/controlplane-api/pkg/model"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -221,5 +224,88 @@ var _ = Describe("Application.IpRestrictions", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(updated.IPRestrictions.Allow).To(BeEmpty())
 		Expect(updated.IPRestrictions.Deny).To(BeEmpty())
+	})
+})
+
+var _ = Describe("Application.PermissionsURL resolver", func() {
+	var (
+		client *ent.Client
+		r      *resolvers.Resolver
+		s      *testutil.SeedData
+	)
+
+	BeforeEach(func() {
+		client = testutil.NewTestClient(GinkgoT())
+		r = resolvers.NewResolver(client, service.Services{}, nil, "")
+		s = testutil.SeedStandard(client)
+	})
+
+	AfterEach(func() {
+		client.Close()
+	})
+
+	It("should return nil when zone has no permissionsURL", func() {
+		ctx := viewer.NewContext(testutil.AllowContext(), &viewer.Viewer{Teams: []string{"team-alpha"}})
+
+		result, err := r.Application().PermissionsURL(ctx, s.AppAlpha)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result).To(BeNil())
+	})
+
+	It("should return nil when zone permissionsURL is empty", func() {
+		ctx := testutil.AllowContext()
+		empty := ""
+		_, err := client.Zone.UpdateOneID(s.ZoneEU.ID).SetPermissionsURL(empty).Save(ctx)
+		Expect(err).NotTo(HaveOccurred())
+
+		viewerCtx := viewer.NewContext(ctx, &viewer.Viewer{Teams: []string{"team-alpha"}})
+		result, err := r.Application().PermissionsURL(viewerCtx, s.AppAlpha)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result).To(BeNil())
+	})
+
+	It("should return nil when application has no clientID", func() {
+		ctx := testutil.AllowContext()
+		_, err := client.Zone.UpdateOneID(s.ZoneEU.ID).SetPermissionsURL("https://perms.example.com").Save(ctx)
+		Expect(err).NotTo(HaveOccurred())
+
+		app, err := client.Application.Create().
+			SetNamespace("default").SetName("app-no-cid").
+			SetOwnerTeam(s.TeamAlpha).SetZone(s.ZoneEU).Save(ctx)
+		Expect(err).NotTo(HaveOccurred())
+
+		viewerCtx := viewer.NewContext(ctx, &viewer.Viewer{Teams: []string{"team-alpha"}})
+		result, err := r.Application().PermissionsURL(viewerCtx, app)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result).To(BeNil())
+	})
+
+	It("should build URL with encoded application query parameter", func() {
+		ctx := testutil.AllowContext()
+		_, err := client.Zone.UpdateOneID(s.ZoneEU.ID).SetPermissionsURL("https://perms.example.com").Save(ctx)
+		Expect(err).NotTo(HaveOccurred())
+
+		viewerCtx := viewer.NewContext(ctx, &viewer.Viewer{Teams: []string{"team-alpha"}})
+		result, err := r.Application().PermissionsURL(viewerCtx, s.AppAlpha)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result).NotTo(BeNil())
+		Expect(*result).To(Equal("https://perms.example.com?application=client-alpha"))
+	})
+
+	It("should URL-encode special characters in clientID", func() {
+		ctx := testutil.AllowContext()
+		_, err := client.Zone.UpdateOneID(s.ZoneEU.ID).SetPermissionsURL("https://perms.example.com").Save(ctx)
+		Expect(err).NotTo(HaveOccurred())
+
+		app, err := client.Application.Create().
+			SetNamespace("default").SetName("app-special").SetClientID("client with spaces&more=yes").
+			SetOwnerTeam(s.TeamAlpha).SetZone(s.ZoneEU).Save(ctx)
+		Expect(err).NotTo(HaveOccurred())
+
+		viewerCtx := viewer.NewContext(ctx, &viewer.Viewer{Teams: []string{"team-alpha"}})
+		result, err := r.Application().PermissionsURL(viewerCtx, app)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result).NotTo(BeNil())
+		Expect(*result).To(Equal("https://perms.example.com?application=client+with+spaces%26more%3Dyes"))
 	})
 })

--- a/controlplane-api/schema.graphql
+++ b/controlplane-api/schema.graphql
@@ -279,6 +279,8 @@ type EventExposureInfo {
 extend type Application {
   "Owning team (reduced view for cross-tenant safety)"
   ownerTeam: TeamInfo!
+  "PermissionsUrl for permission queries (dynamically built from gateway URL) with ?application=<clientId> appended when querying"
+  permissionsURL: String @goField(forceResolver: true)
 }
 
 extend type Zone {

--- a/organization-server/internal/graphql/generated.go
+++ b/organization-server/internal/graphql/generated.go
@@ -8127,6 +8127,22 @@ type ZoneWhereInput struct {
 	IssuerURLNotNil       *bool    `json:"issuerURLNotNil"`
 	IssuerURLEqualFold    *string  `json:"issuerURLEqualFold"`
 	IssuerURLContainsFold *string  `json:"issuerURLContainsFold"`
+	// permissions_url field predicates
+	PermissionsURL             *string  `json:"permissionsURL"`
+	PermissionsURLNEQ          *string  `json:"permissionsURLNEQ"`
+	PermissionsURLIn           []string `json:"permissionsURLIn"`
+	PermissionsURLNotIn        []string `json:"permissionsURLNotIn"`
+	PermissionsURLGT           *string  `json:"permissionsURLGT"`
+	PermissionsURLGTE          *string  `json:"permissionsURLGTE"`
+	PermissionsURLLT           *string  `json:"permissionsURLLT"`
+	PermissionsURLLTE          *string  `json:"permissionsURLLTE"`
+	PermissionsURLContains     *string  `json:"permissionsURLContains"`
+	PermissionsURLHasPrefix    *string  `json:"permissionsURLHasPrefix"`
+	PermissionsURLHasSuffix    *string  `json:"permissionsURLHasSuffix"`
+	PermissionsURLIsNil        *bool    `json:"permissionsURLIsNil"`
+	PermissionsURLNotNil       *bool    `json:"permissionsURLNotNil"`
+	PermissionsURLEqualFold    *string  `json:"permissionsURLEqualFold"`
+	PermissionsURLContainsFold *string  `json:"permissionsURLContainsFold"`
 	// visibility field predicates
 	Visibility      *ZoneVisibility  `json:"visibility"`
 	VisibilityNEQ   *ZoneVisibility  `json:"visibilityNEQ"`
@@ -8343,6 +8359,51 @@ func (v *ZoneWhereInput) GetIssuerURLEqualFold() *string { return v.IssuerURLEqu
 
 // GetIssuerURLContainsFold returns ZoneWhereInput.IssuerURLContainsFold, and is useful for accessing the field via an interface.
 func (v *ZoneWhereInput) GetIssuerURLContainsFold() *string { return v.IssuerURLContainsFold }
+
+// GetPermissionsURL returns ZoneWhereInput.PermissionsURL, and is useful for accessing the field via an interface.
+func (v *ZoneWhereInput) GetPermissionsURL() *string { return v.PermissionsURL }
+
+// GetPermissionsURLNEQ returns ZoneWhereInput.PermissionsURLNEQ, and is useful for accessing the field via an interface.
+func (v *ZoneWhereInput) GetPermissionsURLNEQ() *string { return v.PermissionsURLNEQ }
+
+// GetPermissionsURLIn returns ZoneWhereInput.PermissionsURLIn, and is useful for accessing the field via an interface.
+func (v *ZoneWhereInput) GetPermissionsURLIn() []string { return v.PermissionsURLIn }
+
+// GetPermissionsURLNotIn returns ZoneWhereInput.PermissionsURLNotIn, and is useful for accessing the field via an interface.
+func (v *ZoneWhereInput) GetPermissionsURLNotIn() []string { return v.PermissionsURLNotIn }
+
+// GetPermissionsURLGT returns ZoneWhereInput.PermissionsURLGT, and is useful for accessing the field via an interface.
+func (v *ZoneWhereInput) GetPermissionsURLGT() *string { return v.PermissionsURLGT }
+
+// GetPermissionsURLGTE returns ZoneWhereInput.PermissionsURLGTE, and is useful for accessing the field via an interface.
+func (v *ZoneWhereInput) GetPermissionsURLGTE() *string { return v.PermissionsURLGTE }
+
+// GetPermissionsURLLT returns ZoneWhereInput.PermissionsURLLT, and is useful for accessing the field via an interface.
+func (v *ZoneWhereInput) GetPermissionsURLLT() *string { return v.PermissionsURLLT }
+
+// GetPermissionsURLLTE returns ZoneWhereInput.PermissionsURLLTE, and is useful for accessing the field via an interface.
+func (v *ZoneWhereInput) GetPermissionsURLLTE() *string { return v.PermissionsURLLTE }
+
+// GetPermissionsURLContains returns ZoneWhereInput.PermissionsURLContains, and is useful for accessing the field via an interface.
+func (v *ZoneWhereInput) GetPermissionsURLContains() *string { return v.PermissionsURLContains }
+
+// GetPermissionsURLHasPrefix returns ZoneWhereInput.PermissionsURLHasPrefix, and is useful for accessing the field via an interface.
+func (v *ZoneWhereInput) GetPermissionsURLHasPrefix() *string { return v.PermissionsURLHasPrefix }
+
+// GetPermissionsURLHasSuffix returns ZoneWhereInput.PermissionsURLHasSuffix, and is useful for accessing the field via an interface.
+func (v *ZoneWhereInput) GetPermissionsURLHasSuffix() *string { return v.PermissionsURLHasSuffix }
+
+// GetPermissionsURLIsNil returns ZoneWhereInput.PermissionsURLIsNil, and is useful for accessing the field via an interface.
+func (v *ZoneWhereInput) GetPermissionsURLIsNil() *bool { return v.PermissionsURLIsNil }
+
+// GetPermissionsURLNotNil returns ZoneWhereInput.PermissionsURLNotNil, and is useful for accessing the field via an interface.
+func (v *ZoneWhereInput) GetPermissionsURLNotNil() *bool { return v.PermissionsURLNotNil }
+
+// GetPermissionsURLEqualFold returns ZoneWhereInput.PermissionsURLEqualFold, and is useful for accessing the field via an interface.
+func (v *ZoneWhereInput) GetPermissionsURLEqualFold() *string { return v.PermissionsURLEqualFold }
+
+// GetPermissionsURLContainsFold returns ZoneWhereInput.PermissionsURLContainsFold, and is useful for accessing the field via an interface.
+func (v *ZoneWhereInput) GetPermissionsURLContainsFold() *string { return v.PermissionsURLContainsFold }
 
 // GetVisibility returns ZoneWhereInput.Visibility, and is useful for accessing the field via an interface.
 func (v *ZoneWhereInput) GetVisibility() *ZoneVisibility { return v.Visibility }

--- a/projector/internal/domain/zone/repository.go
+++ b/projector/internal/domain/zone/repository.go
@@ -58,6 +58,9 @@ func (r *Repository) Upsert(ctx context.Context, data *ZoneData) error {
 	if data.IssuerURL != nil {
 		create = create.SetIssuerURL(*data.IssuerURL)
 	}
+	if data.PermissionURL != nil {
+		create = create.SetPermissionURL(*data.PermissionURL)
+	}
 
 	id, err := create.
 		OnConflictColumns(zone.FieldName).
@@ -73,6 +76,11 @@ func (r *Repository) Upsert(ctx context.Context, data *ZoneData) error {
 				u.SetIssuerURL(*data.IssuerURL)
 			} else {
 				u.ClearIssuerURL()
+			}
+			if data.PermissionURL != nil {
+				u.SetPermissionURL(*data.PermissionURL)
+			} else {
+				u.ClearPermissionURL()
 			}
 		}).
 		ID(ctx)

--- a/projector/internal/domain/zone/repository.go
+++ b/projector/internal/domain/zone/repository.go
@@ -58,8 +58,8 @@ func (r *Repository) Upsert(ctx context.Context, data *ZoneData) error {
 	if data.IssuerURL != nil {
 		create = create.SetIssuerURL(*data.IssuerURL)
 	}
-	if data.PermissionURL != nil {
-		create = create.SetPermissionURL(*data.PermissionURL)
+	if data.PermissionsURL != nil {
+		create = create.SetPermissionsURL(*data.PermissionsURL)
 	}
 
 	id, err := create.
@@ -77,10 +77,10 @@ func (r *Repository) Upsert(ctx context.Context, data *ZoneData) error {
 			} else {
 				u.ClearIssuerURL()
 			}
-			if data.PermissionURL != nil {
-				u.SetPermissionURL(*data.PermissionURL)
+			if data.PermissionsURL != nil {
+				u.SetPermissionsURL(*data.PermissionsURL)
 			} else {
-				u.ClearPermissionURL()
+				u.ClearPermissionsURL()
 			}
 		}).
 		ID(ctx)

--- a/projector/internal/domain/zone/repository_test.go
+++ b/projector/internal/domain/zone/repository_test.go
@@ -155,40 +155,40 @@ var _ = Describe("Zone Repository", func() {
 
 		It("should create a zone with permission URL", func() {
 			data := &zone.ZoneData{
-				Meta:          shared.NewMetadata("admin", "zone-perm", nil),
-				Name:          "zone-perm",
-				GatewayURL:    strPtr("https://gw.example.com"),
-				PermissionURL: strPtr("https://permissions.example.com/api/v1"),
-				Visibility:    "WORLD",
+				Meta:           shared.NewMetadata("admin", "zone-perm", nil),
+				Name:           "zone-perm",
+				GatewayURL:     strPtr("https://gw.example.com"),
+				PermissionsURL: strPtr("https://permissions.example.com/api/v1"),
+				Visibility:     "WORLD",
 			}
 			Expect(repo.Upsert(ctx, data)).To(Succeed())
 
 			z, err := client.Zone.Query().Only(ctx)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(z.PermissionURL).NotTo(BeNil())
-			Expect(*z.PermissionURL).To(Equal("https://permissions.example.com/api/v1"))
+			Expect(z.PermissionsURL).NotTo(BeNil())
+			Expect(*z.PermissionsURL).To(Equal("https://permissions.example.com/api/v1"))
 		})
 
-		It("should clear PermissionURL when updated to nil", func() {
+		It("should clear PermissionsURL when updated to nil", func() {
 			data := &zone.ZoneData{
-				Meta:          shared.NewMetadata("admin", "zone-perm-clear", nil),
-				Name:          "zone-perm-clear",
-				PermissionURL: strPtr("https://permissions.example.com/api/v1"),
-				Visibility:    "ENTERPRISE",
+				Meta:           shared.NewMetadata("admin", "zone-perm-clear", nil),
+				Name:           "zone-perm-clear",
+				PermissionsURL: strPtr("https://permissions.example.com/api/v1"),
+				Visibility:     "ENTERPRISE",
 			}
 			Expect(repo.Upsert(ctx, data)).To(Succeed())
 
 			z, err := client.Zone.Query().Only(ctx)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(z.PermissionURL).NotTo(BeNil())
+			Expect(z.PermissionsURL).NotTo(BeNil())
 
 			// Update with nil permission URL.
-			data.PermissionURL = nil
+			data.PermissionsURL = nil
 			Expect(repo.Upsert(ctx, data)).To(Succeed())
 
 			z, err = client.Zone.Query().Only(ctx)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(z.PermissionURL).To(BeNil())
+			Expect(z.PermissionsURL).To(BeNil())
 		})
 
 		It("should populate the edge cache after upsert", func() {

--- a/projector/internal/domain/zone/repository_test.go
+++ b/projector/internal/domain/zone/repository_test.go
@@ -153,6 +153,44 @@ var _ = Describe("Zone Repository", func() {
 			Expect(z.IssuerURL).To(BeNil())
 		})
 
+		It("should create a zone with permission URL", func() {
+			data := &zone.ZoneData{
+				Meta:          shared.NewMetadata("admin", "zone-perm", nil),
+				Name:          "zone-perm",
+				GatewayURL:    strPtr("https://gw.example.com"),
+				PermissionURL: strPtr("https://permissions.example.com/api/v1"),
+				Visibility:    "WORLD",
+			}
+			Expect(repo.Upsert(ctx, data)).To(Succeed())
+
+			z, err := client.Zone.Query().Only(ctx)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(z.PermissionURL).NotTo(BeNil())
+			Expect(*z.PermissionURL).To(Equal("https://permissions.example.com/api/v1"))
+		})
+
+		It("should clear PermissionURL when updated to nil", func() {
+			data := &zone.ZoneData{
+				Meta:          shared.NewMetadata("admin", "zone-perm-clear", nil),
+				Name:          "zone-perm-clear",
+				PermissionURL: strPtr("https://permissions.example.com/api/v1"),
+				Visibility:    "ENTERPRISE",
+			}
+			Expect(repo.Upsert(ctx, data)).To(Succeed())
+
+			z, err := client.Zone.Query().Only(ctx)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(z.PermissionURL).NotTo(BeNil())
+
+			// Update with nil permission URL.
+			data.PermissionURL = nil
+			Expect(repo.Upsert(ctx, data)).To(Succeed())
+
+			z, err = client.Zone.Query().Only(ctx)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(z.PermissionURL).To(BeNil())
+		})
+
 		It("should populate the edge cache after upsert", func() {
 			data := &zone.ZoneData{
 				Meta:       shared.NewMetadata("admin", "cached-zone", nil),

--- a/projector/internal/domain/zone/translator.go
+++ b/projector/internal/domain/zone/translator.go
@@ -43,12 +43,19 @@ func (t *Translator) Translate(_ context.Context, obj *adminv1.Zone) (*ZoneData,
 		issuerURL = &u
 	}
 
+	var permissionURL *string
+	if obj.Status.Links.PermissionsUrl != "" {
+		u := obj.Status.Links.PermissionsUrl
+		permissionURL = &u
+	}
+
 	return &ZoneData{
-		Meta:       shared.NewMetadata(obj.Namespace, obj.Name, obj.Labels),
-		Name:       obj.Name,
-		GatewayURL: gatewayURL,
-		IssuerURL:  issuerURL,
-		Visibility: strings.ToUpper(string(obj.Spec.Visibility)),
+		Meta:          shared.NewMetadata(obj.Namespace, obj.Name, obj.Labels),
+		Name:          obj.Name,
+		GatewayURL:    gatewayURL,
+		IssuerURL:     issuerURL,
+		PermissionURL: permissionURL,
+		Visibility:    strings.ToUpper(string(obj.Spec.Visibility)),
 	}, nil
 }
 

--- a/projector/internal/domain/zone/translator.go
+++ b/projector/internal/domain/zone/translator.go
@@ -43,19 +43,19 @@ func (t *Translator) Translate(_ context.Context, obj *adminv1.Zone) (*ZoneData,
 		issuerURL = &u
 	}
 
-	var permissionURL *string
+	var permissionsURL *string
 	if obj.Status.Links.PermissionsUrl != "" {
 		u := obj.Status.Links.PermissionsUrl
-		permissionURL = &u
+		permissionsURL = &u
 	}
 
 	return &ZoneData{
-		Meta:          shared.NewMetadata(obj.Namespace, obj.Name, obj.Labels),
-		Name:          obj.Name,
-		GatewayURL:    gatewayURL,
-		IssuerURL:     issuerURL,
-		PermissionURL: permissionURL,
-		Visibility:    strings.ToUpper(string(obj.Spec.Visibility)),
+		Meta:           shared.NewMetadata(obj.Namespace, obj.Name, obj.Labels),
+		Name:           obj.Name,
+		GatewayURL:     gatewayURL,
+		IssuerURL:      issuerURL,
+		PermissionsURL: permissionsURL,
+		Visibility:     strings.ToUpper(string(obj.Spec.Visibility)),
 	}, nil
 }
 

--- a/projector/internal/domain/zone/translator_test.go
+++ b/projector/internal/domain/zone/translator_test.go
@@ -191,6 +191,65 @@ var _ = Describe("Zone Translator", func() {
 					Visibility: "WORLD",
 				},
 			),
+			Entry("permission URL is populated from Status.Links.PermissionsUrl",
+				&adminv1.Zone{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "zone-g",
+						Namespace: "admin",
+						Labels: map[string]string{
+							"cp.ei.telekom.de/environment": "production",
+						},
+					},
+					Spec: adminv1.ZoneSpec{
+						Visibility: adminv1.ZoneVisibilityWorld,
+						Gateway: adminv1.GatewayConfig{
+							Presets: []adminv1.GatewayConfigPreset{
+								{Name: "default", Default: true, Urls: []adminv1.UrlConfig{{Hostname: "gateway.example.com"}}},
+							},
+						},
+					},
+					Status: adminv1.ZoneStatus{
+						Links: adminv1.Links{
+							PermissionsUrl: "https://permissions.example.com/api/v1",
+						},
+					},
+				},
+				&zone.ZoneData{
+					Meta:          shared.NewMetadata("admin", "zone-g", map[string]string{"cp.ei.telekom.de/environment": "production"}),
+					Name:          "zone-g",
+					GatewayURL:    strPtr("https://gateway.example.com"),
+					PermissionURL: strPtr("https://permissions.example.com/api/v1"),
+					Visibility:    "WORLD",
+				},
+			),
+			Entry("empty permission URL is treated as nil",
+				&adminv1.Zone{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "zone-h",
+						Namespace: "admin",
+					},
+					Spec: adminv1.ZoneSpec{
+						Visibility: adminv1.ZoneVisibilityWorld,
+						Gateway: adminv1.GatewayConfig{
+							Presets: []adminv1.GatewayConfigPreset{
+								{Name: "default", Default: true, Urls: []adminv1.UrlConfig{{Hostname: "gw.test"}}},
+							},
+						},
+					},
+					Status: adminv1.ZoneStatus{
+						Links: adminv1.Links{
+							PermissionsUrl: "",
+						},
+					},
+				},
+				&zone.ZoneData{
+					Meta:          shared.NewMetadata("admin", "zone-h", nil),
+					Name:          "zone-h",
+					GatewayURL:    strPtr("https://gw.test"),
+					PermissionURL: nil,
+					Visibility:    "WORLD",
+				},
+			),
 		)
 	})
 

--- a/projector/internal/domain/zone/translator_test.go
+++ b/projector/internal/domain/zone/translator_test.go
@@ -191,7 +191,7 @@ var _ = Describe("Zone Translator", func() {
 					Visibility: "WORLD",
 				},
 			),
-			Entry("permission URL is populated from Status.Links.PermissionsUrl",
+			Entry("permissions URL is populated from Status.Links.PermissionsUrl",
 				&adminv1.Zone{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "zone-g",
@@ -215,11 +215,11 @@ var _ = Describe("Zone Translator", func() {
 					},
 				},
 				&zone.ZoneData{
-					Meta:          shared.NewMetadata("admin", "zone-g", map[string]string{"cp.ei.telekom.de/environment": "production"}),
-					Name:          "zone-g",
-					GatewayURL:    strPtr("https://gateway.example.com"),
-					PermissionURL: strPtr("https://permissions.example.com/api/v1"),
-					Visibility:    "WORLD",
+					Meta:           shared.NewMetadata("admin", "zone-g", map[string]string{"cp.ei.telekom.de/environment": "production"}),
+					Name:           "zone-g",
+					GatewayURL:     strPtr("https://gateway.example.com"),
+					PermissionsURL: strPtr("https://permissions.example.com/api/v1"),
+					Visibility:     "WORLD",
 				},
 			),
 			Entry("empty permission URL is treated as nil",
@@ -243,11 +243,11 @@ var _ = Describe("Zone Translator", func() {
 					},
 				},
 				&zone.ZoneData{
-					Meta:          shared.NewMetadata("admin", "zone-h", nil),
-					Name:          "zone-h",
-					GatewayURL:    strPtr("https://gw.test"),
-					PermissionURL: nil,
-					Visibility:    "WORLD",
+					Meta:           shared.NewMetadata("admin", "zone-h", nil),
+					Name:           "zone-h",
+					GatewayURL:     strPtr("https://gw.test"),
+					PermissionsURL: nil,
+					Visibility:     "WORLD",
 				},
 			),
 		)

--- a/projector/internal/domain/zone/types.go
+++ b/projector/internal/domain/zone/types.go
@@ -15,9 +15,10 @@ type ZoneKey string
 
 // ZoneData carries the transformed data for a Zone entity.
 type ZoneData struct {
-	Meta       shared.Metadata
-	Name       string
-	GatewayURL *string // optional/nillable — nil when Spec.Gateway.Url is empty
-	IssuerURL  *string // optional/nillable — nil when Status.Links.Issuer is empty
-	Visibility string  // "WORLD" or "ENTERPRISE" (upper-cased from CR enum)
+	Meta          shared.Metadata
+	Name          string
+	GatewayURL    *string // optional/nillable — nil when Spec.Gateway.Url is empty
+	IssuerURL     *string // optional/nillable — nil when Status.Links.Issuer is empty
+	PermissionURL *string // optional/nillable — nil when Spec.Links.PermissionsUrl is empty
+	Visibility    string  // "WORLD" or "ENTERPRISE" (upper-cased from CR enum)
 }

--- a/projector/internal/domain/zone/types.go
+++ b/projector/internal/domain/zone/types.go
@@ -15,10 +15,10 @@ type ZoneKey string
 
 // ZoneData carries the transformed data for a Zone entity.
 type ZoneData struct {
-	Meta          shared.Metadata
-	Name          string
-	GatewayURL    *string // optional/nillable — nil when Spec.Gateway.Url is empty
-	IssuerURL     *string // optional/nillable — nil when Status.Links.Issuer is empty
-	PermissionURL *string // optional/nillable — nil when Spec.Links.PermissionsUrl is empty
-	Visibility    string  // "WORLD" or "ENTERPRISE" (upper-cased from CR enum)
+	Meta           shared.Metadata
+	Name           string
+	GatewayURL     *string // optional/nillable — nil when Spec.Gateway.Url is empty
+	IssuerURL      *string // optional/nillable — nil when Status.Links.Issuer is empty
+	PermissionsURL *string // optional/nillable — nil when Spec.Links.PermissionsUrl is empty
+	Visibility     string  // "WORLD" or "ENTERPRISE" (upper-cased from CR enum)
 }


### PR DESCRIPTION
# Query

Takes about ~2.5 - 3sec current for all applications in clusters without limit

```
query ApplicationPermissionsURL {
  applications {
    edges {
      node {
        name
        clientID
        permissionsURL
      }
    }
  }
}
```

# Sample Response
```
        {
          "node": {
            "name": "provider-jm-demo-application-new",
            "clientID": "devops--demo-team--example",
            "permissionsURL": "https://xxxxxx.de/eni/chevron/v2/permission?application=devops--demo-team--example",
          }
        },
```