### PR TITLE
test(ci): scenario - two unrelated modules changed in one PR

### DIFF
--- a/gateway/cmd/main.go
+++ b/gateway/cmd/main.go
@@ -183,4 +183,5 @@ func main() {
 		setupLog.Error(err, "problem running manager")
 		os.Exit(1)
 	}
+	// CI scenario test: touch gateway and permission in one PR (see PR description).
 }

--- a/permission/cmd/main.go
+++ b/permission/cmd/main.go
@@ -148,4 +148,5 @@ func main() {
 		setupLog.Error(err, "problem running manager")
 		os.Exit(1)
 	}
+	// CI scenario test: touch gateway and permission in one PR (see PR description).
 }


### PR DESCRIPTION
**Test-only PR, not to be merged.** Validates that the computed scope is the union of both modules' dependency closures when two unrelated modules (`gateway`, `permission`, no dependency relationship) change in the same PR.

Expected: `build_modules` includes both `gateway` and `permission` plus each one's own dependents, with no duplicates/omissions; `package_modules` includes both (both packageable, both directly changed).