### PR TITLE
test(ci): scenario - common module change (library-wide fan-out)

### DIFF
--- a/common/tools/tools.go
+++ b/common/tools/tools.go
@@ -8,3 +8,4 @@
 package tools
 
 //go:generate go run github.com/vektra/mockery/v2 --config=mockery.client.yaml
+// CI scenario test: touch common module only (see PR description).


### PR DESCRIPTION
**Test-only PR, not to be merged.** Validates the CI redesign's `optimized` mode when `common` (a widely-depended-on library module) changes.

Expected: `build_modules` includes `common` + every module that transitively depends on it (likely most/all packageable modules); `package_modules` should be empty or minimal since `common` itself is non-packageable and no packageable module's own files changed.