### PR TITLE
ci: dependabot npm updates grouped by update type

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,12 +15,10 @@ updates:
       interval: "monthly"
     groups:
       minor-patch:
-        group-by: dependency-name
         update-types:
           - patch
           - minor
       major:
-        group-by: dependency-name
         update-types:
           - major
   - package-ecosystem: "gomod"


### PR DESCRIPTION
npm updates are only relevant for the docs directory and docusaurs requires updating dependencies together. This change configures dependabot to group updates by update type combining all minor changes and all major changes together in one PR.