### PR TITLE
test(ci): scenario - deliberately failing test (failure isolation)

### DIFF
--- a/gateway/internal/handler/gateway/ci_scenario_failure_test.go
+++ b/gateway/internal/handler/gateway/ci_scenario_failure_test.go
@@ -1,0 +1,16 @@
+// Copyright 2025 Deutsche Telekom IT GmbH
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package gateway_test
+
+// This file exists only to validate the CI redesign's failure-isolation
+// behavior: gateway's build should fail while unrelated in-scope modules
+// (e.g. permission, changed in the same PR but sharing no dependency)
+// still build/package successfully. Not meant to be merged.
+
+import "testing"
+
+func TestCIScenarioDeliberateFailure(t *testing.T) {
+	t.Fatal("intentional failure for CI redesign scenario testing - do not merge")
+}

--- a/permission/cmd/main.go
+++ b/permission/cmd/main.go
@@ -148,4 +148,5 @@ func main() {
 		setupLog.Error(err, "problem running manager")
 		os.Exit(1)
 	}
+	// CI scenario test: unrelated module in same PR as gateway's deliberate test failure (see PR description).
 }


### PR DESCRIPTION
**Test-only PR, not to be merged.** Contains an intentionally failing unit test in `gateway`, alongside an unrelated trivial change to `permission` (no shared dependency), to validate failure isolation.

Expected: `Build (gateway)`'s Tests & Coverage job fails; `Build (permission)` still succeeds; `collect_build_status` correctly excludes only `gateway` from `package_matrix` (permission still gets packaged); overall `CI Summary` fails.