### PR TITLE
ci: Fix ROVERCTL_IMAGE must have prefix for version

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -151,7 +151,7 @@ jobs:
           context: rover-ctl
           push: true
           build-args: |
-            ROVERCTL_IMAGE=ghcr.io/telekom/controlplane/rover-ctl:${{ steps.semantic_release.outputs.new_release_version }}
+            ROVERCTL_IMAGE=ghcr.io/telekom/controlplane/rover-ctl:v${{ steps.semantic_release.outputs.new_release_version }}
             ROVERCTL_BASE_IMAGE=${{ vars.REGISTRY_HOST }}/${{ vars.REGISTRY_ROVERCTL_BASE_REPO }}:${{ vars.ROVERCTL_BASE_IMAGE_TAG }}
           tags: |
             ${{ vars.REGISTRY_HOST }}/${{ vars.REGISTRY_ROVERCTL_REPO }}:${{ steps.semantic_release.outputs.new_release_version }}


### PR DESCRIPTION
Add a missing `v` as prefix for the release version to fix the release workflow error in the [release job](https://github.com/telekom/controlplane/actions/runs/32019457157/job/95356094091)

```
failed to build: failed to solve: ghcr.io/telekom/controlplane/rover-ctl:0.23.0: failed to resolve source metadata for ghcr.io/telekom/controlplane/rover-ctl:0.23.0: ghcr.io/telekom/controlplane/rover-ctl:0.23.0: not found
```