### PR TITLE
ci: grouping strategy: by owner/ecosystem for github actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,13 +10,28 @@ updates:
     schedule:
       interval: "monthly"
     groups:
-      minor-patch:
-        update-types:
-          - patch
-          - minor
-      major:
-        update-types:
-          - major
+      # GitHub's official actions are versioned independently but used heavily
+      # across all workflows — group them together for one focused PR.
+      actions:
+        patterns:
+          - "actions/*"
+      # Docker's build/login/setup actions share a release cycle.
+      docker:
+        patterns:
+          - "docker/*"
+      # CodeQL actions must always stay on the same version across init/analyze.
+      codeql:
+        patterns:
+          - "github/codeql-action*"
+      # All remaining third-party actions in one PR.
+      third-party:
+        patterns:
+          - "*"
+        exclude-patterns:
+          - "actions/*"
+          - "docker/*"
+          - "github/codeql-action*"
+
   - package-ecosystem: "npm"
     directory: /docs
     schedule:
@@ -29,6 +44,7 @@ updates:
       major:
         update-types:
           - major
+
   - package-ecosystem: "gomod"
     schedule:
       interval: "monthly"


### PR DESCRIPTION
## New grouping strategy: by owner/ecosystem

### Why this is better than grouping by update-type

The old  minor-patch  /  major  split created one giant PR with every action in the repo, causing merge conflicts and hard-to-review diffs. Grouping by owner means:
• Each PR is semantically coherent (all Docker actions, all CodeQL actions, etc.)
• Conflicts are contained within one owner's actions, not across all of them
• The CodeQL group in particular avoids the real-world footgun of init and analyze  being on different versions