### PR TITLE
test(ci): scenario - global-impact path change (safety valve)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,3 +79,5 @@ ci-graph-check: ## Verify the committed module dependency graph is up to date.
 .PHONY: help
 help: ## Display this help.
 	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_0-9-]+:.*?##/ { printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
+
+# CI scenario test: trivial global-impact-path change (see PR description).


### PR DESCRIPTION
**Test-only PR, not to be merged.** Validates that touching a global-impact path (`Makefile`) forces `mode=maximum` on a `pull_request` event, overriding the default `optimized` mode.

Expected: "Determine CI Scope" step summary reports `mode: maximum`, `run_full: true`; all modules build/test, all packageable modules get an image built/scanned.