### PR TITLE
test(ci): scenario - rover-ctl only change (dedicated package job)

### DIFF
--- a/rover-ctl/main.go
+++ b/rover-ctl/main.go
@@ -34,4 +34,5 @@ func main() {
 	if err := rootCmd.Execute(); err != nil {
 		cmd.ErrorHandler(err, viper.GetBool("debug"))
 	}
+	// CI scenario test: touch rover-ctl only (see PR description).
 }


### PR DESCRIPTION
**Test-only PR, not to be merged.** Validates the special-cased `rover_ctl_package` job (outside the generic package matrix) and the downstream `rover-ctl-image` combined-image job, driven by `collect_build_status.outputs.rover_ctl_ready`.

Expected: `build_modules`/`package_modules` include only `rover-ctl`; `Package (rover-ctl)` (dedicated job) runs and succeeds; `rover-ctl-image` runs after it (rover-ctl-base-image likely skipped, since Dockerfile.base unchanged).