### PR TITLE
test(ci): scenario - rover-ctl/Dockerfile.base change (base image rebuild)

### DIFF
--- a/rover-ctl/Dockerfile.base
+++ b/rover-ctl/Dockerfile.base
@@ -44,3 +44,5 @@ RUN addgroup -g 65532 nonroot \
 
 # ko appends the roverctl binary on top of this image; no ENTRYPOINT/CMD is
 # set here so ko can configure it based on the built Go binary.
+
+# CI scenario test: trivial base image change (see PR description).


### PR DESCRIPTION
**Test-only PR, not to be merged.** Validates that `rover-ctl-base-image-changes`/`rover-ctl-base-image` correctly detect and rebuild the base image on a `Dockerfile.base` change, independent of the module-scoping logic (this path-filter is separate from determine-scope).

Expected: `Detect rover-ctl base image changes` reports `changed=true`; `Rover-CTL Base Image` job runs (may fail on registry auth/secrets in this test context, which is unrelated to the CI redesign logic being validated - only job *triggering* is in scope here).