### PR TITLE
test(ci): scenario - docs-only change (empty CI scope)

### DIFF
--- a/docs/docs/overview/introduction.md
+++ b/docs/docs/overview/introduction.md
@@ -31,3 +31,5 @@ The Control Plane serves two primary audiences:
 - [Admin Journey](../admin-journey/installation.md) — Install and configure the Control Plane
 - [User Journey](../user-journey/onboarding.md) — Start using the platform as an application team
 - [Architecture](../architecture/overview.md) — Understand the system design
+
+<!-- CI scenario test: docs-only change, no module should build/package (see PR description). -->


### PR DESCRIPTION
**Test-only PR, not to be merged.** Validates that a change touching no Go module and no global-impact path yields an empty scope.

Expected: `build_modules`/`package_modules` both empty; `build`, `package`, `collect_build_status` jobs show `skipped`; `CI Summary` still passes.