### PR TITLE
ci: dependabot github-actions updates grouped by update type

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,14 @@ updates:
     directory: /
     schedule:
       interval: "monthly"
+    groups:
+      minor-patch:
+        update-types:
+          - patch
+          - minor
+      major:
+        update-types:
+          - major
   - package-ecosystem: "npm"
     directory: /docs
     schedule:


### PR DESCRIPTION
github-actions updates are only relevant for the .github directory. This change configures dependabot to group updates by update type combining all minor changes and all major changes together in one PR.