### PR TITLE
ci: disable config verification in golangci-lint to prevent timeouts

### DIFF
--- a/.github/workflows/reusable-go-ci.yaml
+++ b/.github/workflows/reusable-go-ci.yaml
@@ -157,6 +157,9 @@ jobs:
         with:
           version: v2.11
           working-directory: ${{ inputs.module }}
+          # `config verify` downloads the JSON schema from golangci-lint.run on every run,
+          # which frequently times out and fails the job.
+          verify: false
           args: --timeout 5m --issues-exit-code=${{ inputs.lint_fail_on_issues && '1' || '0' }} --config ${{ github.workspace }}/.golangci.yml
 
   tests:


### PR DESCRIPTION
The golangci-lint CI step sometimes fails and does not continue with linting. 

```
Error: Command failed: golangci-lint config verify
... failing to load "https://golangci-lint.run/jsonschema/golangci.v2.11.jsonschema.json":
context deadline exceeded (Client.Timeout exceeded while awaiting headers)
```

This removes the flaky network dependency from the lint step. Actual linting is unaffected; only the schema-validation of .golangci.yml is skipped.